### PR TITLE
ELF loading and API fixes

### DIFF
--- a/smda/common/labelprovider/ElfApiResolver.py
+++ b/smda/common/labelprovider/ElfApiResolver.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+import lief
+lief.logging.disable()
+
+from .AbstractLabelProvider import AbstractLabelProvider
+
+
+class ElfApiResolver(AbstractLabelProvider):
+    """ Minimal ELF API reference resolver, extracting APIs from ELF imports """
+
+    def __init__(self, config):
+        self._api_map = {
+            "lief": {}
+        }
+
+    def update(self, binary_info):
+        if binary_info.is_buffer:
+            # cannot reconstruct from shellcode/memory dump at this time
+            return
+
+        else:
+            lief_binary = lief.parse(bytearray(binary_info.raw_data))
+
+            if not isinstance(lief_binary, lief.ELF.Binary):
+                return
+
+            for relocation in lief_binary.relocations:
+                if not relocation.has_symbol:
+                    # doesn't have a name, we won't care about it
+                    continue
+                if not relocation.symbol.imported:
+                    # only interested in APIs from external sources
+                    continue
+                if not relocation.symbol.is_function:
+                    # only interested in APIs (which are functions)
+                    continue
+
+                # we can't really say what library the symbol came from
+                # however, we can treat the version (if present) as relevant metadata?
+                # note: this only works for GNU binaries, such as for Linux
+                lib = None
+                if relocation.symbol.has_version and relocation.symbol.symbol_version.has_auxiliary_version:
+                    # like "GLIBC_2.2.5"
+                    lib = relocation.symbol.symbol_version.symbol_version_auxiliary.name
+
+                name = relocation.symbol.name
+                address = relocation.address
+
+                self._api_map["lief"][address] = (lib, name)
+
+    def isApiProvider(self):
+        """Returns whether the get_api(..) function of the AbstractLabelProvider is functional"""
+        return True
+
+    def getApi(self, to_addr, absolute_addr):
+        """
+        If the LabelProvider has any information about a used API for the given address, return (dll, api), else return None.
+
+        May return None for the `dll` if it cannot be determined.
+        When it can be determined for ELF files, the `dll` field should be interpreted as the API version rather than shared library name.
+        For example: "GLIBC_2.2.5".
+        """
+        return self._api_map["lief"].get(to_addr, None)

--- a/smda/common/labelprovider/ElfApiResolver.py
+++ b/smda/common/labelprovider/ElfApiResolver.py
@@ -54,10 +54,10 @@ class ElfApiResolver(AbstractLabelProvider):
 
     def getApi(self, to_addr, absolute_addr):
         """
-        If the LabelProvider has any information about a used API for the given address, return (dll, api), else return None.
+        If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None).
 
         May return None for the `dll` if it cannot be determined.
         When it can be determined for ELF files, the `dll` field should be interpreted as the API version rather than shared library name.
         For example: "GLIBC_2.2.5".
         """
-        return self._api_map["lief"].get(to_addr, None)
+        return self._api_map["lief"].get(to_addr, (None, None))

--- a/smda/common/labelprovider/WinApiResolver.py
+++ b/smda/common/labelprovider/WinApiResolver.py
@@ -78,12 +78,13 @@ class WinApiResolver(AbstractLabelProvider):
         return True
 
     def getApi(self, to_addr, absolute_addr):
-        """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return None"""
+        """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None)"""
         # if we work on a dump, use ApiScout method:
         if self._is_buffer:
             if self._os_name and self._os_name in self._api_map:
-                return self._api_map[self._os_name].get(absolute_addr, None)
+                return self._api_map[self._os_name].get(absolute_addr, (None, None))
+            else:
+                return (None, None)
         # otherwise take import table info from LIEF
         else:
-            return self._api_map["lief"].get(to_addr, None)
-        return None
+            return self._api_map["lief"].get(to_addr, (None, None))

--- a/smda/intel/IndirectCallAnalyzer.py
+++ b/smda/intel/IndirectCallAnalyzer.py
@@ -56,7 +56,7 @@ class IndirectCallAnalyzer(object):
                     # use that instead of the actual memory value
                     addr = int(match3.group("addr"), 16)
                     dll, api = self.disassembler.resolveApi(addr, addr)
-                    if dll and api:
+                    if dll or api:
                         registers[match3.group("reg")] = addr
                         LOGGER.debug("**moved API ref (%s:%s) @0x%08x to register %s", dll, api, addr, match3.group("reg"))
                         if match3.group("reg") == register_name:
@@ -101,7 +101,7 @@ class IndirectCallAnalyzer(object):
                 if candidate:
                     LOGGER.debug("candidate: 0x%x - %s, register: %s", candidate, ins[3], register_name)
                     dll, api = self.disassembler.resolveApi(candidate, candidate)
-                    if dll and api:
+                    if dll or api:
                         LOGGER.debug("successfully resolved: %s %s", dll, api)
                         api_entry = {"referencing_addr": [], "dll_name": dll, "api_name": api}
                         if candidate in self.disassembly.apis:

--- a/smda/intel/IntelDisassembler.py
+++ b/smda/intel/IntelDisassembler.py
@@ -161,7 +161,7 @@ class IntelDisassembler(object):
             call_destination = rip + self.getReferencedAddr(i_op_str)
             dereferenced = self.disassembly.dereferenceQword(call_destination)
             state.addCodeRef(i_address, call_destination)
-            if dereferenced:
+            if dereferenced is not None:
                 self._handleApiTarget(i_address, call_destination, dereferenced)
         elif i_op_str.startswith("0x"):
             # case = "DIRECT"
@@ -238,7 +238,7 @@ class IntelDisassembler(object):
             dereferenced = self.disassembly.dereferenceDword(jump_destination)
             state.addCodeRef(i_address, jump_destination, by_jump=True)
             self.tailcall_analyzer.addJump(i_address, jump_destination)
-            if dereferenced:
+            if dereferenced is not None:
                 self._handleApiTarget(i_address, jump_destination, dereferenced)
         elif i_op_str.startswith("qword ptr [rip"):
             # case = "QWORD-PTR, RIP-relative"
@@ -248,7 +248,7 @@ class IntelDisassembler(object):
             dereferenced = self.disassembly.dereferenceQword(jump_destination)
             state.addCodeRef(i_address, jump_destination, by_jump=True)
             self.tailcall_analyzer.addJump(i_address, jump_destination)
-            if dereferenced:
+            if dereferenced is not None:
                 self._handleApiTarget(i_address, jump_destination, dereferenced)
         elif i_op_str.startswith("0x"):
             jump_destination = self.getReferencedAddr(i_op_str)

--- a/smda/intel/IntelDisassembler.py
+++ b/smda/intel/IntelDisassembler.py
@@ -182,7 +182,7 @@ class IntelDisassembler(object):
         if to_addr and not self.disassembly.isAddrWithinMemoryImage(dereferenced):
             # identify API calls on the fly
             dll, api = self.resolveApi(to_addr, dereferenced)
-            if dll and api:
+            if dll or api:
                 self._updateApiInformation(from_addr, dereferenced, dll, api)
                 return (dll, api)
             else:

--- a/smda/intel/IntelDisassembler.py
+++ b/smda/intel/IntelDisassembler.py
@@ -179,7 +179,7 @@ class IntelDisassembler(object):
             state.setRecursion(True)
 
     def _handleApiTarget(self, from_addr, to_addr, dereferenced):
-        if to_addr and not self.disassembly.isAddrWithinMemoryImage(dereferenced):
+        if to_addr:
             # identify API calls on the fly
             dll, api = self.resolveApi(to_addr, dereferenced)
             if dll or api:

--- a/smda/intel/IntelDisassembler.py
+++ b/smda/intel/IntelDisassembler.py
@@ -91,9 +91,10 @@ class IntelDisassembler(object):
         for provider in self.label_providers:
             if not provider.isApiProvider():
                 continue
-            result = provider.getApi(to_address, api_address)
-            if result:
-                return result
+            dll, api = provider.getApi(to_address, api_address)
+            if dll or api:
+                return (dll, api)
+
         return ("", "")
 
     def resolveSymbol(self, address):

--- a/smda/intel/IntelDisassembler.py
+++ b/smda/intel/IntelDisassembler.py
@@ -10,6 +10,7 @@ from smda.DisassemblyResult import DisassemblyResult
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.labelprovider.WinApiResolver import WinApiResolver
 from smda.common.labelprovider.ElfSymbolProvider import ElfSymbolProvider
+from smda.common.labelprovider.ElfApiResolver import ElfApiResolver
 from smda.common.labelprovider.PdbSymbolProvider import PdbSymbolProvider
 from smda.common.TailcallAnalyzer import TailcallAnalyzer
 from .definitions import CJMP_INS, LOOP_INS, JMP_INS, CALL_INS, RET_INS, REGS_32BIT, REGS_64BIT, DOUBLE_ZERO
@@ -69,6 +70,7 @@ class IntelDisassembler(object):
 
     def _addLabelProviders(self):
         self.label_providers.append(WinApiResolver(self.config))
+        self.label_providers.append(ElfApiResolver(self.config))
         self.label_providers.append(ElfSymbolProvider(self.config))
         self.label_providers.append(PdbSymbolProvider(self.config))
 


### PR DESCRIPTION
closes:
  - #22 
  - #23 

Adds an `ElfApiResolver` that parses the ELF imports. Fixes ELF loading and updates it for more consistent handling of segments and sections. However, I'm not particularly experienced with ELF files, so please also feel free to cherry-pick some/all/none of those changes.

Also:
  - better check None vs 0
  - support extracting API names without associated DLL (such as in ELF files)
  - don't require APIs to dereference outside of the the image