### PR TITLE
Fix invalid usage of traceback.format_exc

### DIFF
--- a/smda/Disassembler.py
+++ b/smda/Disassembler.py
@@ -108,5 +108,5 @@ class Disassembler(object):
         report.smda_version = self.config.VERSION
         report.status = "error"
         report.execution_time = self._getDurationInSeconds(start, datetime.datetime.utcnow())
-        report.message = traceback.format_exc(exception)
+        report.message = traceback.format_exc()
         return report


### PR DESCRIPTION
This function doesn't even take exception as an argument.
https://docs.python.org/3/library/traceback.html#traceback.format_exc