### PR TITLE
perf(intel): optimize disassembly hot path (hex encoding, set ops, predecessor index)

### DIFF
--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -107,8 +107,7 @@ class DisassemblyResult:
 
     def _transformInstruction(self, ins_tuple):
         ins_addr, _, ins_mnem, ins_ops, ins_raw_bytes = ins_tuple
-        # python3  and python2 do handling differently...
-        ins_hexbytes = "".join([f"{c:02x}" for c in ins_tuple[4]])
+        ins_hexbytes = ins_raw_bytes.hex()
         return [ins_addr, ins_hexbytes, str(ins_mnem), str(ins_ops)]
 
     def getBlocksAsDict(self, function_addr):

--- a/src/smda/intel/FunctionAnalysisState.py
+++ b/src/smda/intel/FunctionAnalysisState.py
@@ -62,14 +62,13 @@ class FunctionAnalysisState:
         self._instructions_sorted = False
         self.instruction_start_bytes.add(ins[0])
         self.current_block.append(ins)
-        for byte in range(i_size):
-            self.processed_bytes.add(i_address + byte)
+        self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:
             self.addCodeRef(i_address, i_address + i_size, self.is_jmp)
         self.is_jmp = False
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
-        self.code_refs.update([(addr_from, addr_to)])
+        self.code_refs.add((addr_from, addr_to))
         refs_from = self.code_refs_from.get(addr_from, set())
         refs_from.update([addr_to])
         self.code_refs_from[addr_from] = refs_from

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -201,7 +201,8 @@ class IndirectCallAnalyzer:
             processed_addrs = frozenset(ins[0] for blk in processed for ins in blk)
             # Use the reverse index (addr_to -> {addr_from}) maintained by
             # add/removeCodeRef instead of scanning the full code_refs set per block.
-            refs_in = [fr for fr in analysis_state.code_refs_to.get(block[0][0], set()) if fr not in processed_addrs]
+            # Default to () (cached singleton, no allocation) since we only iterate it.
+            refs_in = [fr for fr in analysis_state.code_refs_to.get(block[0][0], ()) if fr not in processed_addrs]
             LOGGER.debug(
                 "start processing previous blocks, searching in %d in_refs with remaining depth: %d",
                 len(refs_in),

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -199,7 +199,9 @@ class IndirectCallAnalyzer:
         # process previous blocks
         if depth >= 0:
             processed_addrs = frozenset(ins[0] for blk in processed for ins in blk)
-            refs_in = [fr for (fr, to) in analysis_state.code_refs if to == block[0][0] and fr not in processed_addrs]
+            # Use the reverse index (addr_to -> {addr_from}) maintained by
+            # add/removeCodeRef instead of scanning the full code_refs set per block.
+            refs_in = [fr for fr in analysis_state.code_refs_to.get(block[0][0], set()) if fr not in processed_addrs]
             LOGGER.debug(
                 "start processing previous blocks, searching in %d in_refs with remaining depth: %d",
                 len(refs_in),


### PR DESCRIPTION
## Summary

Four targeted hot-path optimizations on the intel disassembly + report path, found by profiling the `asprox` fixture with the new `profiling/` toolkit. The profile showed SMDA is **~90% Python-bound, ~10% Capstone** — i.e. real headroom in our own code.

| # | Change | File | Win |
|---|--------|------|-----|
| 1 | `bytes.hex()` instead of `"".join([f"{c:02x}" ...])` | `DisassemblyResult._transformInstruction` | ~0.22s tottime + **largest allocator (~1.1M allocs)** removed |
| 2 | Resolve predecessors via existing `code_refs_to` reverse index instead of O(\|code_refs\|) scan per block | `IndirectCallAnalyzer.processBlock` | de-quadratifies indirect-call resolution |
| 3 | `set.add((a,b))` instead of `set.update([(a,b)])` | `FunctionAnalysisState.addCodeRef` | ~0.167s tottime (284k calls) |
| 4 | `set.update(range(...))` instead of per-byte `.add()` loop | `FunctionAnalysisState.addInstruction` | removes a Python loop from a hot method |

Net: **3 files, 6 lines changed.**

## Correctness

Changes #1/#3/#4 are byte-identical by construction. #2 is structural (the reverse index already exists and is kept in sync by `add`/`removeCodeRef`), and its only theoretical risk is iteration order feeding the order-sensitive `any()` short-circuit in `processBlock`.

Validated with a **deep per-instruction + per-function apiref fingerprint** of all 7 fixtures, base `master` vs this branch:

```
asprox    funcs=105  instrs=15706  MATCH
bashlite  funcs=177  instrs=8775   MATCH
blockblast funcs=2219 instrs=9824  MATCH
cutwail   funcs=505  instrs=29372  MATCH
komplex   funcs=211  instrs=4914   MATCH
njrat     funcs=64   instrs=8446   MATCH
pe_export funcs=1    instrs=5      MATCH
```

The apiref comparison specifically covers #2's effect on indirect-call resolution — **no divergence**. (A volatile `dnfile` object `repr` in CIL operands was normalized out; it changes every run regardless of this PR.)

## Performance (fixture median, base → this branch)

```
asprox     0.1560s -> 0.1349s  (-13.5%)
cutwail    0.3721s -> 0.3428s  ( -7.9%)
komplex    0.0590s -> 0.0536s  ( -9.1%)
bashlite   0.1652s -> 0.1602s  ( -3.0%)
blockblast 0.2619s -> 0.2580s  ( -1.5%)
TOTAL      1.0841s -> 1.0207s  ( -5.9%)
```

## Test plan

- [x] `pytest tests/test*` → 111 passed
- [x] Deep fingerprint diff (above) → all fixtures MATCH
- [x] `ruff check` + `ruff format --check` clean
- [x] CI `perf_benchmark.yml` fixture gate + Malpedia paired evaluation (broadest correctness/determinism check for #2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)