### PR TITLE
fix(intel): wildcard movabs absolute offsets

### DIFF
--- a/smda/intel/IntelInstructionEscaper.py
+++ b/smda/intel/IntelInstructionEscaper.py
@@ -2278,16 +2278,22 @@ class IntelInstructionEscaper:
             offset = int(addr_match.group("dword_offset"), 16)
             if "rip -" in ins.operands:
                 offset = 0x100000000 - offset
-            # TODO we need to check if this is actually a 64bit absolute offset (e.g. used by movabs)
+            pack_format = "<I"
             try:
-                packed_hex = str(codecs.encode(struct.pack("I", offset), "hex").decode("ascii"))
+                if ins.getDetailed().disp_size == 8:
+                    pack_format = "<Q"
+            except (AttributeError, AssertionError, NotImplementedError):
+                pass
+            try:
+                packed_hex = str(codecs.encode(struct.pack(pack_format, offset), "hex").decode("ascii"))
             except struct.error:
-                packed_hex = str(codecs.encode(struct.pack("Q", offset), "hex").decode("ascii"))
+                packed_hex = str(codecs.encode(struct.pack("<Q", offset), "hex").decode("ascii"))
+            wildcard = "?" * len(packed_hex)
             num_occurrences = occurrences(ins.bytes, packed_hex)
             if num_occurrences == 1:
-                escaped_sequence = ins.bytes.replace(packed_hex, "????????")
+                escaped_sequence = ins.bytes.replace(packed_hex, wildcard)
             elif num_occurrences == 2:
-                escaped_sequence = "????????".join(escaped_sequence.rsplit(packed_hex, 1))
+                escaped_sequence = wildcard.join(escaped_sequence.rsplit(packed_hex, 1))
                 LOGGER.warning(
                     "IntelInstructionEscaper.escapeBinaryPtrRef: 2 occurrences for %s in %s (%s %s), escaping only the second one",
                     packed_hex,

--- a/tests/testEscaper.py
+++ b/tests/testEscaper.py
@@ -168,6 +168,34 @@ class DisassemblyTestSuite(unittest.TestCase):
                 "bitness": 64,
                 "expected_opc": "66666666480f00??????????",
             },
+            # movabs with a 64-bit absolute memory offset should wildcard all 8 offset bytes
+            {
+                "ins": (
+                    0,
+                    "48a10000000000004000",
+                    "movabs",
+                    "rax, qword ptr [0x40000000000000]",
+                ),
+                "lower": None,
+                "upper": None,
+                "expected_bin": "48a1????????????????",
+                "bitness": 64,
+                "expected_opc": "48a1????????????????",
+            },
+            # same 64-bit absolute memory offset behavior for the store form
+            {
+                "ins": (
+                    0,
+                    "48a30000000000004000",
+                    "movabs",
+                    "qword ptr [0x40000000000000], rax",
+                ),
+                "lower": None,
+                "upper": None,
+                "expected_bin": "48a3????????????????",
+                "bitness": 64,
+                "expected_opc": "48a3????????????????",
+            },
         ]
         for data in test_data:
             smda_report = SmdaReport()


### PR DESCRIPTION
## Summary

This PR fixes Intel instruction wildcarding for `movabs` memory operands that Capstone reports with 64-bit absolute offsets.

Previously, `escapeBinaryPtrRef()` parsed bracketed pointer operands and tried to encode the parsed offset as a 32-bit value first. That worked for ordinary 32-bit displacements and RIP-relative references, but it did not distinguish `movabs` absolute memory offsets whose displacement is encoded as 8 bytes. As a result, those instructions could be wildcarded with the wrong operand width.

## What changed

- Uses Capstone detail metadata (`disp_size`) to detect 8-byte absolute memory offsets.
- Packs 8-byte displacements as little-endian 64-bit values and generates a matching 16-character wildcard mask.
- Keeps the existing 32-bit behavior for ordinary pointer references and RIP-relative operands.
- Preserves the existing duplicate-match behavior that escapes the rightmost occurrence when the packed offset appears twice.
- Adds regression coverage for both `movabs` absolute-memory forms:
  - `movabs rax, qword ptr [abs64]`
  - `movabs qword ptr [abs64], rax`

## Impact

This only changes Intel binary wildcarding output for pointer references whose encoded displacement is actually 8 bytes. It does not change public APIs, report serialization, or disassembly control flow.

## Validation

- `.venv/bin/python -m pytest tests/testEscaper.py -q`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`
- `PATH="$PWD/.venv/bin:$PATH" make lint`
