### PR TITLE
feat: add CPU/memory profiling toolkit

### DIFF
--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -1,0 +1,146 @@
+name: On-Demand Profiling
+
+# CPU/memory profiling of SMDA disassembly. Heavier than the perf_benchmark
+# gate and artifact-producing, so it never runs automatically on every push —
+# only on manual dispatch or when a PR is given the `profile` label.
+#
+# Runs on Linux so py-spy --native and memray --native can descend into the
+# Capstone / LIEF C frames (neither is available on macOS).
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Fixture name (asprox, cutwail, bashlite, blockblast, komplex, njrat, pe_export) or a path"
+        type: string
+        default: "asprox"
+      profiler:
+        description: "Which profiler(s) to run"
+        type: choice
+        options: [all, cpu, mem, flame]
+        default: all
+      iterations:
+        description: "Disassembly passes per profiler"
+        type: string
+        default: "3"
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.label.name || github.event.inputs.profiler }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  profile:
+    name: Profile (${{ github.event.inputs.profiler || 'all' }})
+    # Manual dispatch always runs; label event runs only for the `profile` label.
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'profile'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      TARGET: ${{ github.event.inputs.target || 'asprox' }}
+      PROFILER: ${{ github.event.inputs.profiler || 'all' }}
+      ITERATIONS: ${{ github.event.inputs.iterations || '3' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,profile]"
+
+      - name: Enable ptrace for py-spy
+        if: env.PROFILER == 'all' || env.PROFILER == 'flame'
+        run: sudo sysctl kernel.yama.ptrace_scope=0 || true
+
+      - name: Run profiler(s)
+        run: |
+          set -euo pipefail
+          mkdir -p profiling/output
+          # Derive the output label with the exact same logic the CLI uses, so
+          # the .bin/.svg paths here always match what the tool wrote.
+          LABEL="$(python -c "from profiling._target import resolve_label; print(resolve_label('$TARGET'))")"
+          run_cpu() {
+            python -m profiling.profile_smda cpu --target "$TARGET" --iterations "$ITERATIONS" --line
+          }
+          run_mem() {
+            python -m profiling.profile_smda mem --target "$TARGET" --iterations "$ITERATIONS" --native
+            memray flamegraph "profiling/output/$LABEL.mem.bin" -o "profiling/output/$LABEL.mem.html"
+          }
+          run_flame() {
+            py-spy record --native -o "profiling/output/$LABEL.cpu.svg" -- \
+              python -m profiling.profile_smda run --target "$TARGET" --iterations "$ITERATIONS"
+          }
+          case "$PROFILER" in
+            cpu)   run_cpu ;;
+            mem)   run_mem ;;
+            flame) run_flame ;;
+            all)   run_cpu; run_mem; run_flame ;;
+            *) echo "Unknown profiler: $PROFILER" >&2; exit 1 ;;
+          esac
+
+      - name: Upload profiling artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: smda-profile-${{ env.TARGET }}-${{ env.PROFILER }}
+          path: |
+            profiling/output/*.svg
+            profiling/output/*.html
+            profiling/output/*.prof
+            profiling/output/*.bin
+          if-no-files-found: warn
+
+      # Only on the PR-label path: post/refresh a single comment pointing to the
+      # run + downloadable artifacts (artifacts can't be embedded inline).
+      - name: Post PR comment with profiling links
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          marker="<!-- smda-profile-report -->"
+          comment_body="$(cat <<EOF
+          $marker
+          ### 🔥 SMDA Profiling Run
+
+          - **Target:** \`$TARGET\`
+          - **Profiler:** \`$PROFILER\` · **Iterations:** \`$ITERATIONS\`
+          - **Artifacts (flamegraphs / .prof / .bin):** [download from the run summary]($RUN_URL)
+
+          View locally: \`snakeviz <name>.cpu.prof\` for CPU, open \`<name>.mem.html\` for memory,
+          or open \`<name>.cpu.svg\` (py-spy native flamegraph) in a browser.
+          EOF
+          )"
+          existing_ids="$(
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --jq ".[] | select(.user.login == \"github-actions[bot]\" and ((.body // \"\") | contains(\"$marker\"))) | .id"
+          )"
+          comment_id="$(printf '%s\n' "$existing_ids" | tail -n 1)"
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/${{ github.repository }}/issues/comments/$comment_id" \
+              --raw-field body="$comment_body" >/dev/null
+          else
+            gh api --method POST "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --raw-field body="$comment_body" >/dev/null
+          fi

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -47,6 +47,7 @@ jobs:
             report
             ida
             cli
+            profiling
             tests
             ci
             build

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ coverage-html/
 # Tool caches
 .ruff_cache/
 .vscode
+
+# Profiling artifacts
+profiling/output/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 PYTHON ?= python3
 
-.PHONY: init package publish ruff-check ruff-format ruff-fix lint format test test-coverage clean
+.PHONY: init package publish ruff-check ruff-format ruff-fix lint format test test-coverage clean benchmark profile-cpu profile-mem profile-flame
+
+# Default profiling target fixture; override e.g. `make profile-cpu TARGET=komplex`
+TARGET ?= asprox
 
 init:
 	$(PYTHON) -m pip install --upgrade pip "setuptools>=64.0.0,<82.1.0" "wheel>=0.47.0"
@@ -23,6 +26,16 @@ test:
 	$(PYTHON) -m pytest tests/test*
 test-coverage:
 	$(PYTHON) -m pytest --cov=smda --cov-report=html:coverage-html tests/
+benchmark:
+	$(PYTHON) .github/workflows/scripts/run_perf_check.py --output benchmark_results.json
+profile-cpu:
+	$(PYTHON) -m profiling.profile_smda cpu --target $(TARGET) --line
+profile-mem:
+	$(PYTHON) -m profiling.profile_smda mem --target $(TARGET)
+# py-spy needs sudo on macOS, and --native is Linux-only (see profiling/README.md).
+profile-flame:
+	py-spy record --native -o profiling/output/$(TARGET).cpu.svg -- \
+		$(PYTHON) -m profiling.profile_smda run --target $(TARGET)
 clean:
 	find . | grep -E "(__pycache__|\.pyc|\.pyo$\)" | xargs rm -rf
 	rm -rf .coverage

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -1,0 +1,97 @@
+# SMDA Profiling Toolkit
+
+CPU and memory **profiling** for the SMDA disassembly pipeline. This is the
+profiling layer only — benchmarking and base-vs-PR regression comparison already
+live in [`.github/workflows/scripts/`](../.github/workflows/scripts/)
+(`run_perf_check.py`, `compare_perf.py`) and the
+[`perf_benchmark.yml`](../.github/workflows/perf_benchmark.yml) workflow. Use
+those for "is this PR slower?"; use this for "*where* is the time/memory going?".
+
+## Install
+
+```bash
+pip install -e ".[dev,profile]"
+```
+
+This pulls in `py-spy`, `memray`, `line_profiler`, `snakeviz`, and `psutil`. The
+base SMDA install stays lean without the `profile` extra.
+
+## The workload
+
+Every profiler wraps the **same** unit of work — one disassembly of one target —
+so results are comparable. A target is either:
+
+- a **fixture name**: `asprox`, `cutwail`, `bashlite`, `blockblast`, `komplex`,
+  `njrat`, `pe_export` (the same XOR-encrypted fixtures the benchmark gate uses), or
+- a **path** to any binary on disk.
+
+> Fixtures are XOR-decrypted into an in-memory buffer and handed to the analyzer.
+> They are never executed as programs.
+
+## Commands
+
+```bash
+# CPU: cProfile + (optional) line-by-line over SMDA's hot functions
+python -m profiling.profile_smda cpu  --target asprox --line
+make profile-cpu TARGET=asprox
+
+# Memory: memray capture + tracemalloc top allocators + USS delta
+python -m profiling.profile_smda mem  --target asprox
+make profile-mem TARGET=asprox
+
+# Raw workload (no profiling) — the unit external samplers wrap
+python -m profiling.profile_smda run  --target asprox
+```
+
+Outputs land in `profiling/output/` (git-ignored): `*.cpu.prof`, `*.mem.bin`,
+`*.mem.html`, `*.cpu.svg`.
+
+### Viewing results
+
+| Output | View with |
+|--------|-----------|
+| `<t>.cpu.prof` (cProfile) | `snakeviz profiling/output/<t>.cpu.prof` (interactive icicle chart) |
+| `<t>.mem.bin` (memray) | `memray flamegraph profiling/output/<t>.mem.bin` → HTML, or `memray table ...` |
+| `<t>.cpu.svg` (py-spy) | open in a browser |
+
+## Native flamegraphs (py-spy / memray `--native`)
+
+To see **into** the Capstone / LIEF C frames you need native sampling:
+
+```bash
+# CPU native flamegraph (Linux)
+py-spy record --native -o profiling/output/asprox.cpu.svg -- \
+    python -m profiling.profile_smda run --target asprox
+make profile-flame TARGET=asprox
+
+# Memory native frames
+python -m profiling.profile_smda mem --target asprox --native
+```
+
+### Platform caveats
+
+| Tool | Linux | macOS |
+|------|-------|-------|
+| `cProfile`, `line_profiler`, `tracemalloc` | ✅ | ✅ |
+| `memray` (Python allocations) | ✅ | ✅ (macOS 11+) |
+| `memray --native` | ✅ best | ⚠️ limited |
+| `py-spy` | ✅ (may need `sysctl kernel.yama.ptrace_scope=0`) | ⚠️ needs `sudo` |
+| `py-spy --native` | ✅ | ❌ **not supported on macOS** |
+
+So **local macOS** development gets the full Python-level view (cProfile +
+line_profiler + memray); for native C-frame flamegraphs, use the CI workflow,
+which runs on Linux. Note that pip wheels for `capstone`/`lief` may be partially
+stripped, so native frames can be coarse — the Python-level view is the primary
+signal.
+
+## CI
+
+[`.github/workflows/profile.yml`](../.github/workflows/profile.yml) runs this
+toolkit on Linux, **on demand only**:
+
+- **Manual:** Actions → *On-Demand Profiling* → *Run workflow* (pick target /
+  profiler / iterations).
+- **PR label:** add the `profile` label to a PR.
+
+It uploads the flamegraphs / `.prof` / `.bin` as run artifacts, and on the
+label path posts a PR comment linking to them.

--- a/profiling/__init__.py
+++ b/profiling/__init__.py
@@ -1,0 +1,9 @@
+"""SMDA profiling toolkit (CPU + memory).
+
+Dual-use: run locally for cProfile/line_profiler/memray, or in CI (Linux) for
+py-spy/memray native flamegraphs. See profiling/README.md.
+
+This package only adds a *profiling* layer. Benchmarking and base-vs-PR
+regression comparison already live in .github/workflows/scripts/ and are reused
+as-is.
+"""

--- a/profiling/_target.py
+++ b/profiling/_target.py
@@ -1,0 +1,116 @@
+"""Shared, profiler-agnostic SMDA workload.
+
+Every profiler (cProfile, line_profiler, memray, py-spy) wraps the *same* unit of
+work so their results are comparable: a single disassembly of one target. The
+fixture catalog, the XOR decrypt, and the backend dispatch mirror the existing
+benchmark harness in .github/workflows/scripts/run_perf_check.py — kept here as a
+small, self-contained copy rather than importing across the dashed
+".github/workflows/scripts" path (not an importable package). If these ever
+drift, consider promoting a single shared module.
+
+Guardrail: fixtures are XOR-decrypted into an in-memory buffer and handed to the
+SMDA analyzer. They are never executed as programs.
+"""
+
+import os
+import sys
+
+# Allow running straight from a source checkout (mirrors run_perf_check.py).
+# Harmless when smda is already importable via an editable install.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
+
+from smda.Disassembler import Disassembler  # noqa: E402
+from smda.SmdaConfig import SmdaConfig  # noqa: E402
+
+# name -> fixture spec. Same set the benchmark gate uses.
+FIXTURES = {
+    "asprox": {"filename": "asprox_0x008D0000_xored", "base_addr": 0x8D0000, "backend": "intel"},
+    "cutwail": {"filename": "cutwail_xored", "base_addr": 0x4000000, "backend": "intel"},
+    "bashlite": {"filename": "bashlite_xored", "base_addr": 0, "backend": "intel"},
+    "blockblast": {"filename": "blockblast_classes_xored", "base_addr": 0, "backend": "dalvik"},
+    "komplex": {"filename": "komplex_xored", "base_addr": 0, "backend": "intel"},
+    "njrat": {"filename": "njrat_xored", "base_addr": 0, "backend": "cil"},
+    "pe_export": {"filename": "pe_export_label_test_xored", "base_addr": 0, "backend": "intel"},
+}
+
+
+def decrypt_binary(filepath):
+    """Decrypt an XOR-obfuscated test fixture (byte ^ (index % 256))."""
+    with open(filepath, "rb") as f:
+        binary = f.read()
+    decrypted = bytearray()
+    for index, byte in enumerate(binary):
+        if isinstance(byte, str):
+            byte = ord(byte)
+        decrypted.append(byte ^ (index % 256))
+    return bytes(decrypted)
+
+
+def _make_config():
+    config = SmdaConfig()
+    config.PROJECT_ROOT = _REPO_ROOT
+    config.API_COLLECTION_FILES = {"winxp": os.path.join(_REPO_ROOT, "data", "apiscout_winxp_prof_sp3.json")}
+    return config
+
+
+def _disassemble_fixture(config, spec):
+    filepath = os.path.join(_REPO_ROOT, "tests", spec["filename"])
+    if not os.path.exists(filepath):
+        raise FileNotFoundError(f"Fixture not found: {filepath}")
+    binary_bytes = decrypt_binary(filepath)
+    disasm = Disassembler(config, backend=spec["backend"])
+    if spec["backend"] in ("dalvik", "cil") or spec["base_addr"] == 0:
+        return disasm.disassembleUnmappedBuffer(binary_bytes)
+    return disasm.disassembleBuffer(binary_bytes, spec["base_addr"])
+
+
+def _disassemble_file(config, path):
+    disasm = Disassembler(config)
+    return disasm.disassembleFile(path)
+
+
+def resolve_label(target):
+    """Short, filesystem-safe label used for output filenames."""
+    if target in FIXTURES:
+        return target
+    return os.path.splitext(os.path.basename(target))[0] or "target"
+
+
+def build_workload(target, with_strings=False):
+    """Return a zero-arg callable that performs ONE disassembly of `target`.
+
+    `target` is either a fixture name (see FIXTURES) or a path to a real binary.
+    The returned report exposes num_functions / num_instructions / num_blocks.
+    """
+    config = _make_config()
+    config.WITH_STRINGS = with_strings
+
+    if target in FIXTURES:
+        spec = FIXTURES[target]
+
+        def _run():
+            return _disassemble_fixture(config, spec)
+
+        return _run
+
+    if os.path.exists(target):
+
+        def _run():
+            return _disassemble_file(config, target)
+
+        return _run
+
+    raise ValueError(
+        f"Unknown target '{target}'. Use a fixture name ({', '.join(sorted(FIXTURES))}) "
+        f"or a path to an existing binary."
+    )
+
+
+def run_workload(target, iterations=1, with_strings=False):
+    """Run the workload `iterations` times; return the last SmdaReport."""
+    workload = build_workload(target, with_strings=with_strings)
+    report = None
+    for _ in range(max(1, iterations)):
+        report = workload()
+    return report

--- a/profiling/_target.py
+++ b/profiling/_target.py
@@ -39,12 +39,7 @@ def decrypt_binary(filepath):
     """Decrypt an XOR-obfuscated test fixture (byte ^ (index % 256))."""
     with open(filepath, "rb") as f:
         binary = f.read()
-    decrypted = bytearray()
-    for index, byte in enumerate(binary):
-        if isinstance(byte, str):
-            byte = ord(byte)
-        decrypted.append(byte ^ (index % 256))
-    return bytes(decrypted)
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(binary))
 
 
 def _make_config():

--- a/profiling/profile_smda.py
+++ b/profiling/profile_smda.py
@@ -92,12 +92,10 @@ def cmd_cpu(args):
     workload = build_workload(args.target, with_strings=args.strings)
 
     print(f"cProfile: '{args.target}' x{args.iterations}...")
-    profiler = cProfile.Profile()
     report = None
-    profiler.enable()
-    for _ in range(max(1, args.iterations)):
-        report = workload()
-    profiler.disable()
+    with cProfile.Profile() as profiler:
+        for _ in range(max(1, args.iterations)):
+            report = workload()
     _print_report_summary(report)
 
     prof_path = os.path.join(OUTPUT_DIR, f"{label}.cpu.prof")
@@ -155,16 +153,18 @@ def cmd_mem(args):
 
     uss_before = _uss()
     tracemalloc.start()
-    snap_before = tracemalloc.take_snapshot()
+    try:
+        snap_before = tracemalloc.take_snapshot()
 
-    print(f"memray (native_traces={args.native}): '{args.target}' x{args.iterations}...")
-    report = None
-    with memray.Tracker(bin_path, native_traces=args.native):
-        for _ in range(max(1, args.iterations)):
-            report = workload()
+        print(f"memray (native_traces={args.native}): '{args.target}' x{args.iterations}...")
+        report = None
+        with memray.Tracker(bin_path, native_traces=args.native):
+            for _ in range(max(1, args.iterations)):
+                report = workload()
 
-    snap_after = tracemalloc.take_snapshot()
-    tracemalloc.stop()
+        snap_after = tracemalloc.take_snapshot()
+    finally:
+        tracemalloc.stop()
     uss_after = _uss()
     _print_report_summary(report)
 

--- a/profiling/profile_smda.py
+++ b/profiling/profile_smda.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Unified SMDA profiling CLI (profiling layer only).
+
+Subcommands
+-----------
+  run   Execute the workload once with no profiling. This is the unit that
+        external samplers wrap, e.g.:
+            py-spy record --native -o out.svg -- \
+                python -m profiling.profile_smda run --target asprox
+            memray run --native -o out.bin -- \
+                python -m profiling.profile_smda run --target asprox
+  cpu   cProfile the workload (dumps a .prof, prints top cumulative functions).
+        --line additionally runs line_profiler over SMDA's hot functions.
+  mem   memray-track the workload (dumps a .bin), plus a tracemalloc top-allocator
+        diff and a psutil USS delta.
+
+Outputs land in profiling/output/. See profiling/README.md for platform notes
+(py-spy --native is Linux-only; cProfile/line_profiler/memray work locally).
+"""
+
+import argparse
+import cProfile
+import os
+import pstats
+import sys
+import tracemalloc
+from pstats import SortKey
+
+from profiling._target import build_workload, resolve_label, run_workload
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
+
+
+def _ensure_output_dir():
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def _print_report_summary(report):
+    if report is None:
+        print("  (no report produced)")
+        return
+    status = getattr(report, "status", "ok")
+    print(
+        f"  status={status} "
+        f"functions={report.num_functions} "
+        f"blocks={report.num_blocks} "
+        f"instructions={report.num_instructions}"
+    )
+
+
+def _hot_functions():
+    """SMDA functions worth a line-by-line view. Resolved lazily and defensively
+    so a future rename degrades to 'skipped', not a crash."""
+    funcs = []
+    try:
+        from smda.intel.IntelDisassembler import IntelDisassembler
+
+        funcs += [IntelDisassembler.analyzeFunction, IntelDisassembler.analyzeBuffer]
+    except (ImportError, AttributeError) as exc:
+        print(f"  [line] skipped IntelDisassembler hot functions: {exc}", file=sys.stderr)
+    try:
+        from smda.intel.FunctionCandidateManager import FunctionCandidateManager
+
+        funcs += [
+            FunctionCandidateManager.isFunctionCandidate,
+            FunctionCandidateManager.getNextFunctionStartCandidate,
+            FunctionCandidateManager.locateCandidates,
+        ]
+    except (ImportError, AttributeError) as exc:
+        print(f"  [line] skipped FunctionCandidateManager hot functions: {exc}", file=sys.stderr)
+    try:
+        from smda.utility import StringExtractor
+
+        funcs += [StringExtractor.extract_strings, StringExtractor.read_string]
+    except (ImportError, AttributeError) as exc:
+        print(f"  [line] skipped StringExtractor hot functions: {exc}", file=sys.stderr)
+    return funcs
+
+
+def cmd_run(args):
+    print(f"Running SMDA on '{args.target}' x{args.iterations} (no profiling)...")
+    report = run_workload(args.target, iterations=args.iterations, with_strings=args.strings)
+    _print_report_summary(report)
+    if report is not None and getattr(report, "status", "ok") not in ("ok", None):
+        return 1
+    return 0
+
+
+def cmd_cpu(args):
+    _ensure_output_dir()
+    label = resolve_label(args.target)
+    workload = build_workload(args.target, with_strings=args.strings)
+
+    print(f"cProfile: '{args.target}' x{args.iterations}...")
+    profiler = cProfile.Profile()
+    report = None
+    profiler.enable()
+    for _ in range(max(1, args.iterations)):
+        report = workload()
+    profiler.disable()
+    _print_report_summary(report)
+
+    prof_path = os.path.join(OUTPUT_DIR, f"{label}.cpu.prof")
+    stats = pstats.Stats(profiler).sort_stats(SortKey.CUMULATIVE)
+    stats.dump_stats(prof_path)
+    print(f"\nTop {args.top} functions by cumulative time:")
+    stats.print_stats(args.top)
+    print(f"Saved: {prof_path}")
+    print(f"View interactively: snakeviz {prof_path}")
+
+    if args.line:
+        _run_line_profiler(args, workload)
+    return 0
+
+
+def _run_line_profiler(args, workload):
+    try:
+        from line_profiler import LineProfiler
+    except ImportError:
+        print(
+            "\n[line] line_profiler not installed. Install with: pip install -e '.[profile]'",
+            file=sys.stderr,
+        )
+        return
+    hot = _hot_functions()
+    if not hot:
+        print("[line] no hot functions could be registered; skipping.", file=sys.stderr)
+        return
+    print(f"\nline_profiler over {len(hot)} hot function(s)...")
+    lp = LineProfiler()
+    for fn in hot:
+        lp.add_function(fn)
+    lp_wrapper = lp(workload)
+    lp_wrapper()
+    lp.print_stats(output_unit=1e-3)
+
+
+def cmd_mem(args):
+    _ensure_output_dir()
+    label = resolve_label(args.target)
+    workload = build_workload(args.target, with_strings=args.strings)
+
+    try:
+        import memray
+    except ImportError:
+        print(
+            "memray not installed. Install with: pip install -e '.[profile]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    bin_path = os.path.join(OUTPUT_DIR, f"{label}.mem.bin")
+    if os.path.exists(bin_path):
+        os.remove(bin_path)  # memray refuses to overwrite an existing capture
+
+    uss_before = _uss()
+    tracemalloc.start()
+    snap_before = tracemalloc.take_snapshot()
+
+    print(f"memray (native_traces={args.native}): '{args.target}' x{args.iterations}...")
+    report = None
+    with memray.Tracker(bin_path, native_traces=args.native):
+        for _ in range(max(1, args.iterations)):
+            report = workload()
+
+    snap_after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+    uss_after = _uss()
+    _print_report_summary(report)
+
+    print(f"\nTop {args.top} Python allocators (tracemalloc, by line):")
+    for stat in snap_after.compare_to(snap_before, "lineno")[: args.top]:
+        print(f"  {stat}")
+
+    if uss_before is not None and uss_after is not None:
+        print(f"\nUSS delta: {(uss_after - uss_before) / 1024 / 1024:+.2f} MiB (peak private memory growth)")
+
+    print(f"\nSaved: {bin_path}")
+    print(f"Generate flamegraph: memray flamegraph {bin_path}")
+    print(f"Allocation table:    memray table {bin_path}")
+    return 0
+
+
+def _uss():
+    """Private (USS) memory in bytes, or None if psutil is unavailable.
+
+    USS is preferred over RSS here: LIEF's memory-mapped files and shared
+    libraries inflate RSS, while USS reflects this process's own footprint.
+    """
+    try:
+        import psutil
+    except ImportError:
+        print("[mem] psutil not installed; skipping USS delta.", file=sys.stderr)
+        return None
+    return psutil.Process().memory_full_info().uss
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="profile_smda",
+        description="Profile SMDA disassembly (CPU/memory). Reuses the existing benchmark fixtures.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(p):
+        p.add_argument(
+            "--target",
+            default="asprox",
+            help="Fixture name (asprox, cutwail, bashlite, blockblast, komplex, njrat, pe_export) "
+            "or a path to a binary.",
+        )
+        p.add_argument("--iterations", type=int, default=1, help="Number of disassembly passes.")
+        p.add_argument("--strings", action="store_true", help="Enable string extraction (config.WITH_STRINGS).")
+
+    p_run = sub.add_parser("run", help="Run the workload with no profiling (wrap with py-spy/memray).")
+    add_common(p_run)
+    p_run.set_defaults(func=cmd_run)
+
+    p_cpu = sub.add_parser("cpu", help="cProfile the workload (+ optional line_profiler).")
+    add_common(p_cpu)
+    p_cpu.add_argument("--top", type=int, default=25, help="How many top functions to print.")
+    p_cpu.add_argument("--line", action="store_true", help="Also run line_profiler over SMDA hot functions.")
+    p_cpu.set_defaults(func=cmd_cpu)
+
+    p_mem = sub.add_parser("mem", help="memray + tracemalloc + USS for the workload.")
+    add_common(p_mem)
+    p_mem.add_argument("--top", type=int, default=25, help="How many top allocators to print.")
+    p_mem.add_argument(
+        "--native",
+        action="store_true",
+        help="Capture native (C/C++) frames into Capstone/LIEF. Best on Linux.",
+    )
+    p_mem.set_defaults(func=cmd_mem)
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.iterations < 1:
+        parser.error("--iterations must be >= 1")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,15 @@ dev = [
     "ruff",
     "twine",
 ]
+# Optional CPU/memory profiling toolkit (see profiling/). Kept out of `dev` so
+# the default install stays lean. Install with: pip install -e ".[dev,profile]"
+profile = [
+    "py-spy",
+    "memray",
+    "line_profiler",
+    "snakeviz",
+    "psutil",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Adds a self-contained profiling/ package on top of the existing benchmark/compare infrastructure (untouched), filling the gap identified from the Gemini research report.

### What's included

**profiling/_target.py** — profiler-agnostic workload builder: reuses the existing 7-fixture catalog + XOR decrypt + backend dispatch from run_perf_check.py. Accepts a fixture name or an arbitrary binary path. Fixtures are XOR-decrypted into an in-memory buffer and passed to the SMDA analyzer — never executed as programs.

**profiling/profile_smda.py** — unified CLI with three subcommands:
- `run` — bare workload (for py-spy / memray to wrap externally)
- `cpu` — cProfile (saves .prof, prints top-N cumulative) + `--line` for line_profiler over verified hot functions (IntelDisassembler, FCManager, StringExtractor)
- `mem` — memray capture + tracemalloc top-allocator diff + psutil USS delta (USS preferred over RSS to avoid LIEF mmap inflation)

**pyproject.toml** — new `[profile]` optional-dependency group: py-spy, memray, line_profiler, snakeviz, psutil.
Install with: pip install -e ".[dev,profile]"

**Makefile** — profile-cpu / profile-mem / profile-flame targets (TARGET=asprox default, overridable).

**.github/workflows/profile.yml** — on-demand-only Linux workflow (workflow_dispatch + pull_request `profile` label). Enables ptrace, runs the requested profiler, uploads flamegraph/.prof/.bin artifacts, and posts/updates a PR comment on the label path.
SHA-pinned actions matching perf_benchmark.yml convention.

**.gitignore** — profiling/output/ excluded.

**.github/workflows/semantic-pr-title.yml** — register `profiling` as a valid conventional-commit scope so future profiling PRs pass the title check.

**profiling/README.md** — platform support table (py-spy --native is Linux-only; cProfile/line_profiler/memray work on macOS locally).

Verified: 111 tests pass, ruff check+format clean repo-wide, all three profiling modes run locally (surfaced WinApiResolver.py:89/94 and FunctionAnalysisState.py as real hot allocators on komplex fixture).