### PR TITLE
Allows for finding a function or a block by searching for any addresses that it contains

### DIFF
--- a/smda/common/BlockLocator.py
+++ b/smda/common/BlockLocator.py
@@ -20,10 +20,10 @@ class BlockLocator():
         # 2 a dict of blocks by addresses
         self.blocks_dict = {b.offset:b for b in blocks}
     
-    def FindBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address):
         # do a binary search to find the closest address to the left of inner_address
         block_num = bisect.bisect(self.sorted_blocks_addresses, inner_address)
-        block_start = self.sorted_blocks_addresses[block_num - 2] 
+        block_start = self.sorted_blocks_addresses[block_num - 1] 
 
         block = self.blocks_dict[block_start] 
 

--- a/smda/common/BlockLocator.py
+++ b/smda/common/BlockLocator.py
@@ -1,0 +1,35 @@
+import itertools
+import bisect
+
+
+
+class BlockLocator():
+    """ Class that finds a block by any address within.
+        When instantiated, creates the required data structures. 
+    """
+
+    sorted_blocks_addresses = None
+    blocks_dict = None
+
+    def __init__(self, functions):
+        # Instantiate the datastructures required : 
+        # 1. get a flat list of all the blocks in all the functions
+        blocks = list(itertools.chain(*[f.getBlocks() for f in functions]))
+        self.sorted_blocks_addresses = sorted(b.offset for b in blocks)
+
+        # 2 a dict of blocks by addresses
+        self.blocks_dict = {b.offset:b for b in blocks}
+    
+    def FindBlockByContainedAddress(self, inner_address):
+        # do a binary search to find the closest address to the left of inner_address
+        block_num = bisect.bisect(self.sorted_blocks_addresses, inner_address)
+        block_start = self.sorted_blocks_addresses[block_num - 2] 
+
+        block = self.blocks_dict[block_start] 
+
+        # make sure inner_address falls within the selected block  
+        if inner_address <= block.offset + block.length: 
+            return block
+
+        return None
+         

--- a/smda/common/SmdaReport.py
+++ b/smda/common/SmdaReport.py
@@ -129,18 +129,18 @@ class SmdaReport(object):
             if smda_function.isExported():
                 yield smda_function
 
-    def FindFunctionByContainedAddress(self, inner_address):
-        block = self.FindBlockByContainedAddress(inner_address)
+    def findFunctionByContainedAddress(self, inner_address):
+        block = self.findBlockByContainedAddress(inner_address)
         if block is None:
             return None
         return block.smda_function
 
-    def FindBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address):
         # init the block locator if it hasn't been used yet.
         if self.block_locator is None:
             self.block_locator = BlockLocator(self.getFunctions())
 
-        block = self.block_locator.FindBlockByContainedAddress(inner_address)
+        block = self.block_locator.findBlockByContainedAddress(inner_address)
         return block
 
     def getCapstone(self):

--- a/smda/common/SmdaReport.py
+++ b/smda/common/SmdaReport.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import os
 import zipfile
-
 try:
     from StringIO import StringIO ## for Python 2
 except ImportError:
@@ -14,6 +13,7 @@ from capstone import Cs, CS_ARCH_X86, CS_MODE_32, CS_MODE_64
 from .BinaryInfo import BinaryInfo
 from .SmdaFunction import SmdaFunction
 from smda.common.CodeXref import CodeXref
+from smda.common.BlockLocator import BlockLocator
 from smda.DisassemblyStatistics import DisassemblyStatistics
 
 
@@ -24,6 +24,7 @@ class SmdaReport(object):
     binary_size = None
     binweight = None
     bitness = None
+    block_locator = None
     buffer = None
     code_areas = None
     code_sections = None
@@ -127,6 +128,20 @@ class SmdaReport(object):
         for _, smda_function in sorted(self.xcfg.items()):
             if smda_function.isExported():
                 yield smda_function
+
+    def FindFunctionByContainedAddress(self, inner_address):
+        block = self.FindBlockByContainedAddress(inner_address)
+        if block is None:
+            return None
+        return block.smda_function
+
+    def FindBlockByContainedAddress(self, inner_address):
+        # init the block locator if it hasn't been used yet.
+        if self.block_locator is None:
+            self.block_locator = BlockLocator(self.getFunctions())
+
+        block = self.block_locator.FindBlockByContainedAddress(inner_address)
+        return block
 
     def getCapstone(self):
         if self.capstone is None:


### PR DESCRIPTION
Previous behaviour only allowed to find a function by the start address. Now, any address within any of the function's blocks can be used to find a function. 

To allow this, the BlockLocator is instantiated the first time SmdaReport.findBlockByContainedAddress is called.

BlockLocator creates the required datastructure to perform a binary search on the list of blocks start addresses to find the closest match. 

BlockLocator could be instantiated explicitely (in a similar fashion the CodeXrefs) if that would be a cleaner design. 