### PR TITLE
fix(security): avoid swallowing non-operational exceptions

### DIFF
--- a/smda/Disassembler.py
+++ b/smda/Disassembler.py
@@ -5,6 +5,7 @@ import traceback
 
 from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
 from smda.common.SmdaReport import SmdaReport
 from smda.dalvik.DalvikDisassembler import DalvikDisassembler
@@ -141,9 +142,11 @@ class Disassembler:
             if self.config.STORE_BUFFER:
                 smda_report.buffer = binary_info.binary
         except Exception as exc:
-            LOGGER.error("An error occurred while disassembling file.")
-            # print("-> an error occured (", str(exc), ").")
-            smda_report = self._createErrorReport(start, exc)
+            smda_report = self._handleDisassemblyException(
+                start,
+                exc,
+                "An error occurred while disassembling file.",
+            )
         return smda_report
 
     def disassembleUnmappedBuffer(self, file_content):
@@ -160,9 +163,11 @@ class Disassembler:
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content
         except Exception as exc:
-            LOGGER.error("An error occurred while disassembling unmapped buffer.")
-            # print("-> an error occured (", str(exc), ").")
-            smda_report = self._createErrorReport(start, exc)
+            smda_report = self._handleDisassemblyException(
+                start,
+                exc,
+                "An error occurred while disassembling unmapped buffer.",
+            )
         return smda_report
 
     def disassembleBuffer(
@@ -206,9 +211,11 @@ class Disassembler:
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content
         except Exception as exc:
-            LOGGER.error("An error occurred while disassembling buffer.")
-            # print("-> an error occured (", str(exc), ").")
-            smda_report = self._createErrorReport(start, exc)
+            smda_report = self._handleDisassemblyException(
+                start,
+                exc,
+                "An error occurred while disassembling buffer.",
+            )
         return smda_report
 
     def _disassemble(self, binary_info, timeout=0):
@@ -228,3 +235,8 @@ class Disassembler:
         report.execution_time = self._getDurationInSeconds(start, datetime.datetime.now(datetime.timezone.utc))
         report.message = traceback.format_exc()
         return report
+
+    def _handleDisassemblyException(self, start, exception, log_message):
+        reraise_non_operational_exception(exception)
+        LOGGER.error(log_message)
+        return self._createErrorReport(start, exception)

--- a/smda/common/DominatorTree.py
+++ b/smda/common/DominatorTree.py
@@ -12,6 +12,8 @@
 
 import logging
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -142,7 +144,8 @@ def get_nesting_depth(graph, domtree, root):
 
     try:
         return maximum_costs(root)
-    except Exception:
+    except Exception as exc:
+        reraise_non_operational_exception(exc)
         return 0
 
 

--- a/smda/common/ExceptionHandling.py
+++ b/smda/common/ExceptionHandling.py
@@ -1,0 +1,13 @@
+NON_OPERATIONAL_EXCEPTION_TYPES = (
+    AssertionError,
+    ImportError,
+    MemoryError,
+    NameError,
+    ReferenceError,
+    SyntaxError,
+)
+
+
+def reraise_non_operational_exception(exception):
+    if isinstance(exception, NON_OPERATIONAL_EXCEPTION_TYPES):
+        raise

--- a/smda/common/SmdaFunction.py
+++ b/smda/common/SmdaFunction.py
@@ -6,6 +6,7 @@ import struct
 from typing import Iterator
 
 from smda.common.DominatorTree import build_dominator_tree, get_nesting_depth
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.Tarjan import Tarjan
 from smda.intel.IntelInstructionEscaper import IntelInstructionEscaper
@@ -181,8 +182,8 @@ class SmdaFunction:
                 tree = build_dominator_tree(normalized_blockrefs, root)
                 if tree:
                     nesting_depth = get_nesting_depth(normalized_blockrefs, tree, root)
-        except Exception:
-            pass
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
         return nesting_depth
 
     def getPicHash(self, binary_info):

--- a/smda/common/TailcallAnalyzer.py
+++ b/smda/common/TailcallAnalyzer.py
@@ -3,6 +3,8 @@ import json
 from collections import defaultdict
 from operator import itemgetter
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 
 class TailcallAnalyzer:
     def __init__(self):
@@ -117,8 +119,8 @@ class TailcallAnalyzer:
                     disassembler.analyzeFunction(tailcall["destination_function"])
                     function = self.__getFunctionByStartAddr(tailcall["destination_function"])
                     function.is_tailcall_function = True
-                except Exception:
-                    pass
+                except Exception as exc:
+                    reraise_non_operational_exception(exc)
                     # print ("0x{:x} -> 0x{:x}".format(tailcall["destination_function"], tailcall["destination_addr"]))
             elif verbose:
                 print(

--- a/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/smda/common/labelprovider/DelphiReSymProvider.py
@@ -16,6 +16,8 @@ import struct
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 
 LOGGER = logging.getLogger(__name__)
@@ -279,6 +281,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             else:
                 LOGGER.debug("No Delphi symbols extracted")
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.warning(f"Error during DelphiReSym parsing: {e}")
 
     def _is_compatible(self):
@@ -475,6 +478,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             return object_name
 
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.debug(f"Error traversing RTTI object at 0x{rtti_offset:x}: {e}")
             return None
 
@@ -508,6 +512,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             return self._traverse_rtti_object(rtti_offset, validate_pointers=False)
 
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.debug(f"Error resolving type from double ptr at 0x{ptr_field_offset:x}: {e}")
             return None
 
@@ -557,6 +562,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             return method_info
 
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.debug(f"Error extracting method info at 0x{method_entry_offset:x}: {e}")
             return None
 

--- a/smda/common/labelprovider/GoLabelProvider.py
+++ b/smda/common/labelprovider/GoLabelProvider.py
@@ -6,6 +6,8 @@ from collections import OrderedDict
 
 import lief
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 
 lief.logging.disable()
@@ -31,8 +33,8 @@ class GoSymbolProvider(AbstractLabelProvider):
             elif lief_binary.format == lief.EXE_FORMATS.PE:
                 rdata_offset = lief_binary.get_section(".rdata").offset
                 pclntab_offset = rdata_offset + lief_binary.get_symbol("runtime.pclntab").value
-        except Exception:
-            pass
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
         if pclntab_offset is None:
             # scan for offset of structure
             pclntab_regex = re.compile(b".\xff\xff\xff\x00\x00\x01(\x04|\x08)")
@@ -50,7 +52,8 @@ class GoSymbolProvider(AbstractLabelProvider):
                 result = self._parse_pclntab(pclntab_offset, binary)
                 if result:
                     self._func_symbols = result
-            except Exception:
+            except Exception as exc:
+                reraise_non_operational_exception(exc)
                 return
 
     def isSymbolProvider(self):

--- a/smda/common/labelprovider/PdbSymbolProvider.py
+++ b/smda/common/labelprovider/PdbSymbolProvider.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.utility.PeFileLoader import PeFileLoader
 
 from .AbstractLabelProvider import AbstractLabelProvider
@@ -54,6 +55,7 @@ class PdbSymbolProvider(AbstractLabelProvider):
             pdb = pdbparse.parse(binary_info.file_path)
             self._parseSymbols(pdb)
         except Exception as exc:
+            reraise_non_operational_exception(exc)
             LOGGER.error(
                 'Failed parsing "%s" with exception type: %s',
                 binary_info.file_path,

--- a/smda/common/labelprovider/RustSymbolProvider.py
+++ b/smda/common/labelprovider/RustSymbolProvider.py
@@ -4,6 +4,8 @@ import logging
 
 import lief
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 from .rust_demangler import demangle
 from .rust_demangler.rust import TypeNotFoundError
@@ -40,6 +42,7 @@ class RustSymbolProvider(AbstractLabelProvider):
         try:
             lief_binary = binary_info.getLiefBinary()
         except Exception as exc:
+            reraise_non_operational_exception(exc)
             LOGGER.debug("Failed to parse binary with LIEF: %s", type(exc).__name__)
             return
 

--- a/smda/dalvik/DalvikDisassembler.py
+++ b/smda/dalvik/DalvikDisassembler.py
@@ -5,6 +5,7 @@ import struct
 
 import lief
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.dalvik.DalvikFunctionAnalysisState import DalvikFunctionAnalysisState
 from smda.dalvik.DalvikOpcodeDecoder import (
     decode_instruction,
@@ -86,7 +87,8 @@ class DexReferenceResolver:
     def _safeAttr(self, obj, attr, default=None):
         try:
             return getattr(obj, attr)
-        except Exception:
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
             return default
 
     def _normalizeTypeString(self, type_name):
@@ -952,6 +954,7 @@ class DalvikDisassembler:
                 self.analyzeFunction(dex_file, resolver, method)
                 analyzed_count += 1
             except Exception as exc:
+                reraise_non_operational_exception(exc)
                 LOGGER.warning(
                     "Failed to analyze Dalvik method %s @0x%x: %s",
                     resolver.formatMethod(method),

--- a/smda/intel/FunctionCandidateManager.py
+++ b/smda/intel/FunctionCandidateManager.py
@@ -4,6 +4,7 @@ import struct
 
 from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, Cs
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.utility.BracketQueue import BracketQueue
 from smda.utility.PriorityQueue import PriorityQueue
 
@@ -133,7 +134,8 @@ class FunctionCandidateManager:
             candidates_0 = len([c.getScore() for c in self.candidates.values() if c.getScore() == 0])
             LOGGER.debug("  Max: %f, Min: %f", maxc, minc)
             LOGGER.debug("  2: %d, 1: %d, 0: %d", candidates_2, candidates_1, candidates_0)
-        except Exception:
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
             LOGGER.debug("  No candidates found.")
 
     def getFunctionStartCandidates(self):
@@ -239,7 +241,8 @@ class FunctionCandidateManager:
             # compatibility with python2/3...
             try:
                 byte = self.disassembly.getRawByte(gap_offset)
-            except Exception:
+            except Exception as exc:
+                reraise_non_operational_exception(exc)
                 LOGGER.warn("could not fetch raw byte for gap pointer.")
                 # print("0x%08x" % self.disassembly.binary_info.base_addr, "0x%08x" % self.disassembly.binary_info.binary_size, "0x%08x" % self.gap_pointer, "0x%08x" % gap_offset)
             # try to find padding symbols and skip them

--- a/smda/utility/StringExtractor.py
+++ b/smda/utility/StringExtractor.py
@@ -3,6 +3,7 @@ import struct
 from typing import Iterator, Tuple
 
 from smda.common import SmdaFunction
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 
 _IS_PRINTABLE_CHAR_CODE = tuple(chr(char) in string.printable for char in range(256))
 
@@ -162,8 +163,8 @@ def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int]]:
                                         data_ref,
                                         string_type,
                                     )
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            reraise_non_operational_exception(exc)
                 if not found_string:
                     string_result = read_go_string(f.smda_report, data_ref)
                     if string_result:

--- a/tests/testExceptionHandling.py
+++ b/tests/testExceptionHandling.py
@@ -1,0 +1,131 @@
+import ast
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+from smda.Disassembler import Disassembler
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SMDA_ROOT = PROJECT_ROOT / "smda"
+
+
+class ExceptionHandlingTestSuite(unittest.TestCase):
+    operational_exceptions = (
+        FileNotFoundError("missing input"),
+        RuntimeError("backend failed"),
+        ValueError("malformed input"),
+    )
+
+    non_operational_exceptions = (
+        AssertionError("broken invariant"),
+        GeneratorExit("generator closed"),
+        ImportError("dependency import failed"),
+        KeyboardInterrupt("interrupted"),
+        MemoryError("out of memory"),
+        NameError("missing name"),
+        ReferenceError("lost weak reference"),
+        SyntaxError("invalid generated code"),
+        SystemExit("exiting"),
+    )
+
+    def _call_disassemble_buffer(self, disasm):
+        return disasm.disassembleBuffer(b"dummy_content", 0x1000)
+
+    def _call_disassemble_unmapped_buffer(self, disasm):
+        return disasm.disassembleUnmappedBuffer(b"dummy_content")
+
+    def _call_disassemble_file(self, disasm):
+        with patch("smda.Disassembler.FileLoader") as mock_loader_class:
+            mock_loader_class.return_value = MagicMock()
+            disasm._populateBinaryInfo = MagicMock(
+                return_value=SimpleNamespace(architecture="intel", binary=b"dummy_content")
+            )
+            disasm.initDisassembler = MagicMock()
+            disasm.disassembler = MagicMock()
+            return disasm.disassembleFile("dummy_path")
+
+    def _entry_points(self):
+        return (
+            ("disassembleBuffer", self._call_disassemble_buffer),
+            ("disassembleUnmappedBuffer", self._call_disassemble_unmapped_buffer),
+            ("disassembleFile", self._call_disassemble_file),
+        )
+
+    def test_operational_exceptions_return_error_reports(self):
+        for entry_point_name, call_entry_point in self._entry_points():
+            for exception in self.operational_exceptions:
+                with self.subTest(entry_point=entry_point_name, exception=exception.__class__.__name__):
+                    disasm = Disassembler()
+                    disasm._disassemble = MagicMock(side_effect=exception)
+
+                    report = call_entry_point(disasm)
+
+                    self.assertEqual(report.status, "error")
+                    self.assertIn(exception.__class__.__name__, report.message)
+
+    def test_missing_input_file_returns_error_report(self):
+        with patch("smda.Disassembler.FileLoader", side_effect=FileNotFoundError("missing input")):
+            report = Disassembler().disassembleFile("non_existent_file.bin")
+
+        self.assertEqual(report.status, "error")
+        self.assertIn("FileNotFoundError", report.message)
+
+    def test_non_operational_exceptions_bubble_up(self):
+        for entry_point_name, call_entry_point in self._entry_points():
+            for exception in self.non_operational_exceptions:
+                with self.subTest(entry_point=entry_point_name, exception=exception.__class__.__name__):
+                    disasm = Disassembler()
+                    disasm._disassemble = MagicMock(side_effect=exception)
+
+                    with self.assertRaises(exception.__class__):
+                        call_entry_point(disasm)
+
+    def test_non_operational_helper_reraises_current_exception(self):
+        try:
+            raise NameError("missing name")
+        except Exception as exc:
+            with self.assertRaises(NameError):
+                reraise_non_operational_exception(exc)
+
+    def test_all_broad_exception_handlers_reraise_non_operational_exceptions(self):
+        offenders = []
+        for path in sorted(SMDA_ROOT.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Try):
+                    continue
+                for handler in node.handlers:
+                    if not self._is_broad_exception_handler(handler):
+                        continue
+                    call_names = self._get_handler_call_names(handler)
+                    if not {
+                        "reraise_non_operational_exception",
+                        "_handleDisassemblyException",
+                    }.intersection(call_names):
+                        offenders.append(f"{path.relative_to(PROJECT_ROOT)}:{handler.lineno}")
+
+        self.assertEqual([], offenders)
+
+    def _is_broad_exception_handler(self, handler):
+        if isinstance(handler.type, ast.Name):
+            return handler.type.id == "Exception"
+        if isinstance(handler.type, ast.Tuple):
+            return any(isinstance(elt, ast.Name) and elt.id == "Exception" for elt in handler.type.elts)
+        return False
+
+    def _get_handler_call_names(self, handler):
+        call_names = set()
+        for node in ast.walk(ast.Module(body=handler.body, type_ignores=[])):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name):
+                call_names.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                call_names.add(node.func.attr)
+        return call_names
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a shared helper for broad exception handlers to re-raise non-operational exceptions
- keep public disassembly entry points returning error reports for operational failures
- add an AST regression guard that checks broad `except Exception` handlers under `smda/`

## Review

- repo-local `smda-pattern-scanner` found no confirmed issue in the branch diff
- pattern: broad exception handlers must not swallow developer/runtime-control failures
- instances covered: 19 broad `except Exception` handlers under `smda/`

## Validation

- `python -m pytest tests/testExceptionHandling.py -q` -> 5 passed
- `python -m ruff check .` -> passed