### PR TITLE
ci: harden CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,55 +2,78 @@ name: CI
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [master, main]
   pull_request:
-    branches: [ master, main ]
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   lint:
     name: Code Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-        
-    - name: Install ruff
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ruff
-        
-    - name: Run ruff linting
-      run: ruff check .
-      
-    - name: Run ruff formatting check
-      run: ruff format --check .
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install lint dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run ruff linting
+        run: python -m ruff check .
+
+      - name: Run ruff formatting check
+        run: python -m ruff format --check .
 
   test:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        pip install -e .
-        
-    - name: Run tests
-      run: python -m pytest tests/test*
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install --editable .
+
+      - name: Run tests
+        run: python -m pytest tests/test*


### PR DESCRIPTION
## Summary
- restrict the workflow GITHUB_TOKEN to read-only contents access
- pin official GitHub Actions to full-length commit SHAs while using the latest releases
- add workflow concurrency, job timeouts, pip caching, and a manual dispatch trigger
- keep the Python 3.8-3.13 test matrix and use repository requirements for lint/test dependencies

## Security/documentation basis
- GitHub Actions secure use reference recommends least-privilege GITHUB_TOKEN permissions and pinning actions to full-length commit SHAs: https://docs.github.com/en/actions/reference/security/secure-use
- GitHub workflow syntax documents permissions and concurrency controls: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
- GitHub Python CI guidance recommends setup-python and pip dependency caching: https://docs.github.com/en/actions/how-tos/writing-workflows/building-and-testing/building-and-testing-python

## Validation
- ruby YAML parse for .github/workflows/ci.yml
- git diff --check -- .github/workflows/ci.yml
- make lint
- make test