### PR TITLE
ci: add semantic pull request title workflow

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,53 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+    branches:
+      - master
+      - main
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Conventional Commit format
+        uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            perf
+            refactor
+            test
+            docs
+            ci
+            build
+            chore
+            revert
+          scopes: |
+            core
+            intel
+            dalvik
+            cil
+            common
+            utility
+            loaders
+            labels
+            report
+            ida
+            cli
+            tests
+            ci
+            build
+            docs


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that validates pull request titles against Conventional Commit-style types/scopes.
- Use `amannn/action-semantic-pull-request@v6.1.1`, the latest published release checked before opening this PR.
- Run on `pull_request_target` without checking out or executing pull request code.

## Security notes

- The workflow is title-only: no `actions/checkout`, no shell `run:` steps, and minimal `pull-requests: read` permissions.
- This follows GitHub guidance for `pull_request_target`: avoid building or running untrusted PR code in that event context.

## Validation

- `git diff --check`
- Workflow sanity check: verified no checkout, no `run:` blocks, and `pull_request_target` trigger is present.
