### PR TITLE
Modified ELF parsing to match new LIEF api

### DIFF
--- a/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/smda/common/labelprovider/ElfSymbolProvider.py
@@ -43,7 +43,7 @@ class ElfSymbolProvider(AbstractLabelProvider):
         self._parseOep(lief_binary)
         # TODO split resolution into API/dynamic part and local symbols
         self._parseExports(lief_binary)
-        self._parseSymbols(lief_binary.static_symbols)
+        self._parseSymbols(lief_binary.symtab_symbols)
         self._parseSymbols(lief_binary.dynamic_symbols)
         for reloc in lief_binary.relocations:
             if reloc.has_symbol:

--- a/smda/utility/ElfFileLoader.py
+++ b/smda/utility/ElfFileLoader.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 
 LOGGER = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class ElfFileLoader(object):
                 min_virtual_address = min(min_virtual_address, section.virtual_address)
                 min_raw_offset = min(min_raw_offset, section.file_offset)
         else:
-            LOGGER.warn(f"ELF: found possibly bogus section information, trying to parse segments.")
+            LOGGER.warn("ELF: found possibly bogus section information, trying to parse segments.")
         # parse segments regardless
         for segment in elffile.segments:
             if not segment.virtual_address:
@@ -110,7 +110,7 @@ class ElfFileLoader(object):
             min_raw_offset = min(min_raw_offset, segment.file_offset)
 
         if (max_virtual_address - base_addr) > sys.maxsize:
-            LOGGER.warn(f"ELF: found possibly bogus segment information, trying to parse segments.")
+            LOGGER.warn("ELF: found possibly bogus segment information, trying to parse segments.")
 
         if not max_virtual_address:
             LOGGER.debug("ELF: no section or segment data")
@@ -179,9 +179,9 @@ class ElfFileLoader(object):
         # TODO add machine types whenever we add more architectures
         elffile = lief.parse(binary)
         machine_type = elffile.header.machine_type
-        if machine_type == lief.ELF.ARCH.x86_64:
+        if machine_type == lief.ELF.ARCH.X86_64:
             return 64
-        elif machine_type == lief.ELF.ARCH.i386:
+        elif machine_type == lief.ELF.ARCH.I386:
             return 32
         return 0
 
@@ -207,7 +207,7 @@ class ElfFileLoader(object):
         code_areas = []
         for section in elffile.sections:
             # SHF_EXECINSTR = 4
-            if section.flags & 0x4:
+            if section.flags & lief.ELF.Section.FLAGS.EXECINSTR.value:
                 section_start = section.virtual_address
                 section_size = section.size
                 if section_size % section.alignment != 0:
@@ -216,7 +216,7 @@ class ElfFileLoader(object):
                 code_areas.append([section_start, section_end])    
         for segment in sorted(elffile.segments, key=lambda segment: segment.physical_size, reverse=True):
             # SHF_EXECINSTR = 4
-            if segment.flags & 0x4:
+            if segment.flags.value & lief.ELF.Section.FLAGS.EXECINSTR.value:
                 segment_start = segment.virtual_address
                 segment_size = segment.virtual_size
                 if segment_size % segment.alignment != 0:


### PR DESCRIPTION
Partial fix to the [LIEF update issue](https://github.com/danielplohmann/smda/issues/60).

According to [LIEF's 0.15.0 changelog](https://lief.re/doc/stable/changelog.html#july-21th-2024), ELF API changed a bit, and this PR fixes LIEF usage when dealing with ELF executables.

The changelog states changes for MACO too, and I do not have MACO executables to test against, so I did not do the required changes for MACO in this PR.

I believe this issue has not been noticed earlier because PE parsing API did not change between 0.14.0 and 0.16.0.