### PR TITLE
refactor(intel): clarify indirect import slot resolution

### DIFF
--- a/smda/intel/IndirectCallAnalyzer.py
+++ b/smda/intel/IndirectCallAnalyzer.py
@@ -31,6 +31,12 @@ class IndirectCallAnalyzer:
             return None
         return struct.unpack("I", self.disassembly.getBytes(addr, 4))[0]
 
+    def _resolveDwordPointerValue(self, addr):
+        dll, api = self.disassembler.resolveApi(addr, addr)
+        if dll or api:
+            return addr, dll, api
+        return self.getDword(addr), dll, api
+
     def processBlock(self, analysis_state, block, registers, register_name, processed, depth):
         if not block:
             return False
@@ -65,28 +71,27 @@ class IndirectCallAnalyzer:
                 # mov <reg>, dword ptr [<addr>]
                 match3 = self.RE_REG_DWORD_PTR_ADDR.match(ins[3])
                 if match3:
-                    # HACK: test to see if the address points to a import and
-                    # use that instead of the actual memory value
+                    # Import resolvers may key APIs by the pointer slot address,
+                    # so preserve known import slots instead of dereferencing them.
                     addr = int(match3.group("addr"), 16)
-                    dll, api = self.disassembler.resolveApi(addr, addr)
+                    pointer_value, dll, api = self._resolveDwordPointerValue(addr)
                     if dll or api:
-                        registers[match3.group("reg")] = addr
+                        registers[match3.group("reg")] = pointer_value
                         LOGGER.debug(
                             "**moved API ref (%s:%s) @0x%08x to register %s",
                             dll,
                             api,
-                            addr,
+                            pointer_value,
                             match3.group("reg"),
                         )
                         if match3.group("reg") == register_name:
                             abs_value_found = True
                     else:
-                        dword = self.getDword(addr)
-                        if dword:
-                            registers[match3.group("reg")] = dword
+                        if pointer_value:
+                            registers[match3.group("reg")] = pointer_value
                             LOGGER.debug(
                                 "**moved value 0x%08x to register %s",
-                                dword,
+                                pointer_value,
                                 match3.group("reg"),
                             )
                             if match3.group("reg") == register_name:

--- a/tests/testIndirectCallAnalyzer.py
+++ b/tests/testIndirectCallAnalyzer.py
@@ -69,6 +69,68 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         # eax should have 0x402000
         self.assertEqual(registers.get("eax"), 0x402000, f"Expected eax to be 0x402000, but got {registers.get('eax')}")
 
+    def test_processBlock_preserves_known_import_slot(self):
+        import_slot = 0x403000
+        memory_value = 0x500000
+        disassembler = MagicMock()
+        disassembler.disassembly.apis = {}
+        disassembler.resolveApi.return_value = ("kernel32.dll", "CreateFileA")
+        analyzer = IndirectCallAnalyzer(disassembler)
+        analyzer.getDword = MagicMock(return_value=memory_value)
+
+        analysis_state = MagicMock()
+        analyzer.state = analysis_state
+        analyzer.current_calling_addr = 0x401006
+        registers = {}
+
+        result = analyzer.processBlock(
+            analysis_state,
+            [[0x401000, 6, "mov", "eax, dword ptr [0x403000]"]],
+            registers,
+            "eax",
+            [],
+            1,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(registers["eax"], import_slot)
+        analyzer.getDword.assert_not_called()
+        self.assertEqual(
+            disassembler.disassembly.apis[import_slot],
+            {
+                "referencing_addr": [0x401006],
+                "dll_name": "kernel32.dll",
+                "api_name": "CreateFileA",
+            },
+        )
+
+    def test_processBlock_uses_dword_when_pointer_is_not_import_slot(self):
+        disassembler = MagicMock()
+        disassembler.disassembly.apis = {}
+        disassembler.disassembly.isAddrWithinMemoryImage.return_value = True
+        disassembler.resolveApi.return_value = (None, None)
+        analyzer = IndirectCallAnalyzer(disassembler)
+        analyzer.getDword = MagicMock(return_value=0x401234)
+
+        analysis_state = MagicMock()
+        analyzer.state = analysis_state
+        analyzer.current_calling_addr = 0x401006
+        registers = {}
+
+        result = analyzer.processBlock(
+            analysis_state,
+            [[0x401000, 6, "mov", "eax, dword ptr [0x403000]"]],
+            registers,
+            "eax",
+            [],
+            1,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(registers["eax"], 0x401234)
+        analyzer.getDword.assert_called_once_with(0x403000)
+        disassembler.fc_manager.addCandidate.assert_called_once_with(0x401234, reference_source=0x401006)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This PR clarifies and regression-tests how `IndirectCallAnalyzer` handles `mov <reg>, dword ptr [<addr>]` when `<addr>` is an import-table slot.

The existing code already had the right behavior, but it was hidden behind a `HACK` comment. If the pointer address itself resolves to an imported API, the analyzer must preserve that pointer slot address as the candidate. That keeps API resolution keyed consistently with the PE/ELF import resolvers, which can identify imports by the import slot rather than by the memory value loaded from that slot.

## What changed

- Extracted the import-slot check and dword fallback into `_resolveDwordPointerValue()`.
- Replaced the `HACK` comment with an explanation of why known import slots are preserved.
- Kept the existing final `resolveApi(candidate, candidate)` behavior unchanged.
- Added unit coverage for both paths:
  - known import slot: preserve the slot address and record API metadata under that address
  - non-import pointer: fall back to reading the dword value and queue it as a function candidate when appropriate

## Why

Indirect register-call recovery backtracks register values. For instructions like:

```asm
mov eax, dword ptr [0x403000]
call eax
```

`0x403000` may be an import slot. Dereferencing it too early can lose the address shape that SMDA's import providers use to resolve and record API calls. This PR makes that domain rule explicit and protects it with tests.

## Validation

Run from a clean worktree based on `upstream/master`:

- `python -m pytest tests/testIndirectCallAnalyzer.py -q`
- `python -m ruff check smda/intel/IndirectCallAnalyzer.py tests/testIndirectCallAnalyzer.py`
- `make lint`
- `make test`

Result: all checks passed. Full test suite passed with 82 tests.
