### PR TITLE
perf(common): build reverse blockrefs index for O(1) predecessor lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PYTHON ?= python3
 
+.PHONY: init package publish ruff-check ruff-format ruff-fix lint format test test-coverage clean
+
 init:
 	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0"
 	$(PYTHON) -m pip install -e ".[dev]"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 init:
-	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<75.4.0" wheel
+	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0,<0.48.0"
 	$(PYTHON) -m pip install -e ".[dev]"
 	$(PYTHON) -m pre_commit install
 package:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 
 init:
-	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0,<0.48.0"
+	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0"
 	$(PYTHON) -m pip install -e ".[dev]"
 	$(PYTHON) -m pre_commit install
 package:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and code form
 
 ```bash
 # Install development dependencies
-python3 -m pip install --upgrade pip "setuptools>=64.0.0,<75.4.0" wheel
+python3 -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0"
 python3 -m pip install -e ".[dev]"
 
 # Install pre-commit hooks (optional but recommended)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0,<75.4.0", "wheel"]
+requires = ["setuptools>=64.0.0,<82.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0,<82.1.0", "wheel>=0.47.0,<0.48.0"]
+requires = ["setuptools>=64.0.0,<82.1.0", "wheel>=0.47.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64.0.0,<82.1.0", "wheel"]
+requires = ["setuptools>=64.0.0,<82.1.0", "wheel>=0.47.0,<0.48.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -5,6 +5,7 @@ import traceback
 
 from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
 from smda.common.SmdaReport import SmdaReport
 from smda.dalvik.DalvikDisassembler import DalvikDisassembler
@@ -141,9 +142,11 @@ class Disassembler:
             if self.config.STORE_BUFFER:
                 smda_report.buffer = binary_info.binary
         except Exception as exc:
-            LOGGER.error("An error occurred while disassembling file.")
-            # print("-> an error occured (", str(exc), ").")
-            smda_report = self._createErrorReport(start, exc)
+            smda_report = self._handleDisassemblyException(
+                start,
+                exc,
+                "An error occurred while disassembling file.",
+            )
         return smda_report
 
     def disassembleUnmappedBuffer(self, file_content):
@@ -160,9 +163,11 @@ class Disassembler:
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content
         except Exception as exc:
-            LOGGER.error("An error occurred while disassembling unmapped buffer.")
-            # print("-> an error occured (", str(exc), ").")
-            smda_report = self._createErrorReport(start, exc)
+            smda_report = self._handleDisassemblyException(
+                start,
+                exc,
+                "An error occurred while disassembling unmapped buffer.",
+            )
         return smda_report
 
     def disassembleBuffer(
@@ -206,9 +211,11 @@ class Disassembler:
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content
         except Exception as exc:
-            LOGGER.error("An error occurred while disassembling buffer.")
-            # print("-> an error occured (", str(exc), ").")
-            smda_report = self._createErrorReport(start, exc)
+            smda_report = self._handleDisassemblyException(
+                start,
+                exc,
+                "An error occurred while disassembling buffer.",
+            )
         return smda_report
 
     def _disassemble(self, binary_info, timeout=0):
@@ -228,3 +235,8 @@ class Disassembler:
         report.execution_time = self._getDurationInSeconds(start, datetime.datetime.now(datetime.timezone.utc))
         report.message = traceback.format_exc()
         return report
+
+    def _handleDisassemblyException(self, start, exception, log_message):
+        reraise_non_operational_exception(exception)
+        LOGGER.error(log_message)
+        return self._createErrorReport(start, exception)

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -26,6 +26,7 @@ class Disassembler:
             config = SmdaConfig()
         self.config = config
         self.disassembler = None
+        self._explicit_backend = bool(backend)
         if backend == "intel":
             self.disassembler = IntelDisassembler(self.config)
         elif backend == "cil":
@@ -136,8 +137,8 @@ class Disassembler:
                 self.disassembler.addPdbFile(binary_info, pdb_path)
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
-                is_go_binary = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
-                string_mode = "go" if is_go_binary else None
+                go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
+                string_mode = "go" if go_pclntab_offset is not None else None
                 self._addStringsToReport(smda_report, binary_info.binary, mode=string_mode)
             if self.config.STORE_BUFFER:
                 smda_report.buffer = binary_info.binary
@@ -157,8 +158,8 @@ class Disassembler:
             self.initDisassembler(binary_info.architecture)
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
-                is_go_binary = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
-                string_mode = "go" if is_go_binary else None
+                go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
+                string_mode = "go" if go_pclntab_offset is not None else None
                 self._addStringsToReport(smda_report, file_content, mode=string_mode)
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content
@@ -186,7 +187,7 @@ class Disassembler:
         # Auto-detect DEX when the caller did not explicitly override architecture.
         # disassembleUnmappedBuffer / disassembleFile already use FileLoader for detection;
         # this path bypasses it, so we check the magic bytes manually here.
-        if architecture == "intel" and DexFileLoader.isCompatible(file_content):
+        if not self._explicit_backend and architecture == "intel" and DexFileLoader.isCompatible(file_content):
             architecture = "dalvik"
             if bitness is None:
                 bitness = DexFileLoader.getBitness(file_content)
@@ -205,8 +206,8 @@ class Disassembler:
         try:
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
-                is_go_binary = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
-                string_mode = "go" if is_go_binary else None
+                go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info.binary)
+                string_mode = "go" if go_pclntab_offset is not None else None
                 self._addStringsToReport(smda_report, file_content, mode=string_mode)
             if self.config.STORE_BUFFER:
                 smda_report.buffer = file_content

--- a/src/smda/DisassemblyStatistics.py
+++ b/src/smda/DisassemblyStatistics.py
@@ -8,6 +8,17 @@ class DisassemblyStatistics:
     num_function_calls = None
     num_failed_functions = None
     num_failed_instructions = None
+    _fields = (
+        "num_functions",
+        "num_recursive_functions",
+        "num_leaf_functions",
+        "num_basic_blocks",
+        "num_instructions",
+        "num_api_calls",
+        "num_function_calls",
+        "num_failed_functions",
+        "num_failed_instructions",
+    )
 
     def __init__(self, disassembly_result=None):
         if disassembly_result is not None:
@@ -74,13 +85,14 @@ class DisassemblyStatistics:
     def __add__(self, other):
         if not isinstance(other, DisassemblyStatistics):
             raise ValueError("Needs another DisassemblyStatistics to perform addition of values")
-        self.num_functions += other.num_functions
-        self.num_recursive_functions += other.num_recursive_functions
-        self.num_leaf_functions += other.num_leaf_functions
-        self.num_basic_blocks += other.num_basic_blocks
-        self.num_instructions += other.num_instructions
-        self.num_api_calls += other.num_api_calls
-        self.num_function_calls += other.num_function_calls
-        self.num_failed_functions += other.num_failed_functions
-        self.num_failed_instructions += other.num_failed_instructions
+        result = DisassemblyStatistics()
+        for field in self._fields:
+            setattr(result, field, (getattr(self, field) or 0) + (getattr(other, field) or 0))
+        return result
+
+    def __iadd__(self, other):
+        if not isinstance(other, DisassemblyStatistics):
+            raise ValueError("Needs another DisassemblyStatistics to perform addition of values")
+        for field in self._fields:
+            setattr(self, field, (getattr(self, field) or 0) + (getattr(other, field) or 0))
         return self

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -156,21 +156,6 @@ class CilDisassembler:
             i_size = len(i_bytes)
             i_mnemonic = str(insn.opcode)
             i_op_str = format_operand(pe, insn.operand)
-            # debug output for all instructions
-            if False:
-                from smda.cil.CilInstructionEscaper import CilInstructionEscaper
-                from smda.common.SmdaInstruction import SmdaInstruction
-
-                smda_ins = SmdaInstruction([i_address, i_bytes.hex(), i_mnemonic, i_op_str])
-                escaped = CilInstructionEscaper.escapeBinary(smda_ins)
-                print(
-                    f"{escaped:<20}"
-                    + f"{insn.offset:04X}"
-                    + "    "
-                    + f"{' '.join(f'{b:02x}' for b in insn.get_bytes()): <20}"
-                    + f"{str(insn.opcode): <15}"
-                    + format_operand(pe, insn.operand)
-                )
             # https://en.wikipedia.org/wiki/List_of_CIL_instructions
             if i_mnemonic in ["ret"]:
                 state.setNextInstructionReachable(False)
@@ -211,12 +196,13 @@ class CilDisassembler:
                 target = int(i_op_str, 16)
                 state.addCodeRef(i_address, target, by_jump=True)
             if i_mnemonic in ["jmp"]:
-                raise Exception(
-                    "Found unhandled CIL jmp instruction, report back its structure and have Daniel fix it."
-                )
                 target = int(i_op_str, 16)
                 state.addCodeRef(i_address, target, by_jump=True)
                 state.setNextInstructionReachable(False)
+                LOGGER.error(
+                    "Found unhandled CIL jmp instruction at 0x%x, report back its structure and have Daniel fix it.",
+                    i_address,
+                )
             if i_mnemonic in ["ldstr"]:
                 # we possibly want to extract and collect these and put them in the stringref part of SmdaFunction
                 self.disassembly.addStringRef(start_addr, i_address, i_op_str[1:-1])
@@ -276,6 +262,6 @@ class CilDisassembler:
             self.analyzeFunction(pe, method_body.offset, method_body)
         # package up and finish
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout():
+        if cbAnalysisTimeout and cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True
         return self.disassembly

--- a/src/smda/cil/CilInstructionEscaper.py
+++ b/src/smda/cil/CilInstructionEscaper.py
@@ -303,7 +303,6 @@ class CilInstructionEscaper:
                 mnemonic,
             )
             return "U"
-        return mnemonic
 
     @staticmethod
     def escapeField(op_field, escape_registers=True, escape_pointers=True, escape_constants=True):
@@ -451,6 +450,7 @@ class CilInstructionEscaper:
                 "brtrue",
                 "brtrue.s",
                 "brzero",
+                "brzero.s",
                 "switch",
             ]:
                 escaped_sequence = CilInstructionEscaper.escapeToOpcodeOnly(ins)

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -133,7 +133,6 @@ class FunctionAnalysisState:
                     and i != len(self.instructions) - 1
                     and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
                 ):
-                    break
                     # if we can reach a colliding address from here, the block is broken and should end.
                     reachable_collisions = self.code_refs_from[current[0]].intersection(self.colliding_addresses)
                     next_addr = current[0] + current[1]
@@ -141,7 +140,7 @@ class FunctionAnalysisState:
                     if reachable_collisions and is_next_addr:
                         # we should remove the from/to code references for this collision as there should be no non CFG instruction references between instructions of different functions
                         self.removeCodeRef(current[0], next_addr)
-                        break
+                    break
                 if (
                     i != len(self.instructions) - 1
                     and self.instructions[i + 1][0] in self.code_refs_to

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -80,7 +80,6 @@ class BinaryInfo:
         if self.imported_functions is None:
             lief_result = self.getLiefBinary()
             if isinstance(lief_result, lief.PE.Binary):
-                PeSymbolProvider(None).parseSymbols(lief_result)
                 self.imported_functions = PeSymbolProvider(None).parseImports(lief_result)
             elif isinstance(lief_result, lief.ELF.Binary):
                 self.imported_functions = ElfSymbolProvider(None).parseSymbols(lief_result.dynamic_symbols)

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -17,7 +17,7 @@ class BinaryInfo:
     raw_data = b""
     binary_size = 0
     bitness = None
-    code_areas = []
+    code_areas = None
     component = ""
     family = ""
     file_path = ""
@@ -36,6 +36,7 @@ class BinaryInfo:
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)
+        self.code_areas = []
         self._lief_binary = None
         self.abi = ""
 

--- a/src/smda/common/DominatorTree.py
+++ b/src/smda/common/DominatorTree.py
@@ -12,6 +12,8 @@
 
 import logging
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -142,7 +144,8 @@ def get_nesting_depth(graph, domtree, root):
 
     try:
         return maximum_costs(root)
-    except Exception:
+    except Exception as exc:
+        reraise_non_operational_exception(exc)
         return 0
 
 

--- a/src/smda/common/ExceptionHandling.py
+++ b/src/smda/common/ExceptionHandling.py
@@ -1,0 +1,13 @@
+NON_OPERATIONAL_EXCEPTION_TYPES = (
+    AssertionError,
+    ImportError,
+    MemoryError,
+    NameError,
+    ReferenceError,
+    SyntaxError,
+)
+
+
+def reraise_non_operational_exception(exception):
+    if isinstance(exception, NON_OPERATIONAL_EXCEPTION_TYPES):
+        raise

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -59,7 +59,7 @@ class SmdaBasicBlock:
                         + self.smda_function.smda_report.binary_size,
                     )
                 )
-            return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+            return "".join(escaped_binary_seqs).encode("ascii")
 
     def getOpcBlockHash(self):
         if self.opcblockhash is not None:
@@ -76,7 +76,7 @@ class SmdaBasicBlock:
             escaped_binary_seqs = []
             for instruction in self.getInstructions():
                 escaped_binary_seqs.append(instruction.getEscapedToOpcodeOnly(self.smda_function._escaper))
-            return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+            return "".join(escaped_binary_seqs).encode("ascii")
 
     def getPredecessors(self):
         predecessors = []

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -16,14 +16,18 @@ class SmdaBasicBlock:
     def __init__(self, instructions, smda_function=None):
         assert isinstance(instructions, list)
         self.smda_function = smda_function
+        self.instructions = instructions
+        self.offset = instructions[0].offset if instructions else None
+        self.length = len(instructions)
+        self.picblockhash = None
+        self.opcblockhash = None
         if instructions:
-            self.instructions = instructions
-            self.offset = instructions[0].offset
-            self.length = len(instructions)
             self.picblockhash = self.getPicBlockHash()
             self.opcblockhash = self.getOpcBlockHash()
 
     def getInstructions(self) -> Iterator["SmdaInstruction"]:
+        if self.instructions is None:
+            return
         yield from self.instructions
 
     def getPicBlockHash(self):
@@ -90,12 +94,11 @@ class SmdaBasicBlock:
 
     @classmethod
     def fromDict(cls, block_dict, smda_function=None) -> "SmdaBasicBlock":
-        smda_block = cls(None)
-        smda_block.smda_function = smda_function
-        smda_block.instructions = [SmdaInstruction.fromDict(d, smda_function=smda_function) for d in block_dict]
-        return smda_block
+        return cls([SmdaInstruction.fromDict(d, smda_function=smda_function) for d in block_dict], smda_function)
 
     def toDict(self) -> dict:
+        if self.instructions is None:
+            return []
         return [smda_ins.toDict() for smda_ins in self.instructions]
 
     def __int__(self):

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -79,12 +79,15 @@ class SmdaBasicBlock:
             return "".join(escaped_binary_seqs).encode("ascii")
 
     def getPredecessors(self):
-        predecessors = []
-        if self.smda_function is not None:
-            for frm, to in self.smda_function.blockrefs.items():
-                if self.offset in to:
-                    predecessors.append(frm)
-        return predecessors
+        if self.smda_function is None:
+            return []
+        if self.smda_function._blockrefs_reverse is None:
+            rev: dict = {}
+            for frm, tos in self.smda_function.blockrefs.items():
+                for to in tos:
+                    rev.setdefault(to, []).append(frm)
+            self.smda_function._blockrefs_reverse = rev
+        return list(self.smda_function._blockrefs_reverse.get(self.offset, []))
 
     def getSuccessors(self):
         successors = []

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -35,7 +35,7 @@ class SmdaBasicBlock:
             return self.picblockhash
         picblockhash_sequence = self.getPicBlockHashSequence()
         if picblockhash_sequence is not None:
-            self.picblockhash = struct.unpack("Q", hashlib.sha256(picblockhash_sequence).digest()[:8])[0]
+            self.picblockhash = struct.unpack("<Q", hashlib.sha256(picblockhash_sequence).digest()[:8])[0]
         return self.picblockhash
 
     def getPicBlockHashSequence(self):
@@ -66,7 +66,7 @@ class SmdaBasicBlock:
             return self.opcblockhash
         opcblockhash_sequence = self.getOpcBlockHashSequence()
         if opcblockhash_sequence is not None:
-            self.opcblockhash = struct.unpack("Q", hashlib.sha256(opcblockhash_sequence).digest()[:8])[0]
+            self.opcblockhash = struct.unpack("<Q", hashlib.sha256(opcblockhash_sequence).digest()[:8])[0]
         return self.opcblockhash
 
     def getOpcBlockHashSequence(self):
@@ -105,4 +105,6 @@ class SmdaBasicBlock:
         return self.offset
 
     def __str__(self):
+        if self.offset is None:
+            return f"0x????????: ({self.length:>4})"
         return f"0x{self.offset:08x}: ({self.length:>4})"

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -109,21 +109,21 @@ class SmdaFunction:
 
     @property
     def num_instructions(self):
-        return sum(1 for _ in self.getInstructions())
+        return sum(len(block) for block in self.blocks.values())
 
     @property
     def num_calls(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
-            return sum(1 for ins in self.getInstructions() if ins.mnemonic.startswith("invoke-"))
-        return sum(1 for ins in self.getInstructions() if ins.mnemonic == "call")
+            return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("invoke-"))
+        return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic == "call")
 
     @property
     def num_returns(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
-            return sum(1 for ins in self.getInstructions() if ins.mnemonic.startswith("return"))
-        return sum(1 for ins in self.getInstructions() if ins.mnemonic in ["ret", "retn"])
+            return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("return"))
+        return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic in ("ret", "retn"))
 
     def isApiThunk(self):
         if self.num_instructions != 1:

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -36,11 +36,13 @@ class SmdaFunction:
     function_name = ""
     pic_hash = None
     opc_hash = None
+    nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
+        self.nesting_depth = 0
         if disassembly is not None and function_offset is not None:
             self._escaper = IntelInstructionEscaper if disassembly.binary_info.architecture in ["intel"] else None
             self.offset = function_offset
@@ -72,14 +74,11 @@ class SmdaFunction:
             # DEX strings are part of the parsed file structure, so they're always
             # populated for Dalvik regardless of WITH_STRINGS — no extra extraction
             # cost. For other architectures, honor WITH_STRINGS as usual.
-            if (
-                config
-                and config.WITH_STRINGS
-                or (
-                    disassembly.binary_info.architecture == "dalvik"
-                    and disassembly.getStringRefsForFunction(function_offset)
-                )
-            ):
+            is_dalvik_with_strings = (
+                disassembly.binary_info.architecture == "dalvik"
+                and disassembly.getStringRefsForFunction(function_offset)
+            )
+            if (config and config.WITH_STRINGS) or is_dalvik_with_strings:
                 self.stringrefs = (
                     self._normalizeDalvikStringRefs(disassembly.getStringRefsForFunction(function_offset))
                     if disassembly.binary_info.architecture == "dalvik"
@@ -145,7 +144,7 @@ class SmdaFunction:
         return self.pic_hash
 
     def getPicHashAsHex(self):
-        return struct.pack("l", self.pic_hash).hex()
+        return struct.pack("Q", self.pic_hash).hex()
 
     def getInstructions(self):
         for block in self.getBlocks():

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -276,6 +276,19 @@ class SmdaFunction:
         return None
 
     def getNormalizedBlockRefs(self):
+        # Cache: SmdaFunction construction (__init__ and fromDict) and the
+        # subsequent _calculateSccs / _calculateNestingDepth helpers each
+        # invoke this method, producing the same dict every time because
+        # self.blocks / self.blockrefs / self.architecture_metadata are
+        # immutable after construction. Caching avoids 2-3 redundant
+        # normalization passes per function. The cache key is the identity
+        # of those inputs; if any of them is reassigned externally, callers
+        # must clear self._normalized_blockrefs_cache to force a rebuild.
+        cached = getattr(self, "_normalized_blockrefs_cache", None)
+        if cached is not None:
+            cache_key, cache_value = cached
+            if cache_key == (id(self.blocks), id(self.blockrefs), id(self.architecture_metadata)):
+                return cache_value
         current_blockrefs = self.blockrefs or {}
         normalized_blockrefs = {
             block_start: sorted(current_blockrefs.get(block_start, [])) for block_start in self.blocks
@@ -306,7 +319,12 @@ class SmdaFunction:
                     successors = set(normalized_blockrefs.get(block_start, []))
                     successors.update(normalized_targets)
                     normalized_blockrefs[block_start] = sorted(successors)
-        return {block_start: normalized_blockrefs[block_start] for block_start in sorted(normalized_blockrefs)}
+        result = {block_start: normalized_blockrefs[block_start] for block_start in sorted(normalized_blockrefs)}
+        self._normalized_blockrefs_cache = (
+            (id(self.blocks), id(self.blockrefs), id(self.architecture_metadata)),
+            result,
+        )
+        return result
 
     def toDotGraph(self, with_api=False):
         dot_graph = f'digraph "CFG for 0x{self.offset:x}" {{\n'

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -281,13 +281,22 @@ class SmdaFunction:
         # invoke this method, producing the same dict every time because
         # self.blocks / self.blockrefs / self.architecture_metadata are
         # immutable after construction. Caching avoids 2-3 redundant
-        # normalization passes per function. The cache key is the identity
-        # of those inputs; if any of them is reassigned externally, callers
-        # must clear self._normalized_blockrefs_cache to force a rebuild.
+        # normalization passes per function.
+        #
+        # Subtlety: __init__ does `self.blockrefs = self.getNormalizedBlockRefs()`
+        # right after the first call, so on the next call self.blockrefs is
+        # the previously cached *result*, not the original input. We accept
+        # a cache hit either when self.blockrefs still has the input id or
+        # when it has been reassigned to the cached value itself. Any other
+        # reassignment is treated as a cache miss and recomputes.
         cached = getattr(self, "_normalized_blockrefs_cache", None)
         if cached is not None:
             cache_key, cache_value = cached
-            if cache_key == (id(self.blocks), id(self.blockrefs), id(self.architecture_metadata)):
+            if (
+                cache_key[0] == id(self.blocks)
+                and cache_key[2] == id(self.architecture_metadata)
+                and (cache_key[1] == id(self.blockrefs) or id(cache_value) == id(self.blockrefs))
+            ):
                 return cache_value
         current_blockrefs = self.blockrefs or {}
         normalized_blockrefs = {

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -23,6 +23,7 @@ class SmdaFunction:
     apirefs = None
     stringrefs = None
     blockrefs = None
+    _blockrefs_reverse = None
     inrefs = None
     outrefs = None
     code_inrefs = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -6,6 +6,7 @@ import struct
 from typing import Iterator
 
 from smda.common.DominatorTree import build_dominator_tree, get_nesting_depth
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.Tarjan import Tarjan
 from smda.intel.IntelInstructionEscaper import IntelInstructionEscaper
@@ -181,8 +182,8 @@ class SmdaFunction:
                 tree = build_dominator_tree(normalized_blockrefs, root)
                 if tree:
                     nesting_depth = get_nesting_depth(normalized_blockrefs, tree, root)
-        except Exception:
-            pass
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
         return nesting_depth
 
     def getPicHash(self, binary_info):

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -144,7 +144,7 @@ class SmdaFunction:
         return self.pic_hash
 
     def getPicHashAsHex(self):
-        return struct.pack("Q", self.pic_hash).hex()
+        return struct.pack("<Q", self.pic_hash).hex()
 
     def getInstructions(self):
         for block in self.getBlocks():
@@ -186,7 +186,7 @@ class SmdaFunction:
         return nesting_depth
 
     def getPicHash(self, binary_info):
-        return struct.unpack("Q", hashlib.sha256(self.getPicHashSequence(binary_info)).digest()[:8])[0]
+        return struct.unpack("<Q", hashlib.sha256(self.getPicHashSequence(binary_info)).digest()[:8])[0]
 
     def getPicHashSequence(self, binary_info):
         escaped_binary_seqs = []
@@ -203,7 +203,7 @@ class SmdaFunction:
         return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
 
     def getOpcHash(self):
-        return struct.unpack("Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
+        return struct.unpack("<Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
 
     def getOpcHashSequence(self):
         escaped_binary_seqs = []

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -200,7 +200,7 @@ class SmdaFunction:
                         upper_addr=binary_info.base_addr + binary_info.binary_size,
                     )
                 )
-        return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+        return "".join(escaped_binary_seqs).encode("ascii")
 
     def getOpcHash(self):
         return struct.unpack("<Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
@@ -210,7 +210,7 @@ class SmdaFunction:
         for _, block in sorted(self.blocks.items()):
             for instruction in block:
                 escaped_binary_seqs.append(instruction.getEscapedToOpcodeOnly(self._escaper))
-        return bytes([ord(c) for c in "".join(escaped_binary_seqs)])
+        return "".join(escaped_binary_seqs).encode("ascii")
 
     def _parseBlocks(self, block_dict):
         self.blocks = {}

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -93,7 +93,7 @@ class SmdaFunction:
 
     @property
     def num_edges(self):
-        return sum([len(value) for key, value in self.blockrefs.items()])
+        return sum(len(value) for value in self.blockrefs.values())
 
     @property
     def num_inrefs(self):
@@ -101,7 +101,7 @@ class SmdaFunction:
 
     @property
     def num_outrefs(self):
-        return sum([len(dsts) for src, dsts in self.outrefs.items()])
+        return sum(len(dsts) for dsts in self.outrefs.values())
 
     @property
     def num_blocks(self):
@@ -109,21 +109,21 @@ class SmdaFunction:
 
     @property
     def num_instructions(self):
-        return sum([1 for ins in self.getInstructions()])
+        return sum(1 for _ in self.getInstructions())
 
     @property
     def num_calls(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
-            return sum([1 for ins in self.getInstructions() if ins.mnemonic.startswith("invoke-")])
-        return sum([1 for ins in self.getInstructions() if ins.mnemonic == "call"])
+            return sum(1 for ins in self.getInstructions() if ins.mnemonic.startswith("invoke-"))
+        return sum(1 for ins in self.getInstructions() if ins.mnemonic == "call")
 
     @property
     def num_returns(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
-            return sum([1 for ins in self.getInstructions() if ins.mnemonic.startswith("return")])
-        return sum([1 for ins in self.getInstructions() if ins.mnemonic in ["ret", "retn"]])
+            return sum(1 for ins in self.getInstructions() if ins.mnemonic.startswith("return"))
+        return sum(1 for ins in self.getInstructions() if ins.mnemonic in ["ret", "retn"])
 
     def isApiThunk(self):
         if self.num_instructions != 1:
@@ -217,7 +217,7 @@ class SmdaFunction:
         for offset, block in block_dict.items():
             instructions = [SmdaInstruction(ins, smda_function=self) for ins in block]
             self.blocks[int(offset)] = instructions
-            self.binweight += sum([len(ins.bytes) / 2 for ins in instructions])
+            self.binweight += sum(len(ins.bytes) / 2 for ins in instructions)
 
     @staticmethod
     def _normalizeDalvikStringRefs(stringrefs):

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -75,7 +75,7 @@ class SmdaInstruction:
             # WAIT instruction before the wait version and the NOP instruction
             # before the no-wait version.
             if len(with_details) > 1:
-                LOGGER.warn(
+                LOGGER.warning(
                     f"Sequence {self.bytes} disassembles to {len(with_details)} instructions but expected one - taking the last instruction only!"
                 )
                 self.detailed = with_details[-1]

--- a/src/smda/common/TailcallAnalyzer.py
+++ b/src/smda/common/TailcallAnalyzer.py
@@ -1,9 +1,12 @@
 import bisect
 import json
+import logging
 from collections import defaultdict
 from operator import itemgetter
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TailcallAnalyzer:
@@ -87,15 +90,15 @@ class TailcallAnalyzer:
         # return
         if len(intervals) < 25:
             for one, two in intervals:
-                print(f"  0x{one:x} -> 0x{two:x}")
+                LOGGER.debug("  0x%x -> 0x%x", one, two)
         else:
-            print("Function has too many intervals to display")
+            LOGGER.debug("Function has too many intervals to display")
 
     def resolveTailcalls(self, disassembler, verbose=False):
         newly_created_functions = set()
         for tailcall in self.getTailcalls():
             if verbose:
-                print(f"Processing tailcall:\n{json.dumps(tailcall, indent=2, sort_keys=True)}")
+                LOGGER.debug("Processing tailcall:\n%s", json.dumps(tailcall, indent=2, sort_keys=True))
             # remove the information from the function-analysis state of the disassembly
             function = self.__getFunctionByStartAddr(tailcall["destination_function"])
             if not function or function.is_tailcall_function:
@@ -105,7 +108,7 @@ class TailcallAnalyzer:
             self.__functions.remove(function)
             if function:
                 if verbose:
-                    print("Old function:")
+                    LOGGER.debug("Old function:")
                     self.__printIntervals(self.__getFunctionIntervals(function))
                 function.revertAnalysis()
 
@@ -123,7 +126,7 @@ class TailcallAnalyzer:
                     reraise_non_operational_exception(exc)
                     # print ("0x{:x} -> 0x{:x}".format(tailcall["destination_function"], tailcall["destination_addr"]))
             elif verbose:
-                print(
+                LOGGER.debug(
                     "**** 0x{:x} IS NOW PART OF 0x{:x}".format(
                         tailcall["destination_function"], tailcall["destination_addr"]
                     )
@@ -132,10 +135,10 @@ class TailcallAnalyzer:
             if verbose:
                 function = self.__getFunctionByStartAddr(tailcall["destination_function"])
                 new_function = self.__getFunctionByStartAddr(tailcall["destination_addr"])
-                print("New function:")
+                LOGGER.debug("New function:")
                 if new_function:
                     self.__printIntervals(self.__getFunctionIntervals(new_function))
-                print("Re-disassembled old function:")
+                LOGGER.debug("Re-disassembled old function:")
                 if function:
                     self.__printIntervals(self.__getFunctionIntervals(function))
         return sorted(newly_created_functions)

--- a/src/smda/common/TailcallAnalyzer.py
+++ b/src/smda/common/TailcallAnalyzer.py
@@ -3,6 +3,8 @@ import json
 from collections import defaultdict
 from operator import itemgetter
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 
 class TailcallAnalyzer:
     def __init__(self):
@@ -117,8 +119,8 @@ class TailcallAnalyzer:
                     disassembler.analyzeFunction(tailcall["destination_function"])
                     function = self.__getFunctionByStartAddr(tailcall["destination_function"])
                     function.is_tailcall_function = True
-                except Exception:
-                    pass
+                except Exception as exc:
+                    reraise_non_operational_exception(exc)
                     # print ("0x{:x} -> 0x{:x}".format(tailcall["destination_function"], tailcall["destination_addr"]))
             elif verbose:
                 print(

--- a/src/smda/common/labelprovider/AbstractLabelProvider.py
+++ b/src/smda/common/labelprovider/AbstractLabelProvider.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 LOGGER = logging.getLogger(__name__)
 
 
-class AbstractLabelProvider:
+class AbstractLabelProvider(ABC):
     def __init__(self, config):
-        raise NotImplementedError
+        self._config = config
 
     @abstractmethod
     def update(self, binary_info):
@@ -16,7 +16,7 @@ class AbstractLabelProvider:
         raise NotImplementedError
 
     @abstractmethod
-    def getApi(self, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return None"""
         raise NotImplementedError
 

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -34,6 +34,8 @@ class CilSymbolProvider(AbstractLabelProvider):
         return value.encode("utf-8").decode("utf-8")
 
     def update(self, binary_info):
+        self._addr_to_func_symbols = {}
+        self._func_symbol_to_addr = {}
         try:
             pe = dnfile.dnPE(data=binary_info.raw_data)
         except Exception as exc:

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -4,6 +4,8 @@ import logging
 
 import dnfile
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 
 LOGGER = logging.getLogger(__name__)
@@ -21,13 +23,29 @@ class CilSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def decodeSymbolName(self, value):
         """ensure a proper utf-8 escaped string"""
         return value.encode("utf-8").decode("utf-8")
 
     def update(self, binary_info):
-        pe = dnfile.dnPE(data=binary_info.raw_data)
-        for row in pe.net.mdtables.MethodDef:
+        try:
+            pe = dnfile.dnPE(data=binary_info.raw_data)
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
+            LOGGER.debug("Failed to parse CIL symbols: %s", exc)
+            return
+        if not getattr(pe, "net", None) or not getattr(pe.net, "mdtables", None):
+            return
+        method_defs = getattr(pe.net.mdtables, "MethodDef", None)
+        if not method_defs:
+            return
+        for row in method_defs:
             addr = pe.get_offset_from_rva(row.Rva)
             func_name = self.decodeSymbolName(row.Name.value)
             self._addr_to_func_symbols[addr] = func_name

--- a/src/smda/common/labelprovider/DelphiKbSymbolProvider.py
+++ b/src/smda/common/labelprovider/DelphiKbSymbolProvider.py
@@ -28,6 +28,12 @@ class DelphiKbSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")
 
@@ -58,8 +64,14 @@ class DelphiKbSymbolProvider(AbstractLabelProvider):
         temp_off = fh.tell()
         for modID in modules:
             fh.seek(modules[modID]["offset"])
-            if modID != int.from_bytes(fh.read(2), byteorder="little"):
-                print("ModID doesnt match" + str(modules[modID]["offset"]))
+            actual_mod_id = int.from_bytes(fh.read(2), byteorder="little")
+            if modID != actual_mod_id:
+                LOGGER.warning(
+                    "ModID mismatch at offset 0x%x: expected %d, got %d",
+                    modules[modID]["offset"],
+                    modID,
+                    actual_mod_id,
+                )
             len_name = int.from_bytes(fh.read(2), byteorder="little")
             modules[modID]["name"] = fh.read(len_name).decode()
             modules[modID]["functions"] = []

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -476,7 +476,7 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def isApiProvider(self):
         return False
 
-    def getApi(self, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         return None
 
     def getSymbol(self, address):

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -16,6 +16,8 @@ import struct
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 
 LOGGER = logging.getLogger(__name__)
@@ -279,6 +281,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             else:
                 LOGGER.debug("No Delphi symbols extracted")
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.warning(f"Error during DelphiReSym parsing: {e}")
 
     def _is_compatible(self):
@@ -475,6 +478,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             return object_name
 
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.debug(f"Error traversing RTTI object at 0x{rtti_offset:x}: {e}")
             return None
 
@@ -508,6 +512,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             return self._traverse_rtti_object(rtti_offset, validate_pointers=False)
 
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.debug(f"Error resolving type from double ptr at 0x{ptr_field_offset:x}: {e}")
             return None
 
@@ -557,6 +562,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             return method_info
 
         except Exception as e:
+            reraise_non_operational_exception(e)
             LOGGER.debug(f"Error extracting method info at 0x{method_entry_offset:x}: {e}")
             return None
 

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -686,7 +686,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def isApiProvider(self):
         return False
 
-    def getApi(self, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         return None
 
     def getSymbol(self, address):

--- a/src/smda/common/labelprovider/ElfApiResolver.py
+++ b/src/smda/common/labelprovider/ElfApiResolver.py
@@ -50,7 +50,16 @@ class ElfApiResolver(AbstractLabelProvider):
         """Returns whether the get_api(..) function of the AbstractLabelProvider is functional"""
         return True
 
-    def getApi(self, to_addr, absolute_addr):
+    def isSymbolProvider(self):
+        return False
+
+    def getSymbol(self, address):
+        return ""
+
+    def getFunctionSymbols(self):
+        return {}
+
+    def getApi(self, to_addr, absolute_addr=None):
         """
         If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None).
 

--- a/src/smda/common/labelprovider/ElfApiResolver.py
+++ b/src/smda/common/labelprovider/ElfApiResolver.py
@@ -66,5 +66,7 @@ class ElfApiResolver(AbstractLabelProvider):
         May return None for the `dll` if it cannot be determined.
         When it can be determined for ELF files, the `dll` field should be interpreted as the API version rather than shared library name.
         For example: "GLIBC_2.2.5".
+        `absolute_addr` is part of the label-provider API but intentionally unused here:
+        ELF lookups are keyed by relocation slot address (`to_addr`) in `_api_map["lief"]`.
         """
         return self._api_map["lief"].get(to_addr, (None, None))

--- a/src/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/src/smda/common/labelprovider/ElfSymbolProvider.py
@@ -21,6 +21,12 @@ class ElfSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def _parseOep(self, lief_result):
         if lief_result:
             self._func_symbols[lief_result.header.entrypoint] = "original_entry_point"

--- a/src/smda/common/labelprovider/GoLabelProvider.py
+++ b/src/smda/common/labelprovider/GoLabelProvider.py
@@ -26,13 +26,20 @@ class GoSymbolProvider(AbstractLabelProvider):
         pclntab_offset = None
         try:
             lief_binary = lief.parse(binary)
-            if lief_binary.format == lief.EXE_FORMATS.ELF:
-                pclntab_offset = lief_binary.get_section(".gopclntab").offset
-            elif lief_binary.format == lief.EXE_FORMATS.MACHO:
-                pclntab_offset = lief_binary.get_section("__gopclntab").offset
-            elif lief_binary.format == lief.EXE_FORMATS.PE:
-                rdata_offset = lief_binary.get_section(".rdata").offset
-                pclntab_offset = rdata_offset + lief_binary.get_symbol("runtime.pclntab").value
+            if lief_binary is not None:
+                if lief_binary.format == lief.EXE_FORMATS.ELF:
+                    section = lief_binary.get_section(".gopclntab")
+                    if section is not None:
+                        pclntab_offset = section.offset
+                elif lief_binary.format == lief.EXE_FORMATS.MACHO:
+                    section = lief_binary.get_section("__gopclntab")
+                    if section is not None:
+                        pclntab_offset = section.offset
+                elif lief_binary.format == lief.EXE_FORMATS.PE:
+                    section = lief_binary.get_section(".rdata")
+                    symbol = lief_binary.get_symbol("runtime.pclntab")
+                    if section is not None and symbol is not None:
+                        pclntab_offset = section.offset + symbol.value
         except Exception as exc:
             reraise_non_operational_exception(exc)
         if pclntab_offset is None:
@@ -41,13 +48,13 @@ class GoSymbolProvider(AbstractLabelProvider):
             hits = [match.start() for match in re.finditer(pclntab_regex, binary)]
             if len(hits) == 1:
                 pclntab_offset = hits[0]
-        return pclntab_offset is not None
+        return pclntab_offset
 
     def update(self, binary_info):
         binary = binary_info.binary
         pclntab_offset = self.getPcLntabOffset(binary)
         # if we found a valid offset, do the pclntab parsing
-        if pclntab_offset:
+        if pclntab_offset is not None:
             try:
                 result = self._parse_pclntab(pclntab_offset, binary)
                 if result:
@@ -58,6 +65,12 @@ class GoSymbolProvider(AbstractLabelProvider):
 
     def isSymbolProvider(self):
         return True
+
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
 
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")
@@ -111,7 +124,6 @@ class GoSymbolProvider(AbstractLabelProvider):
             parsed_pclntab_fields = struct.unpack(7 * field_indicator, pclntab_buffer[8 : 8 + 7 * field_size])
             number_of_functions = parsed_pclntab_fields[0]
             function_name_offset = pclntab_offset + parsed_pclntab_fields[2]
-            pclntab_offset + parsed_pclntab_fields[3]
             weird_table_offset = pclntab_offset + parsed_pclntab_fields[6]
             start_text = 0
         elif version == "1.18" or version == "1.20":
@@ -119,7 +131,6 @@ class GoSymbolProvider(AbstractLabelProvider):
             number_of_functions = parsed_pclntab_fields[0]
             start_text = parsed_pclntab_fields[2]
             function_name_offset = pclntab_offset + parsed_pclntab_fields[3]
-            pclntab_offset + parsed_pclntab_fields[5]
             weird_table_offset = pclntab_offset + parsed_pclntab_fields[7]
 
         # first parse function offsets

--- a/src/smda/common/labelprovider/GoLabelProvider.py
+++ b/src/smda/common/labelprovider/GoLabelProvider.py
@@ -6,6 +6,8 @@ from collections import OrderedDict
 
 import lief
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 
 lief.logging.disable()
@@ -31,8 +33,8 @@ class GoSymbolProvider(AbstractLabelProvider):
             elif lief_binary.format == lief.EXE_FORMATS.PE:
                 rdata_offset = lief_binary.get_section(".rdata").offset
                 pclntab_offset = rdata_offset + lief_binary.get_symbol("runtime.pclntab").value
-        except Exception:
-            pass
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
         if pclntab_offset is None:
             # scan for offset of structure
             pclntab_regex = re.compile(b".\xff\xff\xff\x00\x00\x01(\x04|\x08)")
@@ -50,7 +52,8 @@ class GoSymbolProvider(AbstractLabelProvider):
                 result = self._parse_pclntab(pclntab_offset, binary)
                 if result:
                     self._func_symbols = result
-            except Exception:
+            except Exception as exc:
+                reraise_non_operational_exception(exc)
                 return
 
     def isSymbolProvider(self):

--- a/src/smda/common/labelprovider/PdbSymbolProvider.py
+++ b/src/smda/common/labelprovider/PdbSymbolProvider.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.utility.PeFileLoader import PeFileLoader
 
 from .AbstractLabelProvider import AbstractLabelProvider
@@ -54,6 +55,7 @@ class PdbSymbolProvider(AbstractLabelProvider):
             pdb = pdbparse.parse(binary_info.file_path)
             self._parseSymbols(pdb)
         except Exception as exc:
+            reraise_non_operational_exception(exc)
             LOGGER.error(
                 'Failed parsing "%s" with exception type: %s',
                 binary_info.file_path,

--- a/src/smda/common/labelprovider/PdbSymbolProvider.py
+++ b/src/smda/common/labelprovider/PdbSymbolProvider.py
@@ -36,6 +36,12 @@ class PdbSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def _parseOep(self, data):
         oep_rva = PeFileLoader.getOEP(data)
         if oep_rva:

--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -24,6 +24,12 @@ class PeSymbolProvider(AbstractLabelProvider):
     def isSymbolProvider(self):
         return True
 
+    def isApiProvider(self):
+        return False
+
+    def getApi(self, to_addr, absolute_addr=None):
+        return ("", "")
+
     def _parseOep(self, lief_result):
         if lief_result:
             self._func_symbols[lief_result.entrypoint] = "original_entry_point"
@@ -61,7 +67,7 @@ class PeSymbolProvider(AbstractLabelProvider):
                 code_base_address = lief_binary.imagebase + section.virtual_address
                 break
         if code_base_address is None:
-            return
+            return function_symbols
         for symbol in lief_binary.symbols:
             if hasattr(symbol.complex_type, "name") and symbol.complex_type.name == "FUNCTION":
                 function_name = ""

--- a/src/smda/common/labelprovider/RustSymbolProvider.py
+++ b/src/smda/common/labelprovider/RustSymbolProvider.py
@@ -4,6 +4,8 @@ import logging
 
 import lief
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+
 from .AbstractLabelProvider import AbstractLabelProvider
 from .rust_demangler import demangle
 from .rust_demangler.rust import TypeNotFoundError
@@ -40,6 +42,7 @@ class RustSymbolProvider(AbstractLabelProvider):
         try:
             lief_binary = binary_info.getLiefBinary()
         except Exception as exc:
+            reraise_non_operational_exception(exc)
             LOGGER.debug("Failed to parse binary with LIEF: %s", type(exc).__name__)
             return
 

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -91,7 +91,7 @@ class WinApiResolver(AbstractLabelProvider):
         """Returns whether the get_api(..) function of the AbstractLabelProvider is functional"""
         return True
 
-    def getApi(self, to_addr, absolute_addr):
+    def getApi(self, to_addr, absolute_addr=None):
         """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None)"""
         # if we work on a dump, use ApiScout method:
         if self._is_buffer:
@@ -102,3 +102,12 @@ class WinApiResolver(AbstractLabelProvider):
         # otherwise take import table info from LIEF
         else:
             return self._api_map["lief"].get(to_addr, (None, None))
+
+    def isSymbolProvider(self):
+        return False
+
+    def getSymbol(self, address):
+        return ""
+
+    def getFunctionSymbols(self):
+        return {}

--- a/src/smda/common/labelprovider/rust_demangler/rust_legacy.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_legacy.py
@@ -17,7 +17,10 @@ class LegacyDemangler:
     def demangle(self, inpstr: str) -> str:
         self.elements = 0
 
+        original_inpstr = inpstr
         disp = ""
+        if "N" not in inpstr:
+            raise UnableToLegacyDemangle(original_inpstr)
         inpstr = inpstr[inpstr.index("N") + 1 :]
         self.sanity_check(inpstr)
 
@@ -26,7 +29,7 @@ class LegacyDemangler:
             candidate = inpstr[length + 6 :]
             for i in candidate:
                 if i not in string.hexdigits + "@":
-                    raise UnableToLegacyDemangle(inpstr)
+                    raise UnableToLegacyDemangle(original_inpstr)
             inpstr = inpstr[:length]
 
         inn = inpstr
@@ -69,25 +72,34 @@ class LegacyDemangler:
 
                 elif rest.startswith("$"):
                     end = rest[1:].find("$")
+                    if end == -1:
+                        raise UnableToLegacyDemangle(original_inpstr)
                     escape = rest[1 : end + 1]
                     after_escape = rest[end + 2 :]
+                    if not escape:
+                        raise UnableToLegacyDemangle(original_inpstr)
 
                     if escape.startswith("u"):
                         digits = escape[1:]
+                        if not digits:
+                            raise UnableToLegacyDemangle(original_inpstr)
 
                         for i in digits:
                             if i not in string.hexdigits:
-                                raise UnableToLegacyDemangle(inpstr)
+                                raise UnableToLegacyDemangle(original_inpstr)
 
-                        c = int(digits, 16)
-                        disp += chr(c)
+                        try:
+                            c = int(digits, 16)
+                            disp += chr(c)
+                        except (OverflowError, ValueError):
+                            raise UnableToLegacyDemangle(original_inpstr) from None
 
                         rest = after_escape
                         continue
 
                     else:
                         if escape not in self._UNESCAPED:
-                            raise UnableToLegacyDemangle(inpstr)
+                            raise UnableToLegacyDemangle(original_inpstr)
                         disp += self._UNESCAPED[escape]
                         rest = after_escape
                         continue
@@ -95,11 +107,6 @@ class LegacyDemangler:
                 elif ("$") in rest:
                     dollar = rest.find("$")
                     dot = rest.find(".")
-
-                    if dollar == -1:
-                        disp += rest[:dot]
-                        rest = rest[dot:]
-                        continue
 
                     if dot == -1:
                         disp += rest[:dollar]

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -23,6 +23,8 @@ class V0Demangler:
         self.suffix = ""
         self.disp = ""
 
+        if "R" not in inpstr:
+            raise UnableTov0Demangle(inpstr)
         self.inpstr = inpstr[inpstr.index("R") + 1 :]
         self.sanity_check(self.inpstr)
 
@@ -735,17 +737,24 @@ class Printer:
             self.recursion -= 1
 
     def print_path_maybe_open_generics(self):
-        if self.eat("B"):
-            return self.backref_printer().print_path_maybe_open_generics()
+        self.check_recursion_limit()
+        try:
+            if self.eat("B"):
+                prin = self.backref_printer()
+                result = prin.print_path_maybe_open_generics()
+                self.out = prin.out
+                return result
 
-        elif self.eat("I"):
-            self.print_path(False)
-            self.out += "<"
-            self.print_sep_list("print_generic_arg", ", ")
-            return True
-        else:
-            self.print_path(False)
-            return False
+            elif self.eat("I"):
+                self.print_path(False)
+                self.out += "<"
+                self.print_sep_list("print_generic_arg", ", ")
+                return True
+            else:
+                self.print_path(False)
+                return False
+        finally:
+            self.recursion -= 1
 
     def print_dyn_trait(self):
         open = self.print_path_maybe_open_generics()
@@ -828,5 +837,8 @@ class Printer:
 
         char_val = "0x"
         char_val += hex_val
-        c = chr(int(char_val, 16))
+        try:
+            c = chr(int(char_val, 16))
+        except (OverflowError, ValueError):
+            self.invalid()
         self.out += repr(c)

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -5,6 +5,7 @@ import struct
 
 import lief
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.dalvik.DalvikFunctionAnalysisState import DalvikFunctionAnalysisState
 from smda.dalvik.DalvikOpcodeDecoder import (
     decode_instruction,
@@ -86,7 +87,8 @@ class DexReferenceResolver:
     def _safeAttr(self, obj, attr, default=None):
         try:
             return getattr(obj, attr)
-        except Exception:
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
             return default
 
     def _normalizeTypeString(self, type_name):
@@ -952,6 +954,7 @@ class DalvikDisassembler:
                 self.analyzeFunction(dex_file, resolver, method)
                 analyzed_count += 1
             except Exception as exc:
+                reraise_non_operational_exception(exc)
                 LOGGER.warning(
                     "Failed to analyze Dalvik method %s @0x%x: %s",
                     resolver.formatMethod(method),

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -108,11 +108,21 @@ def _register_range(start, names, fmt, size_units, **kwargs):
 
 
 def _mark_can_throw(*mnemonics):
-    remaining = set(mnemonics)
-    for opcode, spec in list(OPCODES.items()):
-        if spec.mnemonic in remaining:
+    """
+    Mark all opcodes matching the given mnemonics as can_throw=True.
+
+    Args:
+        *mnemonics: Variable length list of mnemonics to mark as throwable.
+    Raises:
+        ValueError: If any mnemonic is not found in OPCODES.
+    """
+    to_mark = set(mnemonics)
+    matched = set()
+    for opcode, spec in OPCODES.items():
+        if spec.mnemonic in to_mark:
             OPCODES[opcode] = replace(spec, can_throw=True)
-            remaining.remove(spec.mnemonic)
+            matched.add(spec.mnemonic)
+    remaining = to_mark - matched
     if remaining:
         raise ValueError(f"Unknown Dalvik throwable opcodes: {', '.join(sorted(remaining))}")
 

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -444,46 +444,18 @@ FORMAT_DECODERS = {}
 
 
 def _decode_fmt_10x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
-    return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
-    }
+    return {}
 
 
 FORMAT_DECODERS["10x"] = _decode_fmt_10x
 
 
 def _decode_fmt_10t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     branch_delta = int.from_bytes(raw_bytes[1:2], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    operands = f"{hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "operands": f"{hex(branch_target_idx)}",
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
     }
 
 
@@ -491,25 +463,12 @@ FORMAT_DECODERS["10t"] = _decode_fmt_10t
 
 
 def _decode_fmt_11n(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     literal = _signed((raw_bytes[1] >> 4) & 0x0F, 4)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{literal:+d}",
     }
 
 
@@ -517,24 +476,10 @@ FORMAT_DECODERS["11n"] = _decode_fmt_11n
 
 
 def _decode_fmt_11x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
-    registers = [reg_a]
-    operands = _reg_name(reg_a)
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a],
+        "operands": _reg_name(reg_a),
     }
 
 
@@ -542,25 +487,11 @@ FORMAT_DECODERS["11x"] = _decode_fmt_11x
 
 
 def _decode_fmt_12x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}",
     }
 
 
@@ -568,24 +499,11 @@ FORMAT_DECODERS["12x"] = _decode_fmt_12x
 
 
 def _decode_fmt_20t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    operands = f"{hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "operands": f"{hex(branch_target_idx)}",
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
     }
 
 
@@ -593,25 +511,12 @@ FORMAT_DECODERS["20t"] = _decode_fmt_20t
 
 
 def _decode_fmt_21c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
+        "registers": [reg_a],
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -619,13 +524,6 @@ FORMAT_DECODERS["21c"] = _decode_fmt_21c
 
 
 def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     # The 16-bit immediate is sign-extended per the Dalvik spec before shifting.
     # Using signed=True ensures negative values like 0xFFFF produce -1 << shift
@@ -633,17 +531,10 @@ def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
     value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
     shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
     literal = value << shift
-    registers = [reg_a]
-    sign = "-" if literal < 0 else ""
-    operands = f"{_reg_name(reg_a)}, #{sign}{hex(abs(literal))}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{hex(literal)}",
     }
 
 
@@ -651,25 +542,12 @@ FORMAT_DECODERS["21h"] = _decode_fmt_21h
 
 
 def _decode_fmt_21s(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{literal:+d}",
     }
 
 
@@ -677,26 +555,13 @@ FORMAT_DECODERS["21s"] = _decode_fmt_21s
 
 
 def _decode_fmt_21t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, {hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "registers": [reg_a],
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {hex(branch_target_idx)}",
     }
 
 
@@ -704,26 +569,13 @@ FORMAT_DECODERS["21t"] = _decode_fmt_21t
 
 
 def _decode_fmt_22b(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     reg_b = raw_bytes[2]
     literal = int.from_bytes(raw_bytes[3:4], byteorder="little", signed=True)
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a, reg_b],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}",
     }
 
 
@@ -731,26 +583,13 @@ FORMAT_DECODERS["22b"] = _decode_fmt_22b
 
 
 def _decode_fmt_22c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
+        "registers": [reg_a, reg_b],
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -758,26 +597,13 @@ FORMAT_DECODERS["22c"] = _decode_fmt_22c
 
 
 def _decode_fmt_22s(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
     literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a, reg_b],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}",
     }
 
 
@@ -785,27 +611,14 @@ FORMAT_DECODERS["22s"] = _decode_fmt_22s
 
 
 def _decode_fmt_22t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1] & 0x0F
     reg_b = (raw_bytes[1] >> 4) & 0x0F
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "registers": [reg_a, reg_b],
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}",
     }
 
 
@@ -813,25 +626,11 @@ FORMAT_DECODERS["22t"] = _decode_fmt_22t
 
 
 def _decode_fmt_22x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     reg_b = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}",
     }
 
 
@@ -839,26 +638,12 @@ FORMAT_DECODERS["22x"] = _decode_fmt_22x
 
 
 def _decode_fmt_23x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     reg_b = raw_bytes[2]
     reg_c = raw_bytes[3]
-    registers = [reg_a, reg_b, reg_c]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b, reg_c],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}",
     }
 
 
@@ -866,24 +651,11 @@ FORMAT_DECODERS["23x"] = _decode_fmt_23x
 
 
 def _decode_fmt_30t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
-    operands = f"{hex(branch_target_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
+        "operands": f"{hex(branch_target_idx)}",
         "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
     }
 
 
@@ -891,25 +663,12 @@ FORMAT_DECODERS["30t"] = _decode_fmt_30t
 
 
 def _decode_fmt_31c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:6], byteorder="little")
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
+        "registers": [reg_a],
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -917,25 +676,12 @@ FORMAT_DECODERS["31c"] = _decode_fmt_31c
 
 
 def _decode_fmt_31i(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     literal = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{literal:+d}",
     }
 
 
@@ -943,26 +689,13 @@ FORMAT_DECODERS["31i"] = _decode_fmt_31i
 
 
 def _decode_fmt_31t(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
     payload_idx = byte_idx + branch_delta
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
+        "registers": [reg_a],
         "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}",
     }
 
 
@@ -970,25 +703,11 @@ FORMAT_DECODERS["31t"] = _decode_fmt_31t
 
 
 def _decode_fmt_32x(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = int.from_bytes(raw_bytes[2:4], byteorder="little")
     reg_b = int.from_bytes(raw_bytes[4:6], byteorder="little")
-    registers = [reg_a, reg_b]
-    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
-        "registers": registers,
-        "operands": operands,
-        "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "registers": [reg_a, reg_b],
+        "operands": f"{_reg_name(reg_a)}, {_reg_name(reg_b)}",
     }
 
 
@@ -996,24 +715,12 @@ FORMAT_DECODERS["32x"] = _decode_fmt_32x
 
 
 def _decode_fmt_35c(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     _, registers = _decode_register_list_35c(raw_bytes)
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -1021,26 +728,14 @@ FORMAT_DECODERS["35c"] = _decode_fmt_35c
 
 
 def _decode_fmt_3rc(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     count = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
     registers = _decode_register_range(count, first_reg)
-    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}",
     }
 
 
@@ -1048,29 +743,18 @@ FORMAT_DECODERS["3rc"] = _decode_fmt_3rc
 
 
 def _decode_fmt_45cc(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     _, registers = _decode_register_list_35c(raw_bytes[:6])
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-    operands = (
-        f"{{{_format_registers(registers)}}}, "
-        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
-        f"{resolve_ref('proto', ref_index_aux)}"
-    )
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
         "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": (
+            f"{{{_format_registers(registers)}}}, "
+            f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+            f"{resolve_ref('proto', ref_index_aux)}"
+        ),
     }
 
 
@@ -1078,31 +762,20 @@ FORMAT_DECODERS["45cc"] = _decode_fmt_45cc
 
 
 def _decode_fmt_4rcc(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     count = raw_bytes[1]
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
     registers = _decode_register_range(count, first_reg)
-    operands = (
-        f"{{{_format_registers(registers)}}}, "
-        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
-        f"{resolve_ref('proto', ref_index_aux)}"
-    )
     return {
         "registers": registers,
-        "operands": operands,
-        "literal": literal,
         "ref_index": ref_index,
         "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": (
+            f"{{{_format_registers(registers)}}}, "
+            f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+            f"{resolve_ref('proto', ref_index_aux)}"
+        ),
     }
 
 
@@ -1110,25 +783,12 @@ FORMAT_DECODERS["4rcc"] = _decode_fmt_4rcc
 
 
 def _decode_fmt_51l(raw_bytes, byte_idx, opcode, resolve_ref):
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
     reg_a = raw_bytes[1]
     literal = int.from_bytes(raw_bytes[2:10], byteorder="little", signed=True)
-    registers = [reg_a]
-    operands = f"{_reg_name(reg_a)}, #{hex(literal)}"
     return {
-        "registers": registers,
-        "operands": operands,
+        "registers": [reg_a],
         "literal": literal,
-        "ref_index": ref_index,
-        "ref_index_aux": ref_index_aux,
-        "branch_target_idx": branch_target_idx,
-        "payload_idx": payload_idx,
+        "operands": f"{_reg_name(reg_a)}, #{hex(literal)}",
     }
 
 
@@ -1160,14 +820,14 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
         size_units=opcode.size_units,
         size_bytes=size_bytes,
         bytes_=raw_bytes,
-        operands=result["operands"],
-        registers=result["registers"],
-        literal=result["literal"],
+        operands=result.get("operands", ""),
+        registers=result.get("registers", []),
+        literal=result.get("literal"),
         ref_kind=opcode.ref_kind,
-        ref_index=result["ref_index"],
-        ref_index_aux=result["ref_index_aux"],
-        branch_target_idx=result["branch_target_idx"],
-        payload_idx=result["payload_idx"],
+        ref_index=result.get("ref_index"),
+        ref_index_aux=result.get("ref_index_aux"),
+        branch_target_idx=result.get("branch_target_idx"),
+        payload_idx=result.get("payload_idx"),
         is_invoke=opcode.is_invoke,
         is_terminator=opcode.is_terminator,
         is_conditional=opcode.is_conditional,

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -451,7 +451,6 @@ def _decode_fmt_10x(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    operands = ""
     return {
         "registers": registers,
         "operands": operands,
@@ -499,8 +498,8 @@ def _decode_fmt_11n(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    literal = _signed(raw_bytes[1] >> 4 & 15, 4)
+    reg_a = raw_bytes[1] & 0x0F
+    literal = _signed((raw_bytes[1] >> 4) & 0x0F, 4)
     registers = [reg_a]
     operands = f"{_reg_name(reg_a)}, #{literal:+d}"
     return {
@@ -550,8 +549,8 @@ def _decode_fmt_12x(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     registers = [reg_a, reg_b]
     operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
     return {
@@ -628,6 +627,9 @@ def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
     branch_target_idx = None
     payload_idx = None
     reg_a = raw_bytes[1]
+    # The 16-bit immediate is sign-extended per the Dalvik spec before shifting.
+    # Using signed=True ensures negative values like 0xFFFF produce -1 << shift
+    # rather than 0xFFFF << shift, matching baksmali's output.
     value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
     shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
     literal = value << shift
@@ -736,8 +738,8 @@ def _decode_fmt_22c(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     registers = [reg_a, reg_b]
     operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
@@ -763,8 +765,8 @@ def _decode_fmt_22s(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
     registers = [reg_a, reg_b]
     operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
@@ -790,8 +792,8 @@ def _decode_fmt_22t(raw_bytes, byte_idx, opcode, resolve_ref):
     ref_index_aux = None
     branch_target_idx = None
     payload_idx = None
-    reg_a = raw_bytes[1] & 15
-    reg_b = raw_bytes[1] >> 4 & 15
+    reg_a = raw_bytes[1] & 0x0F
+    reg_b = (raw_bytes[1] >> 4) & 0x0F
     branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
     branch_target_idx = byte_idx + branch_delta
     registers = [reg_a, reg_b]
@@ -1056,8 +1058,10 @@ def _decode_fmt_45cc(raw_bytes, byte_idx, opcode, resolve_ref):
     _, registers = _decode_register_list_35c(raw_bytes[:6])
     ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-    operands = "{{{}}}, {}, {}".format(
-        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    operands = (
+        f"{{{_format_registers(registers)}}}, "
+        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+        f"{resolve_ref('proto', ref_index_aux)}"
     )
     return {
         "registers": registers,
@@ -1086,8 +1090,10 @@ def _decode_fmt_4rcc(raw_bytes, byte_idx, opcode, resolve_ref):
     first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
     ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
     registers = _decode_register_range(count, first_reg)
-    operands = "{{{}}}, {}, {}".format(
-        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    operands = (
+        f"{{{_format_registers(registers)}}}, "
+        f"{resolve_ref(opcode.ref_kind, ref_index)}, "
+        f"{resolve_ref('proto', ref_index_aux)}"
     )
     return {
         "registers": registers,
@@ -1140,27 +1146,12 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
         raise ValueError("Truncated Dalvik instruction")
 
     raw_bytes = bytes(bytecode[byte_idx : byte_idx + size_bytes])
-    registers = []
-    operands = ""
-    literal = None
-    ref_index = None
-    ref_index_aux = None
-    branch_target_idx = None
-    payload_idx = None
 
-    if opcode.fmt not in FORMAT_DECODERS:
+    decoder = FORMAT_DECODERS.get(opcode.fmt)
+    if decoder is None:
         raise ValueError(f"Unsupported Dalvik format {opcode.fmt}")
 
-    decoder = FORMAT_DECODERS[opcode.fmt]
     result = decoder(raw_bytes, byte_idx, opcode, resolve_ref)
-
-    registers = result["registers"]
-    operands = result["operands"]
-    literal = result["literal"]
-    ref_index = result["ref_index"]
-    ref_index_aux = result["ref_index_aux"]
-    branch_target_idx = result["branch_target_idx"]
-    payload_idx = result["payload_idx"]
 
     return DecodedDalvikInstruction(
         opcode=opcode_value,
@@ -1169,14 +1160,14 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
         size_units=opcode.size_units,
         size_bytes=size_bytes,
         bytes_=raw_bytes,
-        operands=operands,
-        registers=registers,
-        literal=literal,
+        operands=result["operands"],
+        registers=result["registers"],
+        literal=result["literal"],
         ref_kind=opcode.ref_kind,
-        ref_index=ref_index,
-        ref_index_aux=ref_index_aux,
-        branch_target_idx=branch_target_idx,
-        payload_idx=payload_idx,
+        ref_index=result["ref_index"],
+        ref_index_aux=result["ref_index_aux"],
+        branch_target_idx=result["branch_target_idx"],
+        payload_idx=result["payload_idx"],
         is_invoke=opcode.is_invoke,
         is_terminator=opcode.is_terminator,
         is_conditional=opcode.is_conditional,

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -1,5 +1,5 @@
 import struct
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional
 
 
@@ -105,6 +105,16 @@ def _register(opcode, mnemonic, fmt, size_units, **kwargs):
 def _register_range(start, names, fmt, size_units, **kwargs):
     for index, mnemonic in enumerate(names):
         _register(start + index, mnemonic, fmt, size_units, **kwargs)
+
+
+def _mark_can_throw(*mnemonics):
+    remaining = set(mnemonics)
+    for opcode, spec in list(OPCODES.items()):
+        if spec.mnemonic in remaining:
+            OPCODES[opcode] = replace(spec, can_throw=True)
+            remaining.remove(spec.mnemonic)
+    if remaining:
+        raise ValueError(f"Unknown Dalvik throwable opcodes: {', '.join(sorted(remaining))}")
 
 
 _register(0x00, "nop", "10x", 1)
@@ -239,6 +249,7 @@ _register_range(
     "21c",
     2,
     ref_kind="field",
+    can_throw=True,
 )
 _register_range(
     0x6E,
@@ -402,6 +413,20 @@ _register_range(
     ],
     "22b",
     2,
+)
+_mark_can_throw(
+    "div-int",
+    "rem-int",
+    "div-long",
+    "rem-long",
+    "div-int/2addr",
+    "rem-int/2addr",
+    "div-long/2addr",
+    "rem-long/2addr",
+    "div-int/lit16",
+    "rem-int/lit16",
+    "div-int/lit8",
+    "rem-int/lit8",
 )
 _register(0xFA, "invoke-polymorphic", "45cc", 4, ref_kind="method", can_throw=True, is_invoke=True)
 _register(0xFB, "invoke-polymorphic/range", "4rcc", 4, ref_kind="method", can_throw=True, is_invoke=True)

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -440,6 +440,695 @@ def _signed(value, bits):
     return (value & (sign_bit - 1)) - (value & sign_bit)
 
 
+FORMAT_DECODERS = {}
+
+
+def _decode_fmt_10x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    operands = ""
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["10x"] = _decode_fmt_10x
+
+
+def _decode_fmt_10t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    branch_delta = int.from_bytes(raw_bytes[1:2], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    operands = f"{hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["10t"] = _decode_fmt_10t
+
+
+def _decode_fmt_11n(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    literal = _signed(raw_bytes[1] >> 4 & 15, 4)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["11n"] = _decode_fmt_11n
+
+
+def _decode_fmt_11x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    registers = [reg_a]
+    operands = _reg_name(reg_a)
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["11x"] = _decode_fmt_11x
+
+
+def _decode_fmt_12x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["12x"] = _decode_fmt_12x
+
+
+def _decode_fmt_20t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    operands = f"{hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["20t"] = _decode_fmt_20t
+
+
+def _decode_fmt_21c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21c"] = _decode_fmt_21c
+
+
+def _decode_fmt_21h(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
+    shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
+    literal = value << shift
+    registers = [reg_a]
+    sign = "-" if literal < 0 else ""
+    operands = f"{_reg_name(reg_a)}, #{sign}{hex(abs(literal))}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21h"] = _decode_fmt_21h
+
+
+def _decode_fmt_21s(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21s"] = _decode_fmt_21s
+
+
+def _decode_fmt_21t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, {hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["21t"] = _decode_fmt_21t
+
+
+def _decode_fmt_22b(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    reg_b = raw_bytes[2]
+    literal = int.from_bytes(raw_bytes[3:4], byteorder="little", signed=True)
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22b"] = _decode_fmt_22b
+
+
+def _decode_fmt_22c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22c"] = _decode_fmt_22c
+
+
+def _decode_fmt_22s(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22s"] = _decode_fmt_22s
+
+
+def _decode_fmt_22t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1] & 15
+    reg_b = raw_bytes[1] >> 4 & 15
+    branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22t"] = _decode_fmt_22t
+
+
+def _decode_fmt_22x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    reg_b = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["22x"] = _decode_fmt_22x
+
+
+def _decode_fmt_23x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    reg_b = raw_bytes[2]
+    reg_c = raw_bytes[3]
+    registers = [reg_a, reg_b, reg_c]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["23x"] = _decode_fmt_23x
+
+
+def _decode_fmt_30t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
+    branch_target_idx = byte_idx + branch_delta
+    operands = f"{hex(branch_target_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["30t"] = _decode_fmt_30t
+
+
+def _decode_fmt_31c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:6], byteorder="little")
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["31c"] = _decode_fmt_31c
+
+
+def _decode_fmt_31i(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    literal = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{literal:+d}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["31i"] = _decode_fmt_31i
+
+
+def _decode_fmt_31t(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
+    payload_idx = byte_idx + branch_delta
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["31t"] = _decode_fmt_31t
+
+
+def _decode_fmt_32x(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    reg_b = int.from_bytes(raw_bytes[4:6], byteorder="little")
+    registers = [reg_a, reg_b]
+    operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["32x"] = _decode_fmt_32x
+
+
+def _decode_fmt_35c(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    _, registers = _decode_register_list_35c(raw_bytes)
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["35c"] = _decode_fmt_35c
+
+
+def _decode_fmt_3rc(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    count = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
+    registers = _decode_register_range(count, first_reg)
+    operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["3rc"] = _decode_fmt_3rc
+
+
+def _decode_fmt_45cc(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    _, registers = _decode_register_list_35c(raw_bytes[:6])
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
+    operands = "{{{}}}, {}, {}".format(
+        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    )
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["45cc"] = _decode_fmt_45cc
+
+
+def _decode_fmt_4rcc(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    count = raw_bytes[1]
+    ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
+    first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
+    ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
+    registers = _decode_register_range(count, first_reg)
+    operands = "{{{}}}, {}, {}".format(
+        _format_registers(registers), resolve_ref(opcode.ref_kind, ref_index), resolve_ref("proto", ref_index_aux)
+    )
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["4rcc"] = _decode_fmt_4rcc
+
+
+def _decode_fmt_51l(raw_bytes, byte_idx, opcode, resolve_ref):
+    registers = []
+    operands = ""
+    literal = None
+    ref_index = None
+    ref_index_aux = None
+    branch_target_idx = None
+    payload_idx = None
+    reg_a = raw_bytes[1]
+    literal = int.from_bytes(raw_bytes[2:10], byteorder="little", signed=True)
+    registers = [reg_a]
+    operands = f"{_reg_name(reg_a)}, #{hex(literal)}"
+    return {
+        "registers": registers,
+        "operands": operands,
+        "literal": literal,
+        "ref_index": ref_index,
+        "ref_index_aux": ref_index_aux,
+        "branch_target_idx": branch_target_idx,
+        "payload_idx": payload_idx,
+    }
+
+
+FORMAT_DECODERS["51l"] = _decode_fmt_51l
+
+
 def decode_instruction(bytecode, byte_idx, resolve_ref):
     opcode_value = bytecode[byte_idx]
     if opcode_value not in OPCODES:
@@ -459,155 +1148,19 @@ def decode_instruction(bytecode, byte_idx, resolve_ref):
     branch_target_idx = None
     payload_idx = None
 
-    if opcode.fmt == "10x":
-        operands = ""
-    elif opcode.fmt == "10t":
-        branch_delta = int.from_bytes(raw_bytes[1:2], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        operands = f"{hex(branch_target_idx)}"
-    elif opcode.fmt == "11n":
-        reg_a = raw_bytes[1] & 0x0F
-        literal = _signed((raw_bytes[1] >> 4) & 0x0F, 4)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{literal:+d}"
-    elif opcode.fmt == "11x":
-        reg_a = raw_bytes[1]
-        registers = [reg_a]
-        operands = _reg_name(reg_a)
-    elif opcode.fmt == "12x":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
-    elif opcode.fmt == "20t":
-        branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        operands = f"{hex(branch_target_idx)}"
-    elif opcode.fmt == "21c":
-        reg_a = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "21h":
-        reg_a = raw_bytes[1]
-        # The 16-bit immediate is sign-extended per the Dalvik spec before shifting.
-        # Using signed=True ensures negative values like 0xFFFF produce -1 << shift
-        # rather than 0xFFFF << shift, matching baksmali's output.
-        value = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-        shift = 48 if opcode.mnemonic.endswith("wide/high16") else 16
-        literal = value << shift
-        registers = [reg_a]
-        sign = "-" if literal < 0 else ""
-        operands = f"{_reg_name(reg_a)}, #{sign}{hex(abs(literal))}"
-    elif opcode.fmt == "21s":
-        reg_a = raw_bytes[1]
-        literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{literal:+d}"
-    elif opcode.fmt == "21t":
-        reg_a = raw_bytes[1]
-        branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, {hex(branch_target_idx)}"
-    elif opcode.fmt == "22b":
-        reg_a = raw_bytes[1]
-        reg_b = raw_bytes[2]
-        literal = int.from_bytes(raw_bytes[3:4], byteorder="little", signed=True)
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
-    elif opcode.fmt == "22c":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "22s":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        literal = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True)
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, #{literal:+d}"
-    elif opcode.fmt == "22t":
-        reg_a = raw_bytes[1] & 0x0F
-        reg_b = (raw_bytes[1] >> 4) & 0x0F
-        branch_delta = int.from_bytes(raw_bytes[2:4], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {hex(branch_target_idx)}"
-    elif opcode.fmt == "22x":
-        reg_a = raw_bytes[1]
-        reg_b = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
-    elif opcode.fmt == "23x":
-        reg_a = raw_bytes[1]
-        reg_b = raw_bytes[2]
-        reg_c = raw_bytes[3]
-        registers = [reg_a, reg_b, reg_c]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}, {_reg_name(reg_c)}"
-    elif opcode.fmt == "30t":
-        branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
-        branch_target_idx = byte_idx + branch_delta
-        operands = f"{hex(branch_target_idx)}"
-    elif opcode.fmt == "31c":
-        reg_a = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:6], byteorder="little")
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "31i":
-        reg_a = raw_bytes[1]
-        literal = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{literal:+d}"
-    elif opcode.fmt == "31t":
-        reg_a = raw_bytes[1]
-        branch_delta = int.from_bytes(raw_bytes[2:6], byteorder="little", signed=True) * 2
-        payload_idx = byte_idx + branch_delta
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, payload@{hex(payload_idx)}"
-    elif opcode.fmt == "32x":
-        reg_a = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        reg_b = int.from_bytes(raw_bytes[4:6], byteorder="little")
-        registers = [reg_a, reg_b]
-        operands = f"{_reg_name(reg_a)}, {_reg_name(reg_b)}"
-    elif opcode.fmt == "35c":
-        _, registers = _decode_register_list_35c(raw_bytes)
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "3rc":
-        count = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
-        registers = _decode_register_range(count, first_reg)
-        operands = f"{{{_format_registers(registers)}}}, {resolve_ref(opcode.ref_kind, ref_index)}"
-    elif opcode.fmt == "45cc":
-        _, registers = _decode_register_list_35c(raw_bytes[:6])
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-        operands = "{{{}}}, {}, {}".format(
-            _format_registers(registers),
-            resolve_ref(opcode.ref_kind, ref_index),
-            resolve_ref("proto", ref_index_aux),
-        )
-    elif opcode.fmt == "4rcc":
-        count = raw_bytes[1]
-        ref_index = int.from_bytes(raw_bytes[2:4], byteorder="little")
-        first_reg = int.from_bytes(raw_bytes[4:6], byteorder="little")
-        ref_index_aux = int.from_bytes(raw_bytes[6:8], byteorder="little")
-        registers = _decode_register_range(count, first_reg)
-        operands = "{{{}}}, {}, {}".format(
-            _format_registers(registers),
-            resolve_ref(opcode.ref_kind, ref_index),
-            resolve_ref("proto", ref_index_aux),
-        )
-    elif opcode.fmt == "51l":
-        reg_a = raw_bytes[1]
-        literal = int.from_bytes(raw_bytes[2:10], byteorder="little", signed=True)
-        registers = [reg_a]
-        operands = f"{_reg_name(reg_a)}, #{hex(literal)}"
-    else:
+    if opcode.fmt not in FORMAT_DECODERS:
         raise ValueError(f"Unsupported Dalvik format {opcode.fmt}")
+
+    decoder = FORMAT_DECODERS[opcode.fmt]
+    result = decoder(raw_bytes, byte_idx, opcode, resolve_ref)
+
+    registers = result["registers"]
+    operands = result["operands"]
+    literal = result["literal"]
+    ref_index = result["ref_index"]
+    ref_index_aux = result["ref_index_aux"]
+    branch_target_idx = result["branch_target_idx"]
+    payload_idx = result["payload_idx"]
 
     return DecodedDalvikInstruction(
         opcode=opcode_value,

--- a/src/smda/ida/IdaExporter.py
+++ b/src/smda/ida/IdaExporter.py
@@ -1,10 +1,13 @@
 import datetime
+import logging
 
 from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, Cs
 
 from smda.DisassemblyResult import DisassemblyResult
 
 from .IdaInterface import IdaInterface
+
+LOGGER = logging.getLogger(__name__)
 
 
 class IdaExporter:
@@ -30,7 +33,7 @@ class IdaExporter:
         else:
             # record error and emit placeholder instruction
             bytes_as_hex = "".join([f"{c:02x}" for c in bytearray(instruction_bytes)])
-            print(f"missing capstone disassembly output at 0x{offset:x} ({bytes_as_hex})")
+            LOGGER.warning("missing capstone disassembly output at 0x%x (%s)", offset, bytes_as_hex)
             self.disassembly.errors[offset] = {
                 "type": "capstone disassembly failure",
                 "instruction_bytes": bytes_as_hex,

--- a/src/smda/ida/IdaInterface.py
+++ b/src/smda/ida/IdaInterface.py
@@ -32,14 +32,15 @@ class IdaInterface:
 
     def __init__(self):
         if not IdaInterface.instance:
-            if idaapi.IDA_SDK_VERSION < 740:
+            sdk_version = idaapi.IDA_SDK_VERSION
+            if not isinstance(sdk_version, int):
+                raise ValueError("Unsupported IDA SDK version")
+            if sdk_version < 740:
                 IdaInterface.instance = Ida73Interface()
-            elif idaapi.IDA_SDK_VERSION >= 740 and idaapi.IDA_SDK_VERSION < 850:
+            elif sdk_version < 850:
                 IdaInterface.instance = Ida74Interface()
-            elif idaapi.IDA_SDK_VERSION >= 850:
-                IdaInterface.instance = Ida85Interface()
             else:
-                raise ValueError("Unsupported IDA version")
+                IdaInterface.instance = Ida85Interface()
 
     def __getattr__(self, name):
         return getattr(self.instance, name)
@@ -122,7 +123,7 @@ class Ida74Interface(BackendInterface):
         if segment_starts:
             first_segment_start = segment_starts[0]
             # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start / 0x10000) * 0x10000
+            first_segment_start = (first_segment_start // 0x10000) * 0x10000
             base_addr = int(first_segment_start)
         return base_addr
 
@@ -233,9 +234,11 @@ class Ida73Interface(BackendInterface):
 
     def getBaseAddr(self):
         segment_starts = list(idautils.Segments())
+        if not segment_starts:
+            return 0
         first_segment_start = segment_starts[0]
         # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-        first_segment_start = (first_segment_start / 0x10000) * 0x10000
+        first_segment_start = (first_segment_start // 0x10000) * 0x10000
         return int(first_segment_start)
 
     def getBinary(self):
@@ -350,7 +353,7 @@ class Ida85Interface(BackendInterface):
         if segment_starts:
             first_segment_start = segment_starts[0]
             # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start / 0x10000) * 0x10000
+            first_segment_start = (first_segment_start // 0x10000) * 0x10000
             base_addr = int(first_segment_start)
         return base_addr
 

--- a/src/smda/intel/BitnessAnalyzer.py
+++ b/src/smda/intel/BitnessAnalyzer.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import struct
-from collections import Counter
 
 from .definitions import COMMON_START_BYTES
 
@@ -21,7 +20,7 @@ class BitnessAnalyzer:
         return self.determineBitness(binary=disassembly.binary_info.binary)
 
     def determineBitness(self, binary):
-        candidate_first_bytes = Counter()
+        candidate_first_bytes = set()
         # check for potential call instructions and collect their first bytes
         for call_match in re.finditer(b"\xe8", binary):
             if len(binary) - call_match.start() > 5:
@@ -30,17 +29,13 @@ class BitnessAnalyzer:
                 call_destination = rel_call_offset + call_match.start() + 5  # & bitmask
                 if call_destination > 0 and call_destination < len(binary):
                     first_byte = binary[call_destination]
-                    candidate_first_bytes[first_byte] += 1
+                    candidate_first_bytes.add(f"{first_byte:02x}")
         score = {"32": 0, "64": 0}
         for bitness in ["32", "64"]:
             for candidate_sequence in candidate_first_bytes:
-                if isinstance(candidate_sequence, int):
-                    candidate_sequence = f"{candidate_sequence:02x}"
-                elif isinstance(candidate_sequence, str):
-                    candidate_sequence = candidate_sequence.encode("hex")
-                for common_sequence, sequence_score in COMMON_START_BYTES[bitness].items():
-                    if candidate_sequence == str(common_sequence):
-                        score[bitness] += sequence_score * 1.0
+                sequence_score = COMMON_START_BYTES[bitness].get(candidate_sequence)
+                if sequence_score is not None:
+                    score[bitness] += sequence_score * 1.0
         total_score = max(score["32"] + score["64"], 1)
         score["32"] /= total_score
         score["64"] /= total_score

--- a/src/smda/intel/BitnessAnalyzer.py
+++ b/src/smda/intel/BitnessAnalyzer.py
@@ -21,20 +21,19 @@ class BitnessAnalyzer:
         return self.determineBitness(binary=disassembly.binary_info.binary)
 
     def determineBitness(self, binary):
-        candidate_first_bytes = {"32": Counter(), "64": Counter()}
+        candidate_first_bytes = Counter()
         # check for potential call instructions and collect their first bytes
-        for bitness in ["32", "64"]:
-            for call_match in re.finditer(b"\xe8", binary):
-                if len(binary) - call_match.start() > 5:
-                    packed_call = binary[call_match.start() + 1 : call_match.start() + 5]
-                    rel_call_offset = struct.unpack("i", packed_call)[0]
-                    call_destination = rel_call_offset + call_match.start() + 5  # & bitmask
-                    if call_destination > 0 and call_destination < len(binary):
-                        first_byte = binary[call_destination]
-                        candidate_first_bytes[bitness][first_byte] += 1
+        for call_match in re.finditer(b"\xe8", binary):
+            if len(binary) - call_match.start() > 5:
+                packed_call = binary[call_match.start() + 1 : call_match.start() + 5]
+                rel_call_offset = struct.unpack("i", packed_call)[0]
+                call_destination = rel_call_offset + call_match.start() + 5  # & bitmask
+                if call_destination > 0 and call_destination < len(binary):
+                    first_byte = binary[call_destination]
+                    candidate_first_bytes[first_byte] += 1
         score = {"32": 0, "64": 0}
         for bitness in ["32", "64"]:
-            for candidate_sequence in candidate_first_bytes[bitness]:
+            for candidate_sequence in candidate_first_bytes:
                 if isinstance(candidate_sequence, int):
                     candidate_sequence = f"{candidate_sequence:02x}"
                 elif isinstance(candidate_sequence, str):

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -16,10 +16,10 @@ class FunctionCandidate:
         self.is_gap_candidate = False
         self.is_tailcall = False
         self.alignment = 0
-        if addr % 4 == 0:
-            self.alignment = 4
-        elif addr % 16 == 0:
+        if addr % 16 == 0:
             self.alignment = 16
+        elif addr % 4 == 0:
+            self.alignment = 4
         self.analysis_aborted = False
         self.abortion_reason = ""
         self._score = None
@@ -34,6 +34,8 @@ class FunctionCandidate:
         self._tfidf_score = tfidf_score
 
     def getTfIdf(self):
+        if self._tfidf_score is None:
+            return None
         return round(self._tfidf_score, 3)
 
     def getConfidence(self):

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -2,6 +2,10 @@ from binascii import hexlify
 
 from .definitions import COMMON_PROLOGUES
 
+# Hoisted: prologue lengths are checked longest-first on every candidate scoring call.
+# Pre-sort once at import time instead of re-sorting per call (hot path during CFG recovery).
+_COMMON_PROLOGUE_LENGTHS = sorted((int(k) for k in COMMON_PROLOGUES), reverse=True)
+
 
 class FunctionCandidate:
     def __init__(self, binary_info, addr):
@@ -10,7 +14,9 @@ class FunctionCandidate:
         rel_start_addr = addr - binary_info.base_addr
         self.bytes = binary_info.binary[rel_start_addr : rel_start_addr + 5]
         self.lang_spec = None
-        self.call_ref_sources = []
+        # set, not list: addCallRef / removeCallRefs do membership tests in the inner
+        # CFG-recovery loop. Order is never read externally (only len + truthiness).
+        self.call_ref_sources = set()
         self.finished = False
         self.is_symbol = False
         self.is_gap_candidate = False
@@ -61,7 +67,7 @@ class FunctionCandidate:
         return self._confidence
 
     def hasCommonFunctionStart(self):
-        for length in sorted([int(length_str) for length_str in COMMON_PROLOGUES], reverse=True):
+        for length in _COMMON_PROLOGUE_LENGTHS:
             byte_sequence = self.bytes[:length]
             if byte_sequence in COMMON_PROLOGUES[f"{length}"][self.bitness]:
                 return True
@@ -69,7 +75,7 @@ class FunctionCandidate:
 
     def getFunctionStartScore(self):
         if self.function_start_score is None:
-            for length in sorted([int(length_str) for length_str in COMMON_PROLOGUES], reverse=True):
+            for length in _COMMON_PROLOGUE_LENGTHS:
                 byte_sequence = self.bytes[:length]
                 if byte_sequence in COMMON_PROLOGUES[f"{length}"][self.bitness]:
                     self.function_start_score = COMMON_PROLOGUES[f"{length}"][self.bitness][byte_sequence]
@@ -78,14 +84,12 @@ class FunctionCandidate:
         return self.function_start_score
 
     def addCallRef(self, source_addr):
-        if source_addr not in self.call_ref_sources:
-            self.call_ref_sources.append(source_addr)
+        self.call_ref_sources.add(source_addr)
         self._score = None
 
     def removeCallRefs(self, source_addrs):
         for addr in source_addrs:
-            if addr in self.call_ref_sources:
-                self.call_ref_sources.remove(addr)
+            self.call_ref_sources.discard(addr)
         self._score = None
 
     def setIsTailcallCandidate(self, is_tailcall):
@@ -179,11 +183,10 @@ class FunctionCandidate:
     def __str__(self):
         characteristics = self.getCharacteristics()
         prologue_score = f"{self.getFunctionStartScore()}"
-        ref_summary = (
-            f"{len(self.call_ref_sources)}"
-            if len(self.call_ref_sources) != 1
-            else f"{len(self.call_ref_sources)}: 0x{self.call_ref_sources[0]:x}"
-        )
+        if len(self.call_ref_sources) == 1:
+            ref_summary = f"1: 0x{next(iter(self.call_ref_sources)):x}"
+        else:
+            ref_summary = f"{len(self.call_ref_sources)}"
         return f"0x{self.addr:x}: {hexlify(self.bytes)} -> {prologue_score} (total score: {self.getScore()}), inref: {ref_summary} | {characteristics}"
 
     def toJson(self):

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -88,8 +88,7 @@ class FunctionCandidate:
         self._score = None
 
     def removeCallRefs(self, source_addrs):
-        for addr in source_addrs:
-            self.call_ref_sources.discard(addr)
+        self.call_ref_sources.difference_update(source_addrs)
         self._score = None
 
     def setIsTailcallCandidate(self, is_tailcall):

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -243,7 +243,7 @@ class FunctionCandidateManager:
                 byte = self.disassembly.getRawByte(gap_offset)
             except Exception as exc:
                 reraise_non_operational_exception(exc)
-                LOGGER.warn("could not fetch raw byte for gap pointer.")
+                LOGGER.warning("could not fetch raw byte for gap pointer.")
                 # print("0x%08x" % self.disassembly.binary_info.base_addr, "0x%08x" % self.disassembly.binary_info.binary_size, "0x%08x" % self.gap_pointer, "0x%08x" % gap_offset)
             # try to find padding symbols and skip them
             if isinstance(byte, int):
@@ -409,9 +409,9 @@ class FunctionCandidateManager:
             addr_block = self.disassembly.getRawBytes(offset + 2, 4)
             function_pointer = struct.unpack("i", addr_block)[0]
             # we need to calculate RIP + offset + 7 (48 ff 25 ** ** ** **)
-            if self.disassembly.getRawBytes(offset, 2) == "\xff\x25":
+            if self.disassembly.getRawBytes(offset, 2) == b"\xff\x25":
                 function_pointer += offset + 7
-            elif self.disassembly.getRawBytes(offset, 2) == "\xff\x15":
+            elif self.disassembly.getRawBytes(offset, 2) == b"\xff\x15":
                 function_pointer += offset + 6
             else:
                 raise Exception("resolvePointerReference: should only be used on call/jmp * ptr")

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -418,22 +418,16 @@ class FunctionCandidateManager:
     def _identifyAlignment(self):
         identified_alignment = 0
         if self.config.USE_ALIGNMENT:
-            num_candidates = sum(
-                [1 for addr, candidate in self.candidates.items() if len(candidate.call_ref_sources) > 1]
-            )
+            num_candidates = sum(1 for candidate in self.candidates.values() if len(candidate.call_ref_sources) > 1)
             num_aligned_16_candidates = sum(
-                [
-                    1
-                    for addr, candidate in self.candidates.items()
-                    if len(candidate.call_ref_sources) > 1 and candidate.alignment == 16
-                ]
+                1
+                for candidate in self.candidates.values()
+                if len(candidate.call_ref_sources) > 1 and candidate.alignment == 16
             )
             num_aligned_4_candidates = sum(
-                [
-                    1
-                    for addr, candidate in self.candidates.items()
-                    if len(candidate.call_ref_sources) > 1 and candidate.alignment >= 4
-                ]
+                1
+                for candidate in self.candidates.values()
+                if len(candidate.call_ref_sources) > 1 and candidate.alignment >= 4
             )
             if num_candidates:
                 alignment_16_ratio = 1.0 * num_aligned_16_candidates / num_candidates

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -4,6 +4,7 @@ import struct
 
 from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, Cs
 
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.utility.BracketQueue import BracketQueue
 from smda.utility.PriorityQueue import PriorityQueue
 
@@ -133,7 +134,8 @@ class FunctionCandidateManager:
             candidates_0 = len([c.getScore() for c in self.candidates.values() if c.getScore() == 0])
             LOGGER.debug("  Max: %f, Min: %f", maxc, minc)
             LOGGER.debug("  2: %d, 1: %d, 0: %d", candidates_2, candidates_1, candidates_0)
-        except Exception:
+        except Exception as exc:
+            reraise_non_operational_exception(exc)
             LOGGER.debug("  No candidates found.")
 
     def getFunctionStartCandidates(self):
@@ -239,7 +241,8 @@ class FunctionCandidateManager:
             # compatibility with python2/3...
             try:
                 byte = self.disassembly.getRawByte(gap_offset)
-            except Exception:
+            except Exception as exc:
+                reraise_non_operational_exception(exc)
                 LOGGER.warn("could not fetch raw byte for gap pointer.")
                 # print("0x%08x" % self.disassembly.binary_info.base_addr, "0x%08x" % self.disassembly.binary_info.binary_size, "0x%08x" % self.gap_pointer, "0x%08x" % gap_offset)
             # try to find padding symbols and skip them

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -124,20 +124,6 @@ class FunctionCandidateManager:
                     continue
                 yield candidate
 
-    def _logCandidateStats(self):
-        LOGGER.debug("Candidate Statistics:")
-        try:
-            maxc = max([c.getScore() for c in self.candidates.values()])
-            minc = min([c.getScore() for c in self.candidates.values()])
-            candidates_2 = len([c.getScore() for c in self.candidates.values() if c.getScore() == 2])
-            candidates_1 = len([c.getScore() for c in self.candidates.values() if c.getScore() == 1])
-            candidates_0 = len([c.getScore() for c in self.candidates.values() if c.getScore() == 0])
-            LOGGER.debug("  Max: %f, Min: %f", maxc, minc)
-            LOGGER.debug("  2: %d, 1: %d, 0: %d", candidates_2, candidates_1, candidates_0)
-        except Exception as exc:
-            reraise_non_operational_exception(exc)
-            LOGGER.debug("  No candidates found.")
-
     def getFunctionStartCandidates(self):
         return self._candidate_offsets
 

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -19,11 +19,33 @@ class IndirectCallAnalyzer:
         self.disassembly = self.disassembler.disassembly
         self.current_calling_addr = 0
         self.state = None
+        # Lazy {instruction_addr: containing_block} index, populated for the
+        # lifetime of a single resolveRegisterCalls() call. Cleared afterwards
+        # so a reused analyzer instance never serves a stale index.
+        self._block_index = None
+
+    @staticmethod
+    def _buildBlockIndex(analysis_state):
+        # Preserve "first matching block wins" — overlapping potential_starts
+        # in FunctionAnalysisState.getBlocks() can place the same instruction
+        # in more than one block; the legacy linear scan returned the first.
+        index = {}
+        for block in analysis_state.getBlocks():
+            for ins in block:
+                addr = ins[0]
+                if addr not in index:
+                    index[addr] = block
+        return index
 
     def searchBlock(self, analysis_state, address):
+        if self._block_index is not None:
+            return self._block_index.get(address, [])
+        # Fallback for direct callers (e.g. unit tests) that bypass
+        # resolveRegisterCalls and never seed the index.
         for block in analysis_state.getBlocks():
-            if address in [i[0] for i in block]:
-                return block
+            for ins in block:
+                if ins[0] == address:
+                    return block
         return []
 
     def getDword(self, addr):
@@ -209,38 +231,47 @@ class IndirectCallAnalyzer:
                 len(analysis_state.call_register_ins),
                 analysis_state.start_addr,
             )
-        max_calls_per_block = 10
-        calls_per_block = {}
-        for calling_addr in analysis_state.call_register_ins:
-            LOGGER.debug("#" * 20)
-            self.current_calling_addr = calling_addr
-            self.state = analysis_state
-            start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
-            if not start_block:
-                return
-            # we only process at most 10 register-calls per block to avoid extreme cases
-            # found one Go sample with 130k register calls.
-            if start_block[0] not in calls_per_block:
-                calls_per_block[start_block[0]] = 0
-            calls_per_block[start_block[0]] += 1
-            # if we have an old config, default to 50
-            max_calls = (
-                self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
-                if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
-                else 50
-            )
-            if calls_per_block[start_block[0]] > max_calls:
-                break
-            LOGGER.debug(
-                "For this block, we can still analyze %d indirect calls.",
-                max_calls_per_block - calls_per_block[start_block[0]],
-            )
-            if start_block:
-                self.processBlock(
-                    analysis_state,
-                    start_block,
-                    {},
-                    start_block[-1][3],
-                    [],
-                    block_depth,
+        # Build the instruction->block index once per function. The previous
+        # implementation scanned every block linearly inside searchBlock for
+        # every calling address AND recursively for every incoming ref up to
+        # block_depth — O(N**2) on call-heavy functions (e.g. Go binaries with
+        # many register calls). With the index, each lookup is O(1).
+        self._block_index = self._buildBlockIndex(analysis_state)
+        try:
+            max_calls_per_block = 10
+            calls_per_block = {}
+            for calling_addr in analysis_state.call_register_ins:
+                LOGGER.debug("#" * 20)
+                self.current_calling_addr = calling_addr
+                self.state = analysis_state
+                start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
+                if not start_block:
+                    return
+                # we only process at most 10 register-calls per block to avoid extreme cases
+                # found one Go sample with 130k register calls.
+                if start_block[0] not in calls_per_block:
+                    calls_per_block[start_block[0]] = 0
+                calls_per_block[start_block[0]] += 1
+                # if we have an old config, default to 50
+                max_calls = (
+                    self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
+                    if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
+                    else 50
                 )
+                if calls_per_block[start_block[0]] > max_calls:
+                    break
+                LOGGER.debug(
+                    "For this block, we can still analyze %d indirect calls.",
+                    max_calls_per_block - calls_per_block[start_block[0]],
+                )
+                if start_block:
+                    self.processBlock(
+                        analysis_state,
+                        start_block,
+                        {},
+                        start_block[-1][3],
+                        [],
+                        block_depth,
+                    )
+        finally:
+            self._block_index = None

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import re
 import struct
@@ -19,34 +20,32 @@ class IndirectCallAnalyzer:
         self.disassembly = self.disassembler.disassembly
         self.current_calling_addr = 0
         self.state = None
-        # Lazy {instruction_addr: containing_block} index, populated for the
-        # lifetime of a single resolveRegisterCalls() call. Cleared afterwards
-        # so a reused analyzer instance never serves a stale index.
-        self._block_index = None
-
-    @staticmethod
-    def _buildBlockIndex(analysis_state):
-        # Preserve "first matching block wins" — overlapping potential_starts
-        # in FunctionAnalysisState.getBlocks() can place the same instruction
-        # in more than one block; the legacy linear scan returned the first.
-        index = {}
-        for block in analysis_state.getBlocks():
-            for ins in block:
-                addr = ins[0]
-                if addr not in index:
-                    index[addr] = block
-        return index
 
     def searchBlock(self, analysis_state, address):
-        if self._block_index is not None:
-            return self._block_index.get(address, [])
-        # Fallback for direct callers (e.g. unit tests) that bypass
-        # resolveRegisterCalls and never seed the index.
-        for block in analysis_state.getBlocks():
-            for ins in block:
-                if ins[0] == address:
-                    return block
-        return []
+        # Lazy-cache an {instruction_addr: containing_block} index on the
+        # analysis_state so subsequent lookups during the same function
+        # analysis are O(1) instead of O(blocks * instructions). The cache
+        # lives on the state (not on self) so the analyzer stays
+        # re-entrancy-safe and the index can't outlive the function being
+        # analyzed.
+        block_index = getattr(analysis_state, "_block_index", None)
+        if not isinstance(block_index, dict):
+            block_index = {}
+            # Preserve "first matching block wins" — overlapping
+            # potential_starts in FunctionAnalysisState.getBlocks() can
+            # place the same instruction in more than one block; the
+            # legacy linear scan returned the first.
+            for block in analysis_state.getBlocks():
+                for ins in block:
+                    addr = ins[0]
+                    if addr not in block_index:
+                        block_index[addr] = block
+            # Objects with __slots__ or read-only attribute surfaces (and some
+            # test doubles) reject the assignment; the lookup below still works
+            # on the freshly built index.
+            with contextlib.suppress(AttributeError):
+                analysis_state._block_index = block_index
+        return block_index.get(address, [])
 
     def getDword(self, addr):
         if not self.disassembly.isAddrWithinMemoryImage(addr):
@@ -231,47 +230,38 @@ class IndirectCallAnalyzer:
                 len(analysis_state.call_register_ins),
                 analysis_state.start_addr,
             )
-        # Build the instruction->block index once per function. The previous
-        # implementation scanned every block linearly inside searchBlock for
-        # every calling address AND recursively for every incoming ref up to
-        # block_depth — O(N**2) on call-heavy functions (e.g. Go binaries with
-        # many register calls). With the index, each lookup is O(1).
-        self._block_index = self._buildBlockIndex(analysis_state)
-        try:
-            max_calls_per_block = 10
-            calls_per_block = {}
-            for calling_addr in analysis_state.call_register_ins:
-                LOGGER.debug("#" * 20)
-                self.current_calling_addr = calling_addr
-                self.state = analysis_state
-                start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
-                if not start_block:
-                    return
-                # we only process at most 10 register-calls per block to avoid extreme cases
-                # found one Go sample with 130k register calls.
-                if start_block[0] not in calls_per_block:
-                    calls_per_block[start_block[0]] = 0
-                calls_per_block[start_block[0]] += 1
-                # if we have an old config, default to 50
-                max_calls = (
-                    self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
-                    if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
-                    else 50
+        max_calls_per_block = 10
+        calls_per_block = {}
+        for calling_addr in analysis_state.call_register_ins:
+            LOGGER.debug("#" * 20)
+            self.current_calling_addr = calling_addr
+            self.state = analysis_state
+            start_block = [ins for ins in self.searchBlock(analysis_state, calling_addr) if ins[0] <= calling_addr]
+            if not start_block:
+                return
+            # we only process at most 10 register-calls per block to avoid extreme cases
+            # found one Go sample with 130k register calls.
+            if start_block[0] not in calls_per_block:
+                calls_per_block[start_block[0]] = 0
+            calls_per_block[start_block[0]] += 1
+            # if we have an old config, default to 50
+            max_calls = (
+                self.disassembler.config.MAX_INDIRECT_CALLS_PER_BASIC_BLOCK
+                if hasattr(self.disassembler.config, "MAX_INDIRECT_CALLS_PER_BASIC_BLOCK")
+                else 50
+            )
+            if calls_per_block[start_block[0]] > max_calls:
+                break
+            LOGGER.debug(
+                "For this block, we can still analyze %d indirect calls.",
+                max_calls_per_block - calls_per_block[start_block[0]],
+            )
+            if start_block:
+                self.processBlock(
+                    analysis_state,
+                    start_block,
+                    {},
+                    start_block[-1][3],
+                    [],
+                    block_depth,
                 )
-                if calls_per_block[start_block[0]] > max_calls:
-                    break
-                LOGGER.debug(
-                    "For this block, we can still analyze %d indirect calls.",
-                    max_calls_per_block - calls_per_block[start_block[0]],
-                )
-                if start_block:
-                    self.processBlock(
-                        analysis_state,
-                        start_block,
-                        {},
-                        start_block[-1][3],
-                        [],
-                        block_depth,
-                    )
-        finally:
-            self._block_index = None

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -622,6 +622,6 @@ class IntelDisassembler:
                 candidate.getConfidence()
             self.disassembly.candidates[addr] = candidate
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout():
+        if cbAnalysisTimeout and cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True
         return self.disassembly

--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -2047,7 +2047,6 @@ class IntelInstructionEscaper:
                 mnemonic,
             )
             return "U"
-        return mnemonic
 
     @staticmethod
     def escapeField(op_field, escape_registers=True, escape_pointers=True, escape_constants=True):

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -155,6 +155,9 @@ class JumpTableAnalyzer:
                         "Q",
                         self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
                     )[0]
+                else:
+                    LOGGER.warning("Unsupported bitness for jump table analysis: %s", bitness)
+                    break
                 if not self.disassembly.isAddrWithinMemoryImage(table_entry):
                     break
                 state.addDataRef(

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -142,22 +142,21 @@ class JumpTableAnalyzer:
         jumptable_size = jumptable_size if jumptable_size is not None else 0xFF
         jumptable_addresses = []
         bitness = self.disassembly.binary_info.bitness
-        entry_size = 4 if bitness == 32 else 8
+        if bitness == 32:
+            entry_size = 4
+            entry_format = "I"
+        elif bitness == 64:
+            entry_size = 8
+            entry_format = "Q"
+        else:
+            LOGGER.warning("Unsupported %s-bit jump table analysis", bitness)
+            return jumptable_addresses
         if self.disassembly.isAddrWithinMemoryImage(jumptable_address):
             for i in range(jumptable_size):
-                if bitness == 32:
-                    table_entry = struct.unpack(
-                        "I",
-                        self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
-                    )[0]
-                elif bitness == 64:
-                    table_entry = struct.unpack(
-                        "Q",
-                        self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
-                    )[0]
-                else:
-                    LOGGER.warning("Unsupported bitness for jump table analysis: %s", bitness)
-                    break
+                table_entry = struct.unpack(
+                    entry_format,
+                    self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size),
+                )[0]
                 if not self.disassembly.isAddrWithinMemoryImage(table_entry):
                     break
                 state.addDataRef(

--- a/src/smda/intel/LanguageAnalyzer.py
+++ b/src/smda/intel/LanguageAnalyzer.py
@@ -21,13 +21,12 @@ class LanguageAnalyzer:
         self.strings = None
 
     def validPEHeader(self):
-        is_pe = True
-        is_pe |= self.disassembly.binary_info.binary[0:2] == "\x4d\x5a"
+        is_pe = self.disassembly.binary_info.binary[0:2] == b"\x4d\x5a"
         if len(self.disassembly.binary_info.binary) > 0x40:
             pe_offset = struct.unpack("I", self.disassembly.binary_info.binary[0x3C:0x40])[0]
-            is_pe |= (
+            is_pe = is_pe and (
                 len(self.disassembly.binary_info.binary) > pe_offset
-                and self.disassembly.binary_info.binary[pe_offset : pe_offset + 2] == "\x50\x45"
+                and self.disassembly.binary_info.binary[pe_offset : pe_offset + 2] == b"\x50\x45"
             )
         else:
             is_pe = False
@@ -54,14 +53,14 @@ class LanguageAnalyzer:
     def getVisualBasicScore(self):
         # check for the typical import of msvbvm60.dll
         vb_score = 0.0
-        if "MSVBVM60.DLL" in self.getStrings():
+        if b"MSVBVM60.DLL" in self.getStrings():
             vb_score = 0.5
         return vb_score
 
     def getDotNetScore(self):
         dot_net_score = 0.0
         # check for the typical import of mscorelib.dll and mscoree.dll
-        if "mscorelib.dll" in self.getStrings() or "mscoree.dll" in self.getStrings():
+        if b"mscorelib.dll" in self.getStrings() or b"mscoree.dll" in self.getStrings():
             dot_net_score = 0.35
         # check for a functioning PE-Header and typical meta-data
         if self.validPEHeader():
@@ -73,7 +72,7 @@ class LanguageAnalyzer:
                 start_addr = struct.unpack("<I", match.group("start"))[0]
                 if start_addr == 0x2000:
                     dot_net_score = max(dot_net_score, 0.8)
-                if self.disassembly.getRawBytes(start_addr, 4) == "\xdb\x4d\x00\x79":
+                if self.disassembly.getRawBytes(start_addr, 4) == b"\xdb\x4d\x00\x79":
                     dot_net_score = max(dot_net_score, 0.9)
         return dot_net_score
 
@@ -83,7 +82,7 @@ class LanguageAnalyzer:
     def getDelphiScore(self):
         delphi_score = 0.0
         # Check if Delphi-Locales are present in strings
-        if "Borland\\locales" in self.getStrings():
+        if b"Borland\\locales" in self.getStrings():
             delphi_score = max(delphi_score, 0.5)
         if self._getPETimestamp() == 0x2A425E19:
             delphi_score = 0.5

--- a/src/smda/intel/LanguageAnalyzer.py
+++ b/src/smda/intel/LanguageAnalyzer.py
@@ -183,15 +183,12 @@ class LanguageAnalyzer:
         patterns.append(b"\x8b\x4d[\\S\\s]\xe8[\\S\\s]{3}(\x00|\xff)")
         # mov ecx, <reg>; call XYZ
         patterns.append(b"\x8b[\xc8-\xcf]\xe8[\\S\\s]{3}(\x00|\xff)")
+        thiscall_count = sum(len(re.findall(pattern, self.disassembly.binary_info.binary)) for pattern in patterns)
         result["c++"] = min(
             1,
-            6.0
-            * sum([len(re.findall(pattern, self.disassembly.binary_info.binary)) for pattern in patterns])
-            / max(1, len(self.disassembly.functions)),
+            6.0 * thiscall_count / max(1, len(self.disassembly.functions)),
         )
-        result["_count_thiscalls"] = sum(
-            [len(re.findall(pattern, self.disassembly.binary_info.binary)) for pattern in patterns]
-        )
+        result["_count_thiscalls"] = thiscall_count
 
         # guess the programming language and
         # return dict with probabilities for the use of certain programming languages

--- a/src/smda/intel/LanguageAnalyzer.py
+++ b/src/smda/intel/LanguageAnalyzer.py
@@ -163,7 +163,7 @@ class LanguageAnalyzer:
         result["delphi"] = self.getDelphiScore()
         if self.checkDelphi():
             t_objects = self.getDelphiObjects()
-            functions = sum([len(t_objects[t_string]) for t_string in t_objects])
+            functions = sum(len(t_string) for t_string in t_objects.values())
             # result["_delphi_objects"] = t_objects.keys()
             result["_count_delphi_objects"] = len(t_objects)
             if len(t_objects) > 5 and functions > 10:

--- a/src/smda/intel/MnemonicTfIdf.py
+++ b/src/smda/intel/MnemonicTfIdf.py
@@ -438,6 +438,8 @@ class MnemonicTfIdf:
         return self.tfidf(term_counts)
 
     def tfidf(self, term_counts):
+        if not term_counts:
+            return 0.0
         score = 0
         sum_term_counts = sum(term_counts.values())
         max_count = max(term_counts.values())

--- a/src/smda/utility/BracketQueue.py
+++ b/src/smda/utility/BracketQueue.py
@@ -1,6 +1,6 @@
 class BracketQueue:
     """
-    This queue is tailored based on our research rsults regarding function entry point identification
+    This queue is tailored based on our research results regarding function entry point identification
     """
 
     def __init__(self, candidates=None, initial_brackets=None):

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -32,9 +32,14 @@ class ElfFileLoader:
         return data[:4] == b"\x7fELF"
 
     @staticmethod
-    def getBaseAddress(binary, elffile=None):
-        if elffile is None:
-            elffile = lief.parse(binary)
+    def parseBinary(binary):
+        # Single lief.parse entry point so FileLoader can share one parse
+        # across all accessors instead of each accessor re-parsing.
+        return lief.parse(binary)
+
+    @staticmethod
+    def getBaseAddress(binary, parsed=None):
+        elffile = parsed if parsed is not None else lief.parse(binary)
         # Determine base address of binary
         #
         base_addr = 0
@@ -152,15 +157,15 @@ class ElfFileLoader:
                 mapped_binary[rva : rva + section.size] = content_to_be_mapped
 
     @staticmethod
-    def mapBinary(binary):
+    def mapBinary(binary, parsed=None):
         """
         map the ELF file sections and segments into a contiguous bytearray
         as if into virtual memory with the given base address.
         """
-        elffile = lief.parse(binary)
+        elffile = parsed if parsed is not None else lief.parse(binary)
         if not elffile:
             return b""
-        base_addr = ElfFileLoader.getBaseAddress(binary, elffile=elffile)
+        base_addr = ElfFileLoader.getBaseAddress(binary, parsed=elffile)
 
         LOGGER.debug("ELF: base address: 0x%x", base_addr)
 
@@ -208,10 +213,10 @@ class ElfFileLoader:
         return bytes(mapped_binary)
 
     @staticmethod
-    def getAbi(binary):
+    def getAbi(binary, parsed=None):
         abi = ""
         try:
-            elffile = lief.parse(binary)
+            elffile = parsed if parsed is not None else lief.parse(binary)
             if elffile:
                 abi = elffile.header.identity_os_abi.name
         except lief.bad_file as exc:
@@ -219,14 +224,14 @@ class ElfFileLoader:
         return abi
 
     @staticmethod
-    def getArchitecture(binary):
-        architecture = "intel"
-        return architecture
+    def getArchitecture(binary, parsed=None):
+        del binary, parsed
+        return "intel"
 
     @staticmethod
-    def getBitness(binary):
+    def getBitness(binary, parsed=None):
         # TODO add machine types whenever we add more architectures
-        elffile = lief.parse(binary)
+        elffile = parsed if parsed is not None else lief.parse(binary)
         if not elffile:
             return 0
         machine_type = elffile.header.machine_type
@@ -254,9 +259,9 @@ class ElfFileLoader:
         return merged_code_areas
 
     @staticmethod
-    def getCodeAreas(binary):
+    def getCodeAreas(binary, parsed=None):
         # TODO add machine types whenever we add more architectures
-        elffile = lief.parse(binary)
+        elffile = parsed if parsed is not None else lief.parse(binary)
         if elffile is None:
             return []
         code_areas = []

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -8,6 +8,11 @@ from smda.SmdaConfig import SmdaConfig
 
 LOGGER = logging.getLogger(__name__)
 
+# Sentinel: distinguishes "caller did not supply parsed" (legacy direct
+# call, do your own lief.parse) from "caller already tried to parse and
+# got None" (e.g. FileLoader saw lief.parse fail; do NOT retry).
+_NOT_PROVIDED = object()
+
 
 def align(v, alignment):
     remainder = v % alignment
@@ -38,8 +43,8 @@ class ElfFileLoader:
         return lief.parse(binary)
 
     @staticmethod
-    def getBaseAddress(binary, parsed=None):
-        elffile = parsed if parsed is not None else lief.parse(binary)
+    def getBaseAddress(binary, parsed=_NOT_PROVIDED):
+        elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         # Determine base address of binary
         #
         base_addr = 0
@@ -157,12 +162,12 @@ class ElfFileLoader:
                 mapped_binary[rva : rva + section.size] = content_to_be_mapped
 
     @staticmethod
-    def mapBinary(binary, parsed=None):
+    def mapBinary(binary, parsed=_NOT_PROVIDED):
         """
         map the ELF file sections and segments into a contiguous bytearray
         as if into virtual memory with the given base address.
         """
-        elffile = parsed if parsed is not None else lief.parse(binary)
+        elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not elffile:
             return b""
         base_addr = ElfFileLoader.getBaseAddress(binary, parsed=elffile)
@@ -213,10 +218,10 @@ class ElfFileLoader:
         return bytes(mapped_binary)
 
     @staticmethod
-    def getAbi(binary, parsed=None):
+    def getAbi(binary, parsed=_NOT_PROVIDED):
         abi = ""
         try:
-            elffile = parsed if parsed is not None else lief.parse(binary)
+            elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
             if elffile:
                 abi = elffile.header.identity_os_abi.name
         except lief.bad_file as exc:
@@ -224,14 +229,14 @@ class ElfFileLoader:
         return abi
 
     @staticmethod
-    def getArchitecture(binary, parsed=None):
+    def getArchitecture(binary, parsed=_NOT_PROVIDED):
         del binary, parsed
         return "intel"
 
     @staticmethod
-    def getBitness(binary, parsed=None):
+    def getBitness(binary, parsed=_NOT_PROVIDED):
         # TODO add machine types whenever we add more architectures
-        elffile = parsed if parsed is not None else lief.parse(binary)
+        elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not elffile:
             return 0
         machine_type = elffile.header.machine_type
@@ -259,9 +264,9 @@ class ElfFileLoader:
         return merged_code_areas
 
     @staticmethod
-    def getCodeAreas(binary, parsed=None):
+    def getCodeAreas(binary, parsed=_NOT_PROVIDED):
         # TODO add machine types whenever we add more architectures
-        elffile = parsed if parsed is not None else lief.parse(binary)
+        elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if elffile is None:
             return []
         code_areas = []

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -61,14 +61,14 @@ class ElfFileLoader:
         return base_addr
 
     @staticmethod
-    def _calculate_boundaries(elffile):
+    def _calculate_boundaries(elffile, base_addr=0):
         # find min and max virtual addresses.
         max_virtual_address = 0
         min_virtual_address = 0xFFFFFFFFFFFFFFFF
         min_raw_offset = 0xFFFFFFFFFFFFFFFF
 
         # find begin of the first section/segment and end of the last section/segment.
-        if not has_bogus_sections(elffile):
+        if not has_bogus_sections(elffile, base_addr):
             for section in sorted(elffile.sections, key=lambda section: section.size, reverse=True):
                 if not section.virtual_address:
                     continue
@@ -158,8 +158,6 @@ class ElfFileLoader:
         map the ELF file sections and segments into a contiguous bytearray
         as if into virtual memory with the given base address.
         """
-        # ELFFile needs a file-like object...
-        # Attention: for Python 2.x use the cStringIO package for StringIO
         elffile = lief.parse(binary)
         if not elffile:
             return b""
@@ -175,10 +173,9 @@ class ElfFileLoader:
         # we expect the section data to overwrite the segment data; however,
         # it should be exactly the same data.
 
-        max_virtual_address, min_virtual_address, min_raw_offset = ElfFileLoader._calculate_boundaries(elffile)
-
-        if (max_virtual_address - base_addr) > sys.maxsize:
-            LOGGER.warn("ELF: found possibly bogus segment information, trying to parse segments.")
+        max_virtual_address, min_virtual_address, min_raw_offset = ElfFileLoader._calculate_boundaries(
+            elffile, base_addr
+        )
 
         if not max_virtual_address:
             LOGGER.debug("ELF: no section or segment data")

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -61,28 +61,7 @@ class ElfFileLoader:
         return base_addr
 
     @staticmethod
-    def mapBinary(binary):
-        """
-        map the ELF file sections and segments into a contiguous bytearray
-        as if into virtual memory with the given base address.
-        """
-        # ELFFile needs a file-like object...
-        # Attention: for Python 2.x use the cStringIO package for StringIO
-        elffile = lief.parse(binary)
-        if not elffile:
-            return b""
-        base_addr = ElfFileLoader.getBaseAddress(binary, elffile=elffile)
-
-        LOGGER.debug("ELF: base address: 0x%x", base_addr)
-
-        # a segment may contain 0 or more sections.
-        # ref: https://stackoverflow.com/a/14382477/87207
-        #
-        # i'm not sure if a section may be found outside of a segment.
-        # therefore, lets load segments first, and then load sections over them.
-        # we expect the section data to overwrite the segment data; however,
-        # it should be exactly the same data.
-
+    def _calculate_boundaries(elffile):
         # find min and max virtual addresses.
         max_virtual_address = 0
         min_virtual_address = 0xFFFFFFFFFFFFFFFF
@@ -112,24 +91,10 @@ class ElfFileLoader:
             min_virtual_address = min(min_virtual_address, segment.virtual_address)
             min_raw_offset = min(min_raw_offset, segment.file_offset)
 
-        if (max_virtual_address - base_addr) > sys.maxsize:
-            LOGGER.warn("ELF: found possibly bogus segment information, trying to parse segments.")
+        return max_virtual_address, min_virtual_address, min_raw_offset
 
-        if not max_virtual_address:
-            LOGGER.debug("ELF: no section or segment data")
-            return b""
-
-        # create mapped region.
-        # offset 0x0 corresponds to the ELF base address
-        virtual_size = max_virtual_address - base_addr
-        if virtual_size > SmdaConfig.MAX_IMAGE_SIZE:
-            raise ValueError("ELF file larger than MAX_IMAGE_SIZE")
-        LOGGER.debug("ELF: max virtual section offset: 0x%x", max_virtual_address)
-        LOGGER.debug("ELF: min virtual section offset: 0x%x", min_virtual_address)
-        LOGGER.debug("ELF: mapped size: 0x%x", virtual_size)
-        LOGGER.debug("ELF: min raw offset: 0x%x", min_raw_offset)
-        mapped_binary = bytearray(align(virtual_size, 0x1000))
-
+    @staticmethod
+    def _map_segments(elffile, mapped_binary, base_addr):
         # map segments.
         # segments may contains 0 or more sections,
         # so we do segments first.
@@ -164,6 +129,8 @@ class ElfFileLoader:
             else:
                 mapped_binary[rva : rva + segment.physical_size] = segment.content
 
+    @staticmethod
+    def _map_sections(elffile, mapped_binary, base_addr):
         # map sections.
         # may overwrite some segment data, but we expect the content to be identical.
         if not has_bogus_sections(elffile, base_addr):
@@ -184,6 +151,52 @@ class ElfFileLoader:
                 if len(section.content) < section.size:
                     content_to_be_mapped += b"\x00" * (section.size - len(section.content))
                 mapped_binary[rva : rva + section.size] = content_to_be_mapped
+
+    @staticmethod
+    def mapBinary(binary):
+        """
+        map the ELF file sections and segments into a contiguous bytearray
+        as if into virtual memory with the given base address.
+        """
+        # ELFFile needs a file-like object...
+        # Attention: for Python 2.x use the cStringIO package for StringIO
+        elffile = lief.parse(binary)
+        if not elffile:
+            return b""
+        base_addr = ElfFileLoader.getBaseAddress(binary, elffile=elffile)
+
+        LOGGER.debug("ELF: base address: 0x%x", base_addr)
+
+        # a segment may contain 0 or more sections.
+        # ref: https://stackoverflow.com/a/14382477/87207
+        #
+        # i'm not sure if a section may be found outside of a segment.
+        # therefore, lets load segments first, and then load sections over them.
+        # we expect the section data to overwrite the segment data; however,
+        # it should be exactly the same data.
+
+        max_virtual_address, min_virtual_address, min_raw_offset = ElfFileLoader._calculate_boundaries(elffile)
+
+        if (max_virtual_address - base_addr) > sys.maxsize:
+            LOGGER.warn("ELF: found possibly bogus segment information, trying to parse segments.")
+
+        if not max_virtual_address:
+            LOGGER.debug("ELF: no section or segment data")
+            return b""
+
+        # create mapped region.
+        # offset 0x0 corresponds to the ELF base address
+        virtual_size = max_virtual_address - base_addr
+        if virtual_size > SmdaConfig.MAX_IMAGE_SIZE:
+            raise ValueError("ELF file larger than MAX_IMAGE_SIZE")
+        LOGGER.debug("ELF: max virtual section offset: 0x%x", max_virtual_address)
+        LOGGER.debug("ELF: min virtual section offset: 0x%x", min_virtual_address)
+        LOGGER.debug("ELF: mapped size: 0x%x", virtual_size)
+        LOGGER.debug("ELF: min raw offset: 0x%x", min_raw_offset)
+        mapped_binary = bytearray(align(virtual_size, 0x1000))
+
+        ElfFileLoader._map_segments(elffile, mapped_binary, base_addr)
+        ElfFileLoader._map_sections(elffile, mapped_binary, base_addr)
 
         # map header.
         # we consider the headers to be any data found before the first section/segment

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -22,8 +22,7 @@ def has_bogus_sections(elffile, base_addr=0):
     for section in elffile.sections:
         if section.virtual_address:
             max_virtual_address = max(max_virtual_address, section.size + section.virtual_address)
-    if (max_virtual_address - base_addr) > sys.maxsize:
-        return True
+    return (max_virtual_address - base_addr) > sys.maxsize
 
 
 class ElfFileLoader:
@@ -79,7 +78,7 @@ class ElfFileLoader:
                 min_virtual_address = min(min_virtual_address, section.virtual_address)
                 min_raw_offset = min(min_raw_offset, section.file_offset)
         else:
-            LOGGER.warn("ELF: found possibly bogus section information, trying to parse segments.")
+            LOGGER.warning("ELF: found possibly bogus section information, trying to parse segments.")
         # parse segments regardless
         for segment in elffile.segments:
             if not segment.virtual_address:
@@ -116,15 +115,15 @@ class ElfFileLoader:
                 segment.virtual_address,
             )
             if len(segment.content) != segment.physical_size:
-                LOGGER.warn("ELF: Mismatch in segment content vs. header-specified physical size!")
+                LOGGER.warning("ELF: Mismatch in segment content vs. header-specified physical size!")
                 if len(segment.content) < segment.physical_size:
-                    LOGGER.warn("ELF: Padding to physical size with zeroes!")
+                    LOGGER.warning("ELF: Padding to physical size with zeroes!")
                     mapped_binary[rva : rva + len(segment.content)] = segment.content
                     mapped_binary[rva + len(segment.content) : rva + segment.physical_size] = b"\x00" * (
                         segment.physical_size - len(segment.content)
                     )
                 else:
-                    LOGGER.warn("ELF: More content than physical size!? Aborting, please report this case. :)")
+                    LOGGER.warning("ELF: More content than physical size!? Aborting, please report this case. :)")
                     raise AssertionError("Received more content than physical size, which should never be possible?")
             else:
                 mapped_binary[rva : rva + segment.physical_size] = segment.content
@@ -258,6 +257,8 @@ class ElfFileLoader:
     def getCodeAreas(binary):
         # TODO add machine types whenever we add more architectures
         elffile = lief.parse(binary)
+        if elffile is None:
+            return []
         code_areas = []
         for section in elffile.sections:
             section_flags = 0

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -16,12 +16,13 @@ class FileLoader:
     _bitness = 0
     _abi = ""
     _architecture = ""
-    _code_areas = []
+    _code_areas = None
     file_loaders = [PeFileLoader, ElfFileLoader, MachoFileLoader, DelphiKbFileLoader, DexFileLoader]
 
     def __init__(self, file_path, load_file=True, map_file=False):
         self._file_path = file_path
         self._map_file = map_file
+        self._code_areas = []
         if load_file:
             self._loadFile()
 

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -42,14 +42,12 @@ class FileLoader:
                     # share a single lief.parse(...) across every accessor
                     # and skip multiple redundant re-parses per binary
                     # load. Delphi/Dex loaders don't need lief, so kw
-                    # stays empty for them. When the LIEF parse itself
-                    # fails (returns None), drop the kwarg so accessors
-                    # don't pointlessly re-try the parse on each call.
-                    kw = {}
-                    if hasattr(loader, "parseBinary"):
-                        parsed = loader.parseBinary(self._raw_data)
-                        if parsed is not None:
-                            kw["parsed"] = parsed
+                    # stays empty for them. We always pass parsed= (even
+                    # when None) so a failed parse short-circuits each
+                    # accessor — the loader-side sentinel default
+                    # distinguishes "caller did not supply" from
+                    # "caller already tried and got None".
+                    kw = {"parsed": loader.parseBinary(self._raw_data)} if hasattr(loader, "parseBinary") else {}
                     self._data = loader.mapBinary(self._raw_data, **kw)
                     self._base_addr = loader.getBaseAddress(self._raw_data, **kw)
                     self._bitness = loader.getBitness(self._raw_data, **kw)

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -42,8 +42,14 @@ class FileLoader:
                     # share a single lief.parse(...) across every accessor
                     # and skip multiple redundant re-parses per binary
                     # load. Delphi/Dex loaders don't need lief, so kw
-                    # stays empty for them.
-                    kw = {"parsed": loader.parseBinary(self._raw_data)} if hasattr(loader, "parseBinary") else {}
+                    # stays empty for them. When the LIEF parse itself
+                    # fails (returns None), drop the kwarg so accessors
+                    # don't pointlessly re-try the parse on each call.
+                    kw = {}
+                    if hasattr(loader, "parseBinary"):
+                        parsed = loader.parseBinary(self._raw_data)
+                        if parsed is not None:
+                            kw["parsed"] = parsed
                     self._data = loader.mapBinary(self._raw_data, **kw)
                     self._base_addr = loader.getBaseAddress(self._raw_data, **kw)
                     self._bitness = loader.getBitness(self._raw_data, **kw)

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -38,12 +38,18 @@ class FileLoader:
         if self._map_file:
             for loader in self.file_loaders:
                 if loader.isCompatible(self._raw_data):
-                    self._data = loader.mapBinary(self._raw_data)
-                    self._base_addr = loader.getBaseAddress(self._raw_data)
-                    self._bitness = loader.getBitness(self._raw_data)
-                    self._code_areas = loader.getCodeAreas(self._raw_data)
-                    self._architecture = loader.getArchitecture(self._raw_data)
-                    self._abi = loader.getAbi(self._raw_data)
+                    # PE/ELF/MachO loaders expose parseBinary() so we can
+                    # share a single lief.parse(...) across every accessor
+                    # and skip multiple redundant re-parses per binary
+                    # load. Delphi/Dex loaders don't need lief, so kw
+                    # stays empty for them.
+                    kw = {"parsed": loader.parseBinary(self._raw_data)} if hasattr(loader, "parseBinary") else {}
+                    self._data = loader.mapBinary(self._raw_data, **kw)
+                    self._base_addr = loader.getBaseAddress(self._raw_data, **kw)
+                    self._bitness = loader.getBitness(self._raw_data, **kw)
+                    self._code_areas = loader.getCodeAreas(self._raw_data, **kw)
+                    self._architecture = loader.getArchitecture(self._raw_data, **kw)
+                    self._abi = loader.getAbi(self._raw_data, **kw)
                     break
         else:
             self._data = self._raw_data

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     LOGGER.warning("LIEF not available, will not be able to parse data from MachO files.")
 
+# Sentinel: distinguishes "caller did not supply parsed" (legacy direct
+# call, do your own lief.parse) from "caller already tried to parse and
+# got None" (e.g. FileLoader saw lief.parse fail; do NOT retry).
+_NOT_PROVIDED = object()
+
 
 def align(v, alignment):
     remainder = v % alignment
@@ -36,8 +41,8 @@ class MachoFileLoader:
         return lief.parse(binary)
 
     @staticmethod
-    def getBaseAddress(binary, parsed=None):
-        macho_file = parsed if parsed is not None else lief.parse(binary)
+    def getBaseAddress(binary, parsed=_NOT_PROVIDED):
+        macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         # Determine base address of binary
         #
         base_addr = 0
@@ -52,14 +57,14 @@ class MachoFileLoader:
         return base_addr
 
     @staticmethod
-    def mapBinary(binary, parsed=None):
+    def mapBinary(binary, parsed=_NOT_PROVIDED):
         """
         map the MachO file sections and segments into a contiguous bytearray
         as if into virtual memory with the given base address.
         """
         # MachO needs a file-like object...
         # Attention: for Python 2.x use the cStringIO package for StringIO
-        macho_file = parsed if parsed is not None else lief.parse(binary)
+        macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not macho_file:
             return b""
         base_addr = MachoFileLoader.getBaseAddress(binary, parsed=macho_file)
@@ -167,14 +172,14 @@ class MachoFileLoader:
         return bytes(mapped_binary)
 
     @staticmethod
-    def getAbi(binary, parsed=None):
+    def getAbi(binary, parsed=_NOT_PROVIDED):
         del binary, parsed
         return ""
 
     @staticmethod
-    def getArchitecture(binary, parsed=None):
+    def getArchitecture(binary, parsed=_NOT_PROVIDED):
         # TODO add machine types whenever we add more architectures
-        macho_file = parsed if parsed is not None else lief.parse(binary)
+        macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not macho_file:
             return ""
         machine_type = macho_file.header.cpu_type
@@ -191,9 +196,9 @@ class MachoFileLoader:
         raise NotImplementedError("SMDA does not support this architecture yet.")
 
     @staticmethod
-    def getBitness(binary, parsed=None):
+    def getBitness(binary, parsed=_NOT_PROVIDED):
         # TODO add machine types whenever we add more architectures
-        macho_file = parsed if parsed is not None else lief.parse(binary)
+        macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not macho_file:
             return 0
         machine_type = macho_file.header.cpu_type
@@ -223,9 +228,9 @@ class MachoFileLoader:
         return merged_code_areas
 
     @staticmethod
-    def getCodeAreas(binary, parsed=None):
+    def getCodeAreas(binary, parsed=_NOT_PROVIDED):
         # TODO add machine types whenever we add more architectures
-        macho_file = parsed if parsed is not None else lief.parse(binary)
+        macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not macho_file:
             return []
         ins_flags = (

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -124,7 +124,10 @@ class MachoFileLoader:
                 rva + segment.file_size,
                 segment.virtual_address,
             )
-            assert len(segment.content) == segment.file_size
+            if len(segment.content) != segment.file_size:
+                raise ValueError(
+                    f"Segment content size mismatch: expected {segment.file_size}, got {len(segment.content)}"
+                )
             mapped_binary[rva : rva + segment.file_size] = segment.content
 
         # map sections.

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -30,9 +30,14 @@ class MachoFileLoader:
         return data[:4] == b"\xce\xfa\xed\xfe" or data[:4] == b"\xcf\xfa\xed\xfe"
 
     @staticmethod
-    def getBaseAddress(binary, macho_file=None):
-        if macho_file is None:
-            macho_file = lief.parse(binary)
+    def parseBinary(binary):
+        # Single lief.parse entry point so FileLoader can share one parse
+        # across all accessors instead of each accessor re-parsing.
+        return lief.parse(binary)
+
+    @staticmethod
+    def getBaseAddress(binary, parsed=None):
+        macho_file = parsed if parsed is not None else lief.parse(binary)
         # Determine base address of binary
         #
         base_addr = 0
@@ -47,17 +52,17 @@ class MachoFileLoader:
         return base_addr
 
     @staticmethod
-    def mapBinary(binary):
+    def mapBinary(binary, parsed=None):
         """
         map the MachO file sections and segments into a contiguous bytearray
         as if into virtual memory with the given base address.
         """
         # MachO needs a file-like object...
         # Attention: for Python 2.x use the cStringIO package for StringIO
-        macho_file = lief.parse(binary)
+        macho_file = parsed if parsed is not None else lief.parse(binary)
         if not macho_file:
             return b""
-        base_addr = MachoFileLoader.getBaseAddress(binary, macho_file=macho_file)
+        base_addr = MachoFileLoader.getBaseAddress(binary, parsed=macho_file)
 
         LOGGER.debug("MachO: base address: 0x%x", base_addr)
 
@@ -162,13 +167,14 @@ class MachoFileLoader:
         return bytes(mapped_binary)
 
     @staticmethod
-    def getAbi(binary):
+    def getAbi(binary, parsed=None):
+        del binary, parsed
         return ""
 
     @staticmethod
-    def getArchitecture(binary):
+    def getArchitecture(binary, parsed=None):
         # TODO add machine types whenever we add more architectures
-        macho_file = lief.parse(binary)
+        macho_file = parsed if parsed is not None else lief.parse(binary)
         if not macho_file:
             return ""
         machine_type = macho_file.header.cpu_type
@@ -185,9 +191,9 @@ class MachoFileLoader:
         raise NotImplementedError("SMDA does not support this architecture yet.")
 
     @staticmethod
-    def getBitness(binary):
+    def getBitness(binary, parsed=None):
         # TODO add machine types whenever we add more architectures
-        macho_file = lief.parse(binary)
+        macho_file = parsed if parsed is not None else lief.parse(binary)
         if not macho_file:
             return 0
         machine_type = macho_file.header.cpu_type
@@ -217,9 +223,9 @@ class MachoFileLoader:
         return merged_code_areas
 
     @staticmethod
-    def getCodeAreas(binary):
+    def getCodeAreas(binary, parsed=None):
         # TODO add machine types whenever we add more architectures
-        macho_file = lief.parse(binary)
+        macho_file = parsed if parsed is not None else lief.parse(binary)
         if not macho_file:
             return []
         ins_flags = (

--- a/src/smda/utility/PeFileLoader.py
+++ b/src/smda/utility/PeFileLoader.py
@@ -7,6 +7,11 @@ from smda.SmdaConfig import SmdaConfig
 
 LOGGER = logging.getLogger(__name__)
 
+# Sentinel: distinguishes "caller did not supply parsed" (legacy direct
+# call, do your own lief.parse) from "caller already tried to parse and got
+# None" (e.g. FileLoader saw lief.parse fail; do NOT retry).
+_NOT_PROVIDED = object()
+
 
 class PeFileLoader:
     BITNESS_MAP = {0x14C: 32, 0x8664: 64}
@@ -22,7 +27,7 @@ class PeFileLoader:
         return lief.parse(binary)
 
     @staticmethod
-    def mapBinary(binary, parsed=None):
+    def mapBinary(binary, parsed=_NOT_PROVIDED):
         # parsed accepted for API uniformity with ELF/MachO; PE mapping is
         # done via struct.unpack on the raw bytes and never needs lief.
         del parsed
@@ -97,7 +102,7 @@ class PeFileLoader:
         return bytes(mapped_binary)
 
     @staticmethod
-    def getBitness(binary, parsed=None):
+    def getBitness(binary, parsed=_NOT_PROVIDED):
         # parsed accepted for API uniformity; PE bitness is read from the
         # COFF header via struct.unpack.
         del parsed
@@ -108,7 +113,7 @@ class PeFileLoader:
         return PeFileLoader.BITNESS_MAP.get(bitness_id, 0)
 
     @staticmethod
-    def getBaseAddress(binary, parsed=None):
+    def getBaseAddress(binary, parsed=_NOT_PROVIDED):
         # parsed accepted for API uniformity; PE base address comes from the
         # optional header via struct.unpack.
         del parsed
@@ -143,14 +148,14 @@ class PeFileLoader:
         return oep_rva
 
     @staticmethod
-    def getAbi(binary, parsed=None):
+    def getAbi(binary, parsed=_NOT_PROVIDED):
         del binary, parsed
         return ""
 
     @staticmethod
-    def getArchitecture(binary, parsed=None):
+    def getArchitecture(binary, parsed=_NOT_PROVIDED):
         architecture = "intel"
-        pefile = parsed if parsed is not None else lief.parse(binary)
+        pefile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if pefile:
             for d in pefile.data_directories:
                 if d.type == lief.PE.DataDirectory.TYPES.CLR_RUNTIME_HEADER and d.size > 0:
@@ -166,8 +171,8 @@ class PeFileLoader:
         return False
 
     @staticmethod
-    def getCodeAreas(binary, parsed=None):
-        pefile = parsed if parsed is not None else lief.parse(binary)
+    def getCodeAreas(binary, parsed=_NOT_PROVIDED):
+        pefile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         code_areas = []
         base_address = PeFileLoader.getBaseAddress(binary)
         if pefile and pefile.sections:

--- a/src/smda/utility/PeFileLoader.py
+++ b/src/smda/utility/PeFileLoader.py
@@ -16,7 +16,16 @@ class PeFileLoader:
         return data[:2] == b"MZ"
 
     @staticmethod
-    def mapBinary(binary):
+    def parseBinary(binary):
+        # Single lief.parse entry point so FileLoader can share one parse
+        # across all accessors instead of each accessor re-parsing.
+        return lief.parse(binary)
+
+    @staticmethod
+    def mapBinary(binary, parsed=None):
+        # parsed accepted for API uniformity with ELF/MachO; PE mapping is
+        # done via struct.unpack on the raw bytes and never needs lief.
+        del parsed
         # This is a pretty rough implementation but does the job for now
         mapped_binary = bytearray([])
         pe_offset = PeFileLoader.getPeOffset(binary)
@@ -88,7 +97,10 @@ class PeFileLoader:
         return bytes(mapped_binary)
 
     @staticmethod
-    def getBitness(binary):
+    def getBitness(binary, parsed=None):
+        # parsed accepted for API uniformity; PE bitness is read from the
+        # COFF header via struct.unpack.
+        del parsed
         bitness_id = 0
         pe_offset = PeFileLoader.getPeOffset(binary)
         if pe_offset and len(binary) >= pe_offset + 0x6:
@@ -96,7 +108,10 @@ class PeFileLoader:
         return PeFileLoader.BITNESS_MAP.get(bitness_id, 0)
 
     @staticmethod
-    def getBaseAddress(binary):
+    def getBaseAddress(binary, parsed=None):
+        # parsed accepted for API uniformity; PE base address comes from the
+        # optional header via struct.unpack.
+        del parsed
         base_addr = 0
         pe_offset = PeFileLoader.getPeOffset(binary)
         if pe_offset and len(binary) >= pe_offset + 0x38:
@@ -128,13 +143,14 @@ class PeFileLoader:
         return oep_rva
 
     @staticmethod
-    def getAbi(binary):
+    def getAbi(binary, parsed=None):
+        del binary, parsed
         return ""
 
     @staticmethod
-    def getArchitecture(binary):
+    def getArchitecture(binary, parsed=None):
         architecture = "intel"
-        pefile = lief.parse(binary)
+        pefile = parsed if parsed is not None else lief.parse(binary)
         if pefile:
             for d in pefile.data_directories:
                 if d.type == lief.PE.DataDirectory.TYPES.CLR_RUNTIME_HEADER and d.size > 0:
@@ -150,8 +166,8 @@ class PeFileLoader:
         return False
 
     @staticmethod
-    def getCodeAreas(binary):
-        pefile = lief.parse(binary)
+    def getCodeAreas(binary, parsed=None):
+        pefile = parsed if parsed is not None else lief.parse(binary)
         code_areas = []
         base_address = PeFileLoader.getBaseAddress(binary)
         if pefile and pefile.sections:

--- a/src/smda/utility/PeFileLoader.py
+++ b/src/smda/utility/PeFileLoader.py
@@ -28,8 +28,6 @@ class PeFileLoader:
 
     @staticmethod
     def mapBinary(binary, parsed=_NOT_PROVIDED):
-        # parsed accepted for API uniformity with ELF/MachO; PE mapping is
-        # done via struct.unpack on the raw bytes and never needs lief.
         del parsed
         # This is a pretty rough implementation but does the job for now
         mapped_binary = bytearray([])
@@ -103,8 +101,6 @@ class PeFileLoader:
 
     @staticmethod
     def getBitness(binary, parsed=_NOT_PROVIDED):
-        # parsed accepted for API uniformity; PE bitness is read from the
-        # COFF header via struct.unpack.
         del parsed
         bitness_id = 0
         pe_offset = PeFileLoader.getPeOffset(binary)
@@ -114,8 +110,6 @@ class PeFileLoader:
 
     @staticmethod
     def getBaseAddress(binary, parsed=_NOT_PROVIDED):
-        # parsed accepted for API uniformity; PE base address comes from the
-        # optional header via struct.unpack.
         del parsed
         base_addr = 0
         pe_offset = PeFileLoader.getPeOffset(binary)

--- a/src/smda/utility/PriorityQueue.py
+++ b/src/smda/utility/PriorityQueue.py
@@ -1,11 +1,19 @@
 import heapq
 
 
+class _MaxHeapItem:
+    def __init__(self, element):
+        self.element = element
+
+    def __lt__(self, other):
+        return other.element < self.element
+
+
 class PriorityQueue:
     def __init__(self, content=None):
         if content is None:
             content = []
-        self.heap = content
+        self.heap = [_MaxHeapItem(element) for element in content]
         if self.heap:
             self.update()
 
@@ -18,21 +26,13 @@ class PriorityQueue:
     def next(self):
         if not self.heap:
             raise StopIteration
-        if len(self.heap) == 1:
-            return self.heap.pop()
-        last_item = self.heap.pop()
-        result = self.heap[0]
-        self.heap[0] = last_item
-        heapq._siftup_max(self.heap, 0)
-        return result
+        return heapq.heappop(self.heap).element
 
     def add(self, element):
-        self.heap.append(element)
-        heapq._siftdown_max(self.heap, 0, len(self.heap) - 1)
+        heapq.heappush(self.heap, _MaxHeapItem(element))
 
     def update(self, target_candidate=None):
-        if target_candidate is None:
-            heapq._heapify_max(self.heap)
+        heapq.heapify(self.heap)
 
     def __str__(self):
-        return str(self.heap)
+        return str([item.element for item in self.heap])

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -3,6 +3,7 @@ import struct
 from typing import Iterator, Tuple
 
 from smda.common import SmdaFunction
+from smda.common.ExceptionHandling import reraise_non_operational_exception
 
 _IS_PRINTABLE_CHAR_CODE = tuple(chr(char) in string.printable for char in range(256))
 
@@ -162,8 +163,8 @@ def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int]]:
                                         data_ref,
                                         string_type,
                                     )
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            reraise_non_operational_exception(exc)
                 if not found_string:
                     string_result = read_go_string(f.smda_report, data_ref)
                     if string_result:

--- a/tests/testBitnessAnalyzer.py
+++ b/tests/testBitnessAnalyzer.py
@@ -1,0 +1,30 @@
+import re
+import struct
+import unittest
+from unittest import mock
+
+from smda.intel.BitnessAnalyzer import BitnessAnalyzer
+
+
+class TestBitnessAnalyzer(unittest.TestCase):
+    def test_determine_bitness_scans_call_opcodes_once(self):
+        binary = bytearray(16)
+        binary[0] = 0xE8
+        binary[1:5] = struct.pack("i", 5)
+        binary[10] = 0x48
+        original_finditer = re.finditer
+        finditer_calls = []
+
+        def counting_finditer(pattern, subject):
+            finditer_calls.append((pattern, subject))
+            return original_finditer(pattern, subject)
+
+        with mock.patch("smda.intel.BitnessAnalyzer.re.finditer", side_effect=counting_finditer):
+            bitness = BitnessAnalyzer().determineBitness(bytes(binary))
+
+        self.assertEqual(bitness, 64)
+        self.assertEqual(finditer_calls, [(b"\xe8", bytes(binary))])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testBracketQueue.py
+++ b/tests/testBracketQueue.py
@@ -6,6 +6,7 @@ import unittest
 from smda.common.BinaryInfo import BinaryInfo
 from smda.intel.FunctionCandidate import FunctionCandidate
 from smda.utility.BracketQueue import BracketQueue
+from smda.utility.PriorityQueue import PriorityQueue
 
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s %(message)s")
@@ -215,6 +216,19 @@ class BracketQueueTestSuite(unittest.TestCase):
         queue.ensure_order()
         for _index, candidate in enumerate(queue):
             print(candidate)
+
+    def test_priority_queue_uses_public_heap_ordering(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        high.addCallRef(0x100)
+
+        queue = PriorityQueue([low, high])
+
+        self.assertIs(next(queue), high)
+        self.assertIs(next(queue), low)
 
 
 if __name__ == "__main__":

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -1,0 +1,31 @@
+import hashlib
+import struct
+import unittest
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
+from smda.common.SmdaFunction import SmdaFunction
+
+
+class TestCommonModels(unittest.TestCase):
+    def test_empty_basic_block_string_is_safe(self):
+        self.assertEqual(str(SmdaBasicBlock([])), "0x????????: (   0)")
+
+    def test_function_hash_helpers_use_little_endian(self):
+        function = SmdaFunction()
+        function.pic_hash = 0x0102030405060708
+        function.getPicHashSequence = lambda binary_info: b"pic-sequence"
+        function.getOpcHashSequence = lambda: b"opc-sequence"
+
+        self.assertEqual(function.getPicHashAsHex(), struct.pack("<Q", function.pic_hash).hex())
+        self.assertEqual(
+            function.getPicHash(None),
+            struct.unpack("<Q", hashlib.sha256(b"pic-sequence").digest()[:8])[0],
+        )
+        self.assertEqual(
+            function.getOpcHash(),
+            struct.unpack("<Q", hashlib.sha256(b"opc-sequence").digest()[:8])[0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -11,7 +11,13 @@ import unittest
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaFunction import SmdaFunction
 from smda.common.SmdaReport import SmdaReport
-from smda.dalvik.DalvikOpcodeDecoder import decode_instruction, parse_code_item_header, read_sleb128, read_uleb128
+from smda.dalvik.DalvikOpcodeDecoder import (
+    OPCODES,
+    decode_instruction,
+    parse_code_item_header,
+    read_sleb128,
+    read_uleb128,
+)
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.utility.DexFileLoader import DexFileLoader
@@ -386,6 +392,79 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         decoded_array = decode_instruction(fill_array, 0, DummyResolver())
         self.assertEqual(decoded_array.mnemonic, "fill-array-data")
         self.assertEqual(decoded_array.payload_idx, 4)
+
+    def testThrowableOpcodeMetadataFeedsExceptionEdges(self):
+        from smda.dalvik.DalvikDisassembler import DalvikDisassembler
+
+        disassembler = DalvikDisassembler(config)
+        by_mnemonic = {spec.mnemonic: opcode for opcode, spec in OPCODES.items()}
+
+        throwable_mnemonics = [
+            "sget",
+            "sget-wide",
+            "sget-object",
+            "sget-boolean",
+            "sget-byte",
+            "sget-char",
+            "sget-short",
+            "sput",
+            "sput-wide",
+            "sput-object",
+            "sput-boolean",
+            "sput-byte",
+            "sput-char",
+            "sput-short",
+            "div-int",
+            "rem-int",
+            "div-long",
+            "rem-long",
+            "div-int/2addr",
+            "rem-int/2addr",
+            "div-long/2addr",
+            "rem-long/2addr",
+            "div-int/lit16",
+            "rem-int/lit16",
+            "div-int/lit8",
+            "rem-int/lit8",
+        ]
+        for mnemonic in throwable_mnemonics:
+            with self.subTest(mnemonic=mnemonic):
+                opcode = by_mnemonic[mnemonic]
+                decoded = decode_instruction(
+                    bytes([opcode]) + b"\x00" * (OPCODES[opcode].size_units * 2 - 1), 0, DummyResolver()
+                )
+                self.assertTrue(decoded.can_throw)
+                self.assertTrue(disassembler._instructionCanThrow(decoded))
+
+        non_throwing_mnemonics = ["add-int", "mul-int", "add-long", "div-float", "rem-double", "shl-int/lit8"]
+        for mnemonic in non_throwing_mnemonics:
+            with self.subTest(mnemonic=mnemonic):
+                opcode = by_mnemonic[mnemonic]
+                decoded = decode_instruction(
+                    bytes([opcode]) + b"\x00" * (OPCODES[opcode].size_units * 2 - 1), 0, DummyResolver()
+                )
+                self.assertFalse(decoded.can_throw)
+                self.assertFalse(disassembler._instructionCanThrow(decoded))
+
+    def testThrowableFieldAndIntegerDivideOpcodesAddExceptionEdges(self):
+        cases = [
+            ("sget", bytes.fromhex("60000000")),
+            ("div-int", bytes.fromhex("93000102")),
+            ("div-int/2addr", bytes.fromhex("b300")),
+            ("div-int/lit8", bytes.fromhex("db000001")),
+        ]
+        for mnemonic, protected_instruction in cases:
+            with self.subTest(mnemonic=mnemonic):
+                handler_addr_units = len(protected_instruction) // 2 + 1
+                code_item = build_code_item(
+                    protected_instruction + bytes.fromhex("0e000d010e00"),
+                    tries=[(0, len(protected_instruction) // 2, 1)],
+                    handlers_blob=bytes([1, 0, handler_addr_units]),
+                )
+                disassembly, func_addr = self._analyzeSyntheticMethod(code_item)
+                handler_addr = func_addr + handler_addr_units * 2
+
+                self.assertIn(handler_addr, disassembly.code_refs_from[func_addr])
 
     def testDisassembleBufferDexAutodetect(self):
         generic_disasm = Disassembler(config)

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -473,16 +473,11 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         self.assertEqual(report.bitness, 32)
         self.assertGreater(report.num_functions, 2000)
 
-    def testDisassembleBufferIntelOnDexAutodetectsDalvik(self):
-        # Pinning the contract: an explicit architecture="intel" on DEX bytes
-        # is overridden by magic-byte autodetection rather than producing
-        # garbage Intel disassembly. If the autodetect ever becomes opt-in,
-        # this test must be updated to assert error/empty Intel output instead.
+    def testDisassembleBufferExplicitIntelBackendPreservedForDexBytes(self):
         intel_disasm = Disassembler(config, backend="intel")
         report = intel_disasm.disassembleBuffer(self.dex_binary, base_addr=0, architecture="intel")
-        self.assertEqual(report.architecture, "dalvik")
+        self.assertEqual(report.architecture, "intel")
         self.assertEqual(report.bitness, 32)
-        self.assertGreater(report.num_functions, 2000)
 
     def testAnalyzeScriptRawDexAvoidsBaseAddrAndOepWarnings(self):
         result = subprocess.run(

--- a/tests/testExceptionHandling.py
+++ b/tests/testExceptionHandling.py
@@ -1,0 +1,131 @@
+import ast
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+from smda.Disassembler import Disassembler
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SMDA_ROOT = PROJECT_ROOT / "src" / "smda"
+
+
+class ExceptionHandlingTestSuite(unittest.TestCase):
+    operational_exceptions = (
+        FileNotFoundError("missing input"),
+        RuntimeError("backend failed"),
+        ValueError("malformed input"),
+    )
+
+    non_operational_exceptions = (
+        AssertionError("broken invariant"),
+        GeneratorExit("generator closed"),
+        ImportError("dependency import failed"),
+        KeyboardInterrupt("interrupted"),
+        MemoryError("out of memory"),
+        NameError("missing name"),
+        ReferenceError("lost weak reference"),
+        SyntaxError("invalid generated code"),
+        SystemExit("exiting"),
+    )
+
+    def _call_disassemble_buffer(self, disasm):
+        return disasm.disassembleBuffer(b"dummy_content", 0x1000)
+
+    def _call_disassemble_unmapped_buffer(self, disasm):
+        return disasm.disassembleUnmappedBuffer(b"dummy_content")
+
+    def _call_disassemble_file(self, disasm):
+        with patch("smda.Disassembler.FileLoader") as mock_loader_class:
+            mock_loader_class.return_value = MagicMock()
+            disasm._populateBinaryInfo = MagicMock(
+                return_value=SimpleNamespace(architecture="intel", binary=b"dummy_content")
+            )
+            disasm.initDisassembler = MagicMock()
+            disasm.disassembler = MagicMock()
+            return disasm.disassembleFile("dummy_path")
+
+    def _entry_points(self):
+        return (
+            ("disassembleBuffer", self._call_disassemble_buffer),
+            ("disassembleUnmappedBuffer", self._call_disassemble_unmapped_buffer),
+            ("disassembleFile", self._call_disassemble_file),
+        )
+
+    def test_operational_exceptions_return_error_reports(self):
+        for entry_point_name, call_entry_point in self._entry_points():
+            for exception in self.operational_exceptions:
+                with self.subTest(entry_point=entry_point_name, exception=exception.__class__.__name__):
+                    disasm = Disassembler()
+                    disasm._disassemble = MagicMock(side_effect=exception)
+
+                    report = call_entry_point(disasm)
+
+                    self.assertEqual(report.status, "error")
+                    self.assertIn(exception.__class__.__name__, report.message)
+
+    def test_missing_input_file_returns_error_report(self):
+        with patch("smda.Disassembler.FileLoader", side_effect=FileNotFoundError("missing input")):
+            report = Disassembler().disassembleFile("non_existent_file.bin")
+
+        self.assertEqual(report.status, "error")
+        self.assertIn("FileNotFoundError", report.message)
+
+    def test_non_operational_exceptions_bubble_up(self):
+        for entry_point_name, call_entry_point in self._entry_points():
+            for exception in self.non_operational_exceptions:
+                with self.subTest(entry_point=entry_point_name, exception=exception.__class__.__name__):
+                    disasm = Disassembler()
+                    disasm._disassemble = MagicMock(side_effect=exception)
+
+                    with self.assertRaises(exception.__class__):
+                        call_entry_point(disasm)
+
+    def test_non_operational_helper_reraises_current_exception(self):
+        try:
+            raise NameError("missing name")
+        except Exception as exc:
+            with self.assertRaises(NameError):
+                reraise_non_operational_exception(exc)
+
+    def test_all_broad_exception_handlers_reraise_non_operational_exceptions(self):
+        offenders = []
+        for path in sorted(SMDA_ROOT.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Try):
+                    continue
+                for handler in node.handlers:
+                    if not self._is_broad_exception_handler(handler):
+                        continue
+                    call_names = self._get_handler_call_names(handler)
+                    if not {
+                        "reraise_non_operational_exception",
+                        "_handleDisassemblyException",
+                    }.intersection(call_names):
+                        offenders.append(f"{path.relative_to(PROJECT_ROOT)}:{handler.lineno}")
+
+        self.assertEqual([], offenders)
+
+    def _is_broad_exception_handler(self, handler):
+        if isinstance(handler.type, ast.Name):
+            return handler.type.id == "Exception"
+        if isinstance(handler.type, ast.Tuple):
+            return any(isinstance(elt, ast.Name) and elt.id == "Exception" for elt in handler.type.elts)
+        return False
+
+    def _get_handler_call_names(self, handler):
+        call_names = set()
+        for node in ast.walk(ast.Module(body=handler.body, type_ignores=[])):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name):
+                call_names.add(node.func.id)
+            elif isinstance(node.func, ast.Attribute):
+                call_names.add(node.func.attr)
+        return call_names
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -3,11 +3,19 @@
 import logging
 import os
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import lief
 
+from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider.ElfApiResolver import ElfApiResolver
+from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
+from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
 from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
 from smda.utility.FileLoader import FileLoader
 
 from .context import config
@@ -136,6 +144,65 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         disasm._disassemble(binary_info)
         komplex_unmapped_disassembly = disasm.disassembleUnmappedBuffer(komplex_binary)
         self.assertEqual(komplex_unmapped_disassembly.num_functions, 211)
+
+    def test_binary_info_and_file_loader_do_not_share_code_areas(self):
+        first_binary = BinaryInfo(b"a")
+        second_binary = BinaryInfo(b"b")
+        first_binary.code_areas.append([1, 2])
+
+        first_loader = FileLoader("/", load_file=False)
+        second_loader = FileLoader("/", load_file=False)
+        first_loader.getCodeAreas().append([3, 4])
+
+        self.assertEqual(second_binary.code_areas, [])
+        self.assertEqual(second_loader.getCodeAreas(), [])
+
+    def test_pe_symbol_provider_returns_empty_mapping_without_code_section(self):
+        symbol_provider = PeSymbolProvider(None)
+        lief_binary = SimpleNamespace(sections=[], symbols=[])
+
+        self.assertEqual(symbol_provider.parseSymbols(lief_binary), {})
+
+    def test_go_pclntab_offset_returns_numeric_zero(self):
+        provider = GoSymbolProvider(None)
+        pclntab = b"\x00\xff\xff\xff\x00\x00\x01\x04"
+
+        self.assertEqual(provider.getPcLntabOffset(pclntab), 0)
+
+    def test_cil_disassembler_accepts_missing_timeout_callback(self):
+        binary_info = BinaryInfo(b"MZ")
+        fake_pe = SimpleNamespace(net=SimpleNamespace(mdtables=SimpleNamespace(MethodDef=[])))
+
+        with mock.patch("smda.cil.CilDisassembler.dnfile.dnPE", return_value=fake_pe):
+            result = CilDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertFalse(result.analysis_timeout)
+
+    def test_cil_jmp_records_edge_without_aborting_function_analysis(self):
+        class FakeInstruction:
+            offset = 0x1000
+            opcode = "jmp"
+            operand = object()
+
+            def get_bytes(self):
+                return b"\x27\x00"
+
+        disassembler = CilDisassembler(SmdaConfig())
+        disassembler.disassembly = DisassemblyResult()
+        method_body = SimpleNamespace(offset=0x1000, instructions=[FakeInstruction()])
+
+        with mock.patch("smda.cil.CilDisassembler.format_operand", return_value="0x2000"):
+            state = disassembler.analyzeFunction(None, method_body.offset, method_body)
+
+        self.assertEqual(state.code_refs_from[0x1000], {0x2000})
+        self.assertIn(0x1000, disassembler.disassembly.functions)
+
+    def test_elf_api_resolver_uses_relocation_slot_address(self):
+        resolver = ElfApiResolver(None)
+        resolver._api_map["lief"][0x4018] = ("GLIBC_2.2.5", "puts")
+
+        self.assertEqual(resolver.getApi(0x4018, absolute_addr=0x1000), ("GLIBC_2.2.5", "puts"))
+        self.assertEqual(resolver.getApi(0x1000, absolute_addr=0x4018), (None, None))
 
 
 if __name__ == "__main__":

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -10,6 +10,7 @@ import lief
 
 from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider.CilSymbolProvider import CilSymbolProvider
 from smda.common.labelprovider.ElfApiResolver import ElfApiResolver
 from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
 from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
@@ -203,6 +204,18 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
 
         self.assertEqual(resolver.getApi(0x4018, absolute_addr=0x1000), ("GLIBC_2.2.5", "puts"))
         self.assertEqual(resolver.getApi(0x1000, absolute_addr=0x4018), (None, None))
+
+    def test_cil_symbol_provider_clears_symbols_before_parse(self):
+        provider = CilSymbolProvider(None)
+        provider._addr_to_func_symbols[0x1000] = "stale"
+        provider._func_symbol_to_addr["stale"] = 0x1000
+        binary_info = BinaryInfo(b"not a dotnet file")
+
+        with mock.patch("smda.common.labelprovider.CilSymbolProvider.dnfile.dnPE", side_effect=ValueError("bad pe")):
+            provider.update(binary_info)
+
+        self.assertEqual(provider.getFunctionSymbols(), {})
+        self.assertIsNone(provider.getAddress("stale"))
 
 
 if __name__ == "__main__":

--- a/tests/testIntegration.py
+++ b/tests/testIntegration.py
@@ -5,9 +5,11 @@ import os
 import unittest
 
 from smda.common.BinaryInfo import BinaryInfo
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.SmdaFunction import SmdaFunction
 from smda.common.SmdaReport import SmdaReport
 from smda.Disassembler import Disassembler
+from smda.DisassemblyStatistics import DisassemblyStatistics
 from smda.utility.FileLoader import FileLoader
 
 from .context import config
@@ -145,6 +147,48 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         found_block = self.asprox_disassembly.findBlockByContainedAddress(0xFFFFFF00)
         assert found_function is None
         assert found_block is None
+
+    def test_smda_basic_block_from_dict_initializes_fields(self):
+        block = SmdaBasicBlock.fromDict([[0x401000, "90", "nop", ""]])
+
+        self.assertEqual(block.offset, 0x401000)
+        self.assertEqual(block.length, 1)
+        self.assertEqual(block.toDict(), [[0x401000, "90", "nop", ""]])
+        self.assertEqual(list(SmdaBasicBlock([]).getInstructions()), [])
+
+    def test_statistics_add_is_pure_and_iadd_mutates(self):
+        left = DisassemblyStatistics.fromDict(
+            {
+                "num_functions": 1,
+                "num_recursive_functions": 2,
+                "num_leaf_functions": 3,
+                "num_basic_blocks": 4,
+                "num_instructions": 5,
+                "num_api_calls": 6,
+                "num_function_calls": 7,
+                "num_failed_functions": 8,
+                "num_failed_instructions": 9,
+            }
+        )
+        right = DisassemblyStatistics.fromDict(
+            {
+                "num_functions": 10,
+                "num_recursive_functions": 20,
+                "num_leaf_functions": 30,
+                "num_basic_blocks": 40,
+                "num_instructions": 50,
+                "num_api_calls": 60,
+                "num_function_calls": 70,
+                "num_failed_functions": 80,
+                "num_failed_instructions": 90,
+            }
+        )
+
+        total = left + right
+        self.assertEqual(left.num_functions, 1)
+        self.assertEqual(total.num_functions, 11)
+        left += right
+        self.assertEqual(left.num_failed_instructions, 99)
 
 
 if __name__ == "__main__":

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -1,6 +1,12 @@
 import unittest
+from types import SimpleNamespace
 
+from smda.common.BinaryInfo import BinaryInfo
+from smda.intel.FunctionCandidate import FunctionCandidate
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.intel.IntelDisassembler import IntelDisassembler
+from smda.intel.MnemonicTfIdf import MnemonicTfIdf
+from smda.SmdaConfig import SmdaConfig
 
 
 class DummyProvider:
@@ -66,6 +72,39 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertEqual(disassembler.resolveApi(0x401000, 0x500000), ("kernel32.dll", "CreateFileA"))
         self.assertEqual(disassembler.resolveSymbol(0x401100), "handler")
         self.assertEqual(set(disassembler.getSymbolCandidates()), {0x401000, 0x401100})
+
+    def test_function_candidate_alignment_and_empty_tfidf_are_safe(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+
+        candidate = FunctionCandidate(binary_info, 0x10)
+
+        self.assertEqual(candidate.alignment, 16)
+        self.assertIsNone(candidate.getTfIdf())
+
+    def test_mnemonic_tfidf_empty_counts_returns_zero(self):
+        self.assertEqual(MnemonicTfIdf().tfidf({}), 0.0)
+
+    def test_pointer_reference_uses_byte_prefixes(self):
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 64
+        manager.disassembly = SimpleNamespace(
+            binary_info=SimpleNamespace(base_addr=0x1000),
+            getRawBytes=lambda offset, size: b"\xff\x25" if size == 2 else (1).to_bytes(4, "little", signed=True),
+        )
+
+        self.assertEqual(manager.resolvePointerReference(0x20), 0x1028)
+
+    def test_accepts_missing_timeout_callback(self):
+        binary_info = BinaryInfo(b"\x90\xc3")
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertFalse(result.analysis_timeout)
 
 
 if __name__ == "__main__":

--- a/tests/testLanguageAnalyzer.py
+++ b/tests/testLanguageAnalyzer.py
@@ -1,0 +1,40 @@
+import re
+import unittest
+from unittest import mock
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.intel.LanguageAnalyzer import LanguageAnalyzer
+
+
+class _DummyDisassembly:
+    def __init__(self, binary, functions=None):
+        self.binary_info = BinaryInfo(binary)
+        self.functions = functions or {}
+
+    def getRawBytes(self, start, size):
+        return self.binary_info.binary[start : start + size]
+
+
+class TestLanguageAnalyzer(unittest.TestCase):
+    def test_identify_reuses_thiscall_pattern_counts(self):
+        binary = b"\x00" * 0x80 + b"\x8b\x4d\x04\xe8\x01\x02\x03\x00" + b"\x00" * 8 + b"\x8b\xc8\xe8\x04\x05\x06\xff"
+        analyzer = LanguageAnalyzer(_DummyDisassembly(binary, functions=dict.fromkeys(range(24))))
+        original_findall = re.findall
+        findall_calls = []
+
+        def counting_findall(pattern, subject):
+            findall_calls.append((pattern, subject))
+            return original_findall(pattern, subject)
+
+        with mock.patch("smda.intel.LanguageAnalyzer.re.findall", side_effect=counting_findall):
+            result = analyzer.identify()
+
+        self.assertEqual(result["_count_thiscalls"], 2)
+        self.assertEqual(result["c++"], 0.5)
+        self.assertEqual(len(findall_calls), 2)
+        self.assertEqual(len({call[0] for call in findall_calls}), 2)
+        self.assertTrue(all(call[1] == binary for call in findall_calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testLanguageAnalyzer.py
+++ b/tests/testLanguageAnalyzer.py
@@ -35,6 +35,18 @@ class TestLanguageAnalyzer(unittest.TestCase):
         self.assertEqual(len({call[0] for call in findall_calls}), 2)
         self.assertTrue(all(call[1] == binary for call in findall_calls))
 
+    def test_uses_bytes_for_pe_and_language_markers(self):
+        binary = bytearray(b"MZ" + b"\x00" * 0x100)
+        binary[0x3C:0x40] = (0x80).to_bytes(4, "little")
+        binary[0x80:0x82] = b"PE"
+        binary.extend(b"MSVBVM60.DLL\x00mscorelib.dll\x00Borland\\locales\x00")
+        analyzer = LanguageAnalyzer(_DummyDisassembly(bytes(binary)))
+
+        self.assertTrue(analyzer.validPEHeader())
+        self.assertEqual(analyzer.getVisualBasicScore(), 0.5)
+        self.assertGreaterEqual(analyzer.getDotNetScore(), 0.35)
+        self.assertEqual(analyzer.getDelphiScore(), 0.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -1,14 +1,17 @@
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.labelprovider.ElfSymbolProvider import ElfSymbolProvider
 from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
 from smda.common.labelprovider.rust_demangler import demangle
 from smda.common.labelprovider.rust_demangler.rust import TypeNotFoundError
+from smda.common.labelprovider.rust_demangler.rust_legacy import LegacyDemangler, UnableToLegacyDemangle
 from smda.common.labelprovider.rust_demangler.rust_v0 import (
     Printer,
     UnableTov0Demangle,
+    V0Demangler,
 )
 from smda.common.labelprovider.rust_demangler.utils import remove_bad_spaces
 from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
@@ -150,6 +153,38 @@ class TestRustDemangler(unittest.TestCase):
             results = list(executor.map(demangle, symbols * 5))
 
         self.assertEqual(results, expected * 5)
+
+    def test_malformed_inputs_raise_demangle_errors(self):
+        """Malformed Rust symbols should use demangler error types."""
+
+        with self.assertRaises(UnableToLegacyDemangle):
+            LegacyDemangler().demangle("_Z3fooE")
+        with self.assertRaises(UnableToLegacyDemangle):
+            LegacyDemangler().demangle("_ZN3$u$E")
+        with self.assertRaises(UnableTov0Demangle):
+            V0Demangler().demangle("_NvC3foo")
+        with self.assertRaises(UnableTov0Demangle):
+            V0Demangler().demangle("_RNvC3fooKc110000")
+
+    def test_v0_backref_path_updates_parent_printer_output(self):
+        """Backref path printers should copy string output back to the caller."""
+
+        class FakeParser:
+            def eat(self, token):
+                return token == "B"
+
+        class FakeBackrefPrinter:
+            out = "prefix::Backref"
+
+            def print_path_maybe_open_generics(self):
+                return True
+
+        printer = Printer(FakeParser(), "prefix::", bound=0)
+
+        with mock.patch.object(printer, "backref_printer", return_value=FakeBackrefPrinter()):
+            self.assertTrue(printer.print_path_maybe_open_generics())
+
+        self.assertEqual(printer.out, "prefix::Backref")
 
 
 class TestRustSymbolProvider(unittest.TestCase):


### PR DESCRIPTION
## Branch and base
Branch: claude/perf-sweep-20260527-predecessors-index
Commit: 4fa0331
Base: master (c1227d7)

## Optimization class
OC-6 — getPredecessors-O(n²)

## Root cause
`SmdaBasicBlock.getPredecessors()` found incoming edges by scanning the full forward adjacency dict (`blockrefs: {frm -> [to, ...]}`) on every call:

```python
for frm, to in self.smda_function.blockrefs.items():
    if self.offset in to:
        predecessors.append(frm)
```

Calling this for all N blocks in a function costs **O(N × E)** total (E = edge count), degrading to O(N²) for dense CFGs. By contrast, `getSuccessors()` already does an O(1) direct key lookup.

## Change
Add `_blockrefs_reverse = None` sentinel on `SmdaFunction`. On the first `getPredecessors()` call for any block in a function, build `{to: [frm, ...]}` in O(E) and cache it on the function. All subsequent calls are O(1) dict lookups. Return contract preserved: a fresh list copy is returned each call.

`blockrefs` is finalized during construction (`__init__` or `fromDict`) before any `SmdaBasicBlock` is accessible, so the lazy index is always built on the final edge set.

## Before / after evidence
Targeted tests (testIntegration + testIntelDisassembler, 16 tests):

```
baseline:  16 passed in 1.05s
after:     16 passed in 1.01s
```

The full benefit is only visible when `getPredecessors()` is called for all or many blocks in a function (e.g. dominator-tree computation, graph visualization). Each function's index is built once; all blocks in that function reuse it.

## Behavior compatibility
Reviewer subagent returned **PASS**. Key confirmations:
- `rev.get(self.offset, [])` returns exactly the same `frm` addresses as the old linear scan. ✓
- `list(...)` return preserves the fresh-list-per-call contract. ✓
- `smda_function is None` early-return preserved. ✓
- Index cannot be built before `blockrefs` is finalized (no `SmdaBasicBlock` exists during construction). ✓
- Benign race under concurrent construction (identical dicts, no corruption) — SMDA is single-threaded. ✓

## Validation commands
```
make lint && make test   # 111 passed
```

## Residual risk
None under single-threaded use. Benign under hypothetical concurrent construction (same dict built twice, last write wins).