### PR TITLE
Datetime timezone usage

### DIFF
--- a/smda/Disassembler.py
+++ b/smda/Disassembler.py
@@ -39,7 +39,7 @@ class Disassembler(object):
     def _callbackAnalysisTimeout(self):
         if not self._timeout:
             return False
-        time_diff = datetime.datetime.now(datetime.UTC) - self._start_time
+        time_diff = datetime.datetime.now(datetime.timezone.utc) - self._start_time
         LOGGER.debug("Current analysis callback time %s", (time_diff))
         return time_diff.seconds >= self._timeout
 
@@ -64,7 +64,7 @@ class Disassembler(object):
         binary_info.base_addr = loader.getBaseAddress()
         binary_info.bitness = loader.getBitness()
         binary_info.code_areas = loader.getCodeAreas()
-        start = datetime.datetime.now(datetime.UTC)
+        start = datetime.datetime.now(datetime.timezone.utc)
         try:
             self.disassembler.addPdbFile(binary_info, pdb_path)
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
@@ -91,7 +91,7 @@ class Disassembler(object):
         binary_info.base_addr = loader.getBaseAddress()
         binary_info.bitness = loader.getBitness()
         binary_info.code_areas = loader.getCodeAreas()
-        start = datetime.datetime.now(datetime.UTC)
+        start = datetime.datetime.now(datetime.timezone.utc)
         try:
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
@@ -109,7 +109,7 @@ class Disassembler(object):
         Disassemble a given buffer (file_content), with given base_addr.
         Optionally specify bitness, the areas to which disassembly should be limited to (code_areas) and an entry point (oep)
         """
-        start = datetime.datetime.now(datetime.UTC)
+        start = datetime.datetime.now(datetime.timezone.utc)
         try:
             binary_info = BinaryInfo(file_content)
             binary_info.base_addr = base_addr
@@ -129,7 +129,7 @@ class Disassembler(object):
         return smda_report
 
     def _disassemble(self, binary_info, timeout=0):
-        self._start_time = datetime.datetime.now(datetime.UTC)
+        self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self.disassembly = self.disassembler.analyzeBuffer(binary_info, self._callbackAnalysisTimeout)
         return SmdaReport(self.disassembly, config=self.config)
@@ -138,6 +138,6 @@ class Disassembler(object):
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
-        report.execution_time = self._getDurationInSeconds(start, datetime.datetime.now(datetime.UTC))
+        report.execution_time = self._getDurationInSeconds(start, datetime.datetime.now(datetime.timezone.utc))
         report.message = traceback.format_exc()
         return report

--- a/smda/DisassemblyResult.py
+++ b/smda/DisassemblyResult.py
@@ -8,7 +8,7 @@ from smda.common.BasicBlock import BasicBlock
 class DisassemblyResult(object):
 
     def __init__(self):
-        self.analysis_start_ts = datetime.datetime.now(datetime.UTC)
+        self.analysis_start_ts = datetime.datetime.now(datetime.timezone.utc)
         self.analysis_end_ts = self.analysis_start_ts
         self.analysis_timeout = False
         self.binary_info = None

--- a/smda/common/SmdaReport.py
+++ b/smda/common/SmdaReport.py
@@ -92,7 +92,7 @@ class SmdaReport(object):
             self.status = disassembly.getAnalysisOutcome()
             if self.status == "timeout":
                 self.message = "Analysis was stopped when running into the timeout."
-            self.timestamp = datetime.datetime.now(datetime.UTC)
+            self.timestamp = datetime.datetime.now(datetime.timezone.utc)
             self.version = disassembly.binary_info.version
             self.xcfg = self._convertCfg(disassembly, config=config)
 

--- a/smda/ida/IdaExporter.py
+++ b/smda/ida/IdaExporter.py
@@ -39,7 +39,7 @@ class IdaExporter(object):
 
     def analyzeBuffer(self, binary_info, cb_analysis_timeout=None):
         """ instead of performing a full analysis, simply collect all data from IDA and convert it into a report """
-        self.disassembly.analysis_start_ts = datetime.datetime.now(datetime.UTC)
+        self.disassembly.analysis_start_ts = datetime.datetime.now(datetime.timezone.utc)
         self.disassembly.binary_info = binary_info
         self.disassembly.binary_info.architecture = self.ida_interface.getArchitecture()
         if not self.disassembly.binary_info.base_addr:
@@ -75,5 +75,5 @@ class IdaExporter(object):
                 self.disassembly.recursive_functions.add(function_offset)
             if self.disassembly.isLeafFunction(function_offset):
                 self.disassembly.leaf_functions.add(function_offset)
-        self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.UTC)
+        self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
         return self.disassembly

--- a/smda/intel/IntelDisassembler.py
+++ b/smda/intel/IntelDisassembler.py
@@ -424,7 +424,7 @@ class IntelDisassembler(object):
         self.disassembly.smda_version = self.config.VERSION
         self.disassembly.setBinaryInfo(binary_info)
         self.disassembly.binary_info.architecture = "intel"
-        self.disassembly.analysis_start_ts = datetime.datetime.now(datetime.UTC)
+        self.disassembly.analysis_start_ts = datetime.datetime.now(datetime.timezone.utc)
         if self.disassembly.binary_info.bitness not in [32, 64]:
             bitness_analyzer = BitnessAnalyzer()
             self.disassembly.binary_info.bitness = bitness_analyzer.determineBitnessFromDisassembly(self.disassembly)
@@ -490,7 +490,7 @@ class IntelDisassembler(object):
                 candidate.setTfIdf(function_tfidf)
                 candidate.getConfidence()
             self.disassembly.candidates[addr] = candidate
-        self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.UTC)
+        self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
         if cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True
         return self.disassembly


### PR DESCRIPTION
Fixes i62 https://github.com/danielplohmann/smda/issues/62

Applied [python's recommendation](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) replacing `datetime.UTC` by `datetime.timezone.utc`.