### PR TITLE
fix(dalvik): recover try-catch exception edges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PYTHON ?= python3
 
+.PHONY: init package publish ruff-check ruff-format ruff-fix lint format test test-coverage clean
+
 init:
 	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<75.4.0" wheel
 	$(PYTHON) -m pip install -e ".[dev]"

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -108,11 +108,21 @@ def _register_range(start, names, fmt, size_units, **kwargs):
 
 
 def _mark_can_throw(*mnemonics):
-    remaining = set(mnemonics)
-    for opcode, spec in list(OPCODES.items()):
-        if spec.mnemonic in remaining:
+    """
+    Mark all opcodes matching the given mnemonics as can_throw=True.
+
+    Args:
+        *mnemonics: Variable length list of mnemonics to mark as throwable.
+    Raises:
+        ValueError: If any mnemonic is not found in OPCODES.
+    """
+    to_mark = set(mnemonics)
+    matched = set()
+    for opcode, spec in OPCODES.items():
+        if spec.mnemonic in to_mark:
             OPCODES[opcode] = replace(spec, can_throw=True)
-            remaining.remove(spec.mnemonic)
+            matched.add(spec.mnemonic)
+    remaining = to_mark - matched
     if remaining:
         raise ValueError(f"Unknown Dalvik throwable opcodes: {', '.join(sorted(remaining))}")
 

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -1,5 +1,5 @@
 import struct
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional
 
 
@@ -105,6 +105,16 @@ def _register(opcode, mnemonic, fmt, size_units, **kwargs):
 def _register_range(start, names, fmt, size_units, **kwargs):
     for index, mnemonic in enumerate(names):
         _register(start + index, mnemonic, fmt, size_units, **kwargs)
+
+
+def _mark_can_throw(*mnemonics):
+    remaining = set(mnemonics)
+    for opcode, spec in list(OPCODES.items()):
+        if spec.mnemonic in remaining:
+            OPCODES[opcode] = replace(spec, can_throw=True)
+            remaining.remove(spec.mnemonic)
+    if remaining:
+        raise ValueError(f"Unknown Dalvik throwable opcodes: {', '.join(sorted(remaining))}")
 
 
 _register(0x00, "nop", "10x", 1)
@@ -239,6 +249,7 @@ _register_range(
     "21c",
     2,
     ref_kind="field",
+    can_throw=True,
 )
 _register_range(
     0x6E,
@@ -402,6 +413,20 @@ _register_range(
     ],
     "22b",
     2,
+)
+_mark_can_throw(
+    "div-int",
+    "rem-int",
+    "div-long",
+    "rem-long",
+    "div-int/2addr",
+    "rem-int/2addr",
+    "div-long/2addr",
+    "rem-long/2addr",
+    "div-int/lit16",
+    "rem-int/lit16",
+    "div-int/lit8",
+    "rem-int/lit8",
 )
 _register(0xFA, "invoke-polymorphic", "45cc", 4, ref_kind="method", can_throw=True, is_invoke=True)
 _register(0xFB, "invoke-polymorphic/range", "4rcc", 4, ref_kind="method", can_throw=True, is_invoke=True)

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -11,7 +11,13 @@ import unittest
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaFunction import SmdaFunction
 from smda.common.SmdaReport import SmdaReport
-from smda.dalvik.DalvikOpcodeDecoder import decode_instruction, parse_code_item_header, read_sleb128, read_uleb128
+from smda.dalvik.DalvikOpcodeDecoder import (
+    OPCODES,
+    decode_instruction,
+    parse_code_item_header,
+    read_sleb128,
+    read_uleb128,
+)
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.utility.DexFileLoader import DexFileLoader
@@ -386,6 +392,79 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         decoded_array = decode_instruction(fill_array, 0, DummyResolver())
         self.assertEqual(decoded_array.mnemonic, "fill-array-data")
         self.assertEqual(decoded_array.payload_idx, 4)
+
+    def testThrowableOpcodeMetadataFeedsExceptionEdges(self):
+        from smda.dalvik.DalvikDisassembler import DalvikDisassembler
+
+        disassembler = DalvikDisassembler(config)
+        by_mnemonic = {spec.mnemonic: opcode for opcode, spec in OPCODES.items()}
+
+        throwable_mnemonics = [
+            "sget",
+            "sget-wide",
+            "sget-object",
+            "sget-boolean",
+            "sget-byte",
+            "sget-char",
+            "sget-short",
+            "sput",
+            "sput-wide",
+            "sput-object",
+            "sput-boolean",
+            "sput-byte",
+            "sput-char",
+            "sput-short",
+            "div-int",
+            "rem-int",
+            "div-long",
+            "rem-long",
+            "div-int/2addr",
+            "rem-int/2addr",
+            "div-long/2addr",
+            "rem-long/2addr",
+            "div-int/lit16",
+            "rem-int/lit16",
+            "div-int/lit8",
+            "rem-int/lit8",
+        ]
+        for mnemonic in throwable_mnemonics:
+            with self.subTest(mnemonic=mnemonic):
+                opcode = by_mnemonic[mnemonic]
+                decoded = decode_instruction(
+                    bytes([opcode]) + b"\x00" * (OPCODES[opcode].size_units * 2 - 1), 0, DummyResolver()
+                )
+                self.assertTrue(decoded.can_throw)
+                self.assertTrue(disassembler._instructionCanThrow(decoded))
+
+        non_throwing_mnemonics = ["add-int", "mul-int", "add-long", "div-float", "rem-double", "shl-int/lit8"]
+        for mnemonic in non_throwing_mnemonics:
+            with self.subTest(mnemonic=mnemonic):
+                opcode = by_mnemonic[mnemonic]
+                decoded = decode_instruction(
+                    bytes([opcode]) + b"\x00" * (OPCODES[opcode].size_units * 2 - 1), 0, DummyResolver()
+                )
+                self.assertFalse(decoded.can_throw)
+                self.assertFalse(disassembler._instructionCanThrow(decoded))
+
+    def testThrowableFieldAndIntegerDivideOpcodesAddExceptionEdges(self):
+        cases = [
+            ("sget", bytes.fromhex("60000000")),
+            ("div-int", bytes.fromhex("93000102")),
+            ("div-int/2addr", bytes.fromhex("b300")),
+            ("div-int/lit8", bytes.fromhex("db000001")),
+        ]
+        for mnemonic, protected_instruction in cases:
+            with self.subTest(mnemonic=mnemonic):
+                handler_addr_units = len(protected_instruction) // 2 + 1
+                code_item = build_code_item(
+                    protected_instruction + bytes.fromhex("0e000d010e00"),
+                    tries=[(0, len(protected_instruction) // 2, 1)],
+                    handlers_blob=bytes([1, 0, handler_addr_units]),
+                )
+                disassembly, func_addr = self._analyzeSyntheticMethod(code_item)
+                handler_addr = func_addr + handler_addr_units * 2
+
+                self.assertIn(handler_addr, disassembly.code_refs_from[func_addr])
 
     def testDisassembleBufferDexAutodetect(self):
         generic_disasm = Disassembler(config)


### PR DESCRIPTION
## Summary

Ports fork PR #44 to upstream on a branch based directly on current `upstream/master`.

- Marks Makefile operational targets as phony.
- Extends Dalvik opcode metadata so throwable static field and division/modulo instructions can produce exception edges.
- Adds Dalvik regression coverage for exception-throwing opcode metadata and try-catch edge recovery.

Fork PR: https://github.com/r0ny123/smda/pull/44

## Validation

- `PATH=".venv/bin:$PATH" python3 -m pytest tests/testDalvikDisassembler.py -q` -> 32 passed
- `PATH=".venv/bin:$PATH" python3 -m ruff check .` -> all checks passed
- `git diff --check upstream/master...HEAD` -> passed

## Risk

Limited to Dalvik exception-edge recovery and Makefile target declaration. The upstream branch was cherry-picked onto current `upstream/master` to avoid carrying unrelated fork-master commits.
