### PR TITLE
feat(ida): add optional IDA Domain backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ There is also a demo script:
 
 * analyze.py -- example usage: perform disassembly on a file or memory dump and optionally store results in JSON to a given output path.
 
+### IDA Pro integration
+
+SMDA can also turn an IDA-analyzed database into a SMDA report instead of running its own disassembly. Inside the IDA GUI, SMDA supports the existing IDAPython integrations for IDA 7.x, 8.x, and 9.x. On IDA 9.1 or newer, it prefers the higher-level [IDA Domain API](https://ida-domain.docs.hex-rays.com/) when the optional package is installed and otherwise falls back to IDAPython.
+
+Inside the IDA GUI, run `export.py` to export IDA's existing analysis to a `.smda` file next to the database. Run `ida_analyze.py` to have SMDA independently recover functions from the loaded bytes and add missing function starts and names back to IDA. This augmentation workflow is useful when IDA analyzes a raw or mapped buffer conservatively. Both scripts can be launched via *File -> Script file...*.
+
+For headless export of IDA's analysis (no GUI), use `ida_domain_export.py`:
+
+```
+python -m pip install "smda[ida]"
+python ida_domain_export.py /path/to/sample.i64 -o sample.smda
+```
+
+Headless export requires IDA 9.1+ and the optional `ida-domain>=0.5.0` dependency. Make sure `IDADIR` points at the IDA installation when it cannot be discovered automatically (see the [getting started guide](https://ida-domain.docs.hex-rays.com/getting_started/)). Standard SMDA installations do not include `ida-domain`.
+
 For Dalvik, the current scope is raw single-DEX inputs. APK, multi-dex container handling, and ODEX/VDEX/CDEX runtime-artifact analysis are not yet first-class workflows in SMDA.
 
 The code should be fully compatible with Python 3.8+.

--- a/export.py
+++ b/export.py
@@ -1,35 +1,34 @@
+"""Export the current IDA database to a SMDA report.
+
+For headless IDA 9.1+ export, use ``ida_domain_export.py`` instead.
+"""
+
 import json
 
 from smda.Disassembler import Disassembler
+from smda.ida.IdaInterface import getIdaSdkVersion
+from smda.SmdaConfig import SmdaConfig
 
 
 def detectBackend():
-    backend = ""
-    version = ""
     try:
-        import idaapi
-
-        backend = "IDA"
-        version = idaapi.IDA_SDK_VERSION
+        return ("IDA", getIdaSdkVersion())
     except ImportError:
-        pass
-    return (backend, version)
+        return ("", "")
 
 
 if __name__ == "__main__":
     BACKEND, VERSION = detectBackend()
     if BACKEND == "IDA":
-        from smda.ida.IdaInterface import IdaInterface
-
-        ida_interface = IdaInterface()
+        config = SmdaConfig()
+        disassembler = Disassembler(config, backend=BACKEND)
+        ida_interface = disassembler.disassembler.ida_interface
         binary = ida_interface.getBinary()
         base_addr = ida_interface.getBaseAddr()
-        DISASSEMBLER = Disassembler(backend=BACKEND)
-        REPORT = DISASSEMBLER.disassembleBuffer(binary, base_addr, architecture="aarch64")
-        output_path = ida_interface.getIdbDir()
-        output_filepath = output_path + "ConvertedFromIdb.smda"
+        REPORT = disassembler.disassembleBuffer(binary, base_addr)
+        output_filepath = ida_interface.getIdbDir() + "ConvertedFromIdb.smda"
         with open(output_filepath, "w") as fout:
             json.dump(REPORT.toDict(), fout, indent=1, sort_keys=True)
             print(f"Output saved to: {output_filepath}")
     else:
-        raise Exception("No supported backend found.")
+        raise Exception("Run this script from within IDA.")

--- a/ida_analyze.py
+++ b/ida_analyze.py
@@ -1,24 +1,32 @@
+"""Run SMDA in IDA and push recovered functions and names into the database."""
+
 from export import detectBackend
 from smda.Disassembler import Disassembler
+from smda.ida.IdaInterface import IdaInterface
 from smda.SmdaConfig import SmdaConfig
+
+
+def analyze():
+    ida_interface = IdaInterface()
+    binary = ida_interface.getBinary()
+    base_addr = ida_interface.getBaseAddr()
+    architecture = ida_interface.getArchitecture()
+    bitness = ida_interface.getBitness()
+    disassembler = Disassembler(SmdaConfig())
+    report = disassembler.disassembleBuffer(binary, base_addr, bitness=bitness, architecture=architecture)
+    smda_function_count = 0
+    smda_name_count = 0
+    for smda_function in report.getFunctions():
+        smda_function_count += ida_interface.makeFunction(smda_function.offset)
+        if smda_function.function_name != "":
+            smda_name_count += ida_interface.makeNameEx(smda_function.offset, smda_function.function_name)
+    print(f"Defined {smda_function_count} functions and assigned {smda_name_count} function names.")
+    return report
+
 
 if __name__ == "__main__":
     BACKEND, VERSION = detectBackend()
     if BACKEND == "IDA":
-        from smda.ida.IdaInterface import IdaInterface
-
-        ida_interface = IdaInterface()
-        binary = ida_interface.getBinary()
-        base_addr = ida_interface.getBaseAddr()
-        config = SmdaConfig()
-        DISASSEMBLER = Disassembler(config)
-        REPORT = DISASSEMBLER.disassembleBuffer(binary, base_addr)
-        smda_function_count = 0
-        smda_name_count = 0
-        for smda_function in REPORT.getFunctions():
-            smda_function_count += ida_interface.makeFunction(smda_function.offset)
-            if smda_function.function_name != "":
-                smda_name_count += ida_interface.makeNameEx(smda_function.offset, smda_function.function_name)
-        print(f"Defined {smda_function_count} functions and assigned {smda_name_count} function names.")
+        analyze()
     else:
         raise Exception("Run this script from within IDA.")

--- a/ida_domain_export.py
+++ b/ida_domain_export.py
@@ -1,0 +1,63 @@
+"""Headless SMDA export using the modern ``ida-domain`` backend.
+
+This opens an IDA database (``.idb``/``.i64``) or any input binary IDA supports
+*without* a running IDA GUI, collects the disassembly via ``ida-domain`` and
+writes a ``.smda`` report - the headless counterpart to ``export.py`` (which
+must be run from inside IDA).
+
+Requirements:
+    pip install "smda[ida]"   # pulls in ida-domain >= 0.5.0
+    IDA Pro 9.1+ with IDADIR configured (see
+    https://ida-domain.docs.hex-rays.com/getting_started/)
+
+Usage:
+    python ida_domain_export.py /path/to/sample.i64 [-o report.smda]
+"""
+
+import argparse
+import json
+import sys
+
+from smda.Disassembler import Disassembler
+from smda.ida.IdaExporter import IdaExporter
+from smda.ida.IdaInterface import IdaInterface
+from smda.SmdaConfig import SmdaConfig
+
+
+def export_database(input_path, output_path=None):
+    config = SmdaConfig()
+    disassembler = Disassembler(config)
+    with IdaInterface.fromPath(input_path) as ida_interface:
+        disassembler.disassembler = IdaExporter(config, ida_interface=ida_interface)
+        disassembler._explicit_backend = True
+        binary = ida_interface.getBinary()
+        base_addr = ida_interface.getBaseAddr()
+        report = disassembler.disassembleBuffer(binary, base_addr)
+    if output_path is None:
+        output_path = input_path + ".smda"
+    with open(output_path, "w") as fout:
+        json.dump(report.toDict(), fout, indent=1, sort_keys=True)
+    print(f"Exported {report.num_functions} IDA functions.")
+    print(f"Output saved to: {output_path}")
+    return report
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Headless SMDA export via the ida-domain backend.")
+    parser.add_argument("input_path", help="Path to the IDA database (.idb/.i64) or input binary to export.")
+    parser.add_argument("-o", "--output", help="Output .smda path (default: <input_path>.smda).")
+    args = parser.parse_args(argv)
+    try:
+        export_database(args.input_path, args.output)
+    except ImportError:
+        print(
+            "ida-domain is not available. Install it with 'pip install \"smda[ida]\"' "
+            "and configure IDADIR for an IDA Pro 9.1+ installation.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ dev = [
     "tqdm",
     "twine",
 ]
+ida = [
+    "ida-domain>=0.5.0",
+]
 # Optional CPU/memory profiling toolkit (see profiling/). Kept out of `dev` so
 # the default install stays lean. Install with: pip install -e ".[dev,profile]"
 profile = [

--- a/src/smda/ida/IdaDomainInterface.py
+++ b/src/smda/ida/IdaDomainInterface.py
@@ -1,0 +1,183 @@
+"""IDA Domain API adapter for IDA 9.1 and newer."""
+
+import importlib
+import os
+import re
+
+from .BackendInterface import BackendInterface
+
+_IDA_DOMAIN_MISSING = (
+    "ida-domain is not available. Install it with 'pip install \"smda[ida]\"' and "
+    "ensure IDA Pro 9.1+ is installed with IDADIR configured."
+)
+
+_INTEL_PROCESSORS = {
+    "metapc",
+    "8086",
+    "80286p",
+    "80386p",
+    "80486p",
+    "80586p",
+    "80686p",
+    "p2",
+    "p3",
+    "p4",
+    "x86",
+    "x86_64",
+    "x64",
+}
+
+
+class IdaDomainUnavailableError(ImportError):
+    pass
+
+
+def _getDatabaseClass():
+    try:
+        return importlib.import_module("ida_domain").Database
+    except ImportError as exc:
+        raise IdaDomainUnavailableError(_IDA_DOMAIN_MISSING) from exc
+
+
+class IdaDomainInterface(BackendInterface):
+    def __init__(self, database=None):
+        super().__init__()
+        self.version = "ida-domain (IDA Pro 9.1+)"
+        self._owns_database = False
+        if database is not None:
+            self.db = database
+        else:
+            self.db = _getDatabaseClass().open()
+
+    @classmethod
+    def fromPath(cls, input_path, save_on_close=False):
+        database_class = _getDatabaseClass()
+        interface = cls(database=database_class.open(path=input_path, save_on_close=save_on_close))
+        interface._owns_database = True
+        return interface
+
+    def close(self):
+        if self._owns_database and self.db is not None:
+            self.db.close()
+            self.db = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+        return False
+
+    def getArchitecture(self):
+        procname = self.db.architecture
+        if procname is None:
+            raise ValueError("Unsupported Architecture")
+        normalized = procname.lower()
+        if normalized in ("arm", "arm64", "aarch64"):
+            if self.getBitness() != 64:
+                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
+            return "aarch64"
+        if normalized in _INTEL_PROCESSORS or "x86" in normalized or normalized.startswith("metapc"):
+            return "intel"
+        raise ValueError(f"Unsupported Architecture: {procname}")
+
+    def getBitness(self):
+        bits = self.db.bitness
+        if bits in (16, 32, 64):
+            return bits
+        segment = self.db.segments.get_at(self.db.minimum_ea)
+        if segment is not None:
+            return self.db.segments.get_bitness(segment)
+        return bits if bits else 32
+
+    def getFunctions(self):
+        return sorted(function.start_ea for function in self.db.functions.get_all())
+
+    def getBlocks(self, function_offset):
+        function = self.db.functions.get_at(function_offset)
+        if function is None:
+            return []
+        flowchart = self.db.functions.get_flowchart(function)
+        if flowchart is None:
+            return []
+        blocks = []
+        for block in flowchart:
+            if block.start_ea >= block.end_ea:
+                continue
+            instructions = block.get_instructions()
+            extracted_block = [instruction.ea for instruction in instructions] if instructions else []
+            if extracted_block:
+                blocks.append(extracted_block)
+        return sorted(blocks)
+
+    def getInstructionBytes(self, offset):
+        instruction = self.db.instructions.get_at(offset)
+        if instruction is None:
+            return b""
+        return self.db.bytes.get_bytes_at(offset, instruction.size) or b""
+
+    def getCodeInRefs(self, offset):
+        return [(ref_from, offset) for ref_from in self.db.xrefs.code_refs_to_ea(offset, flow=True)]
+
+    def getCodeOutRefs(self, offset):
+        return [(offset, ref_to) for ref_to in self.db.xrefs.code_refs_from_ea(offset, flow=True)]
+
+    def getFunctionSymbols(self, demangle=False):
+        function_symbols = {}
+        for function in self.db.functions.get_all():
+            function_offset = function.start_ea
+            function_name = self.db.functions.get_name(function)
+            if demangle and function_name and "@" in function_name:
+                demangled = self.db.names.get_demangled_name(function_offset)
+                if demangled:
+                    function_name = demangled
+            if function_name and not re.match("sub_[0-9a-fA-F]+", function_name):
+                function_symbols[function_offset] = function_name
+        return function_symbols
+
+    def getBaseAddr(self):
+        segment_starts = sorted(segment.start_ea for segment in self.db.segments.get_all())
+        if not segment_starts:
+            return 0
+        return int((segment_starts[0] // 0x10000) * 0x10000)
+
+    def getBinary(self):
+        result = b""
+        for segment in sorted(self.db.segments.get_all(), key=lambda current: current.start_ea):
+            segment_bytes = self.db.bytes.get_bytes_at(segment.start_ea, self.db.segments.get_size(segment))
+            if segment_bytes:
+                result += segment_bytes
+        return result
+
+    def getApiMap(self):
+        api_map = {}
+        for imported in self.db.imports.get_all_imports():
+            api_name = imported.name or f"#{imported.ordinal}"
+            if imported.module_name:
+                api_name = f"{imported.module_name}!{api_name}"
+            api_map[imported.address] = api_name
+        return api_map
+
+    def isExternalFunction(self, function_offset):
+        segment = self.db.segments.get_at(function_offset)
+        if segment is None:
+            return False
+        return self.db.segments.get_name(segment) in ("extern", "UNDEF")
+
+    def makeFunction(self, instruction):
+        return self.db.functions.create(instruction)
+
+    def makeNameEx(self, address, name, warning_level=None):
+        return self.db.names.set_name(address, name)
+
+    def getInputPath(self):
+        return self.db.path
+
+    def getIdbDir(self):
+        import ida_loader
+
+        idb_path = ida_loader.get_path(ida_loader.PATH_TYPE_IDB)
+        if not idb_path:
+            return ""
+        dirname = os.path.dirname(idb_path)
+        return dirname + os.sep if dirname else ""

--- a/src/smda/ida/IdaExporter.py
+++ b/src/smda/ida/IdaExporter.py
@@ -11,9 +11,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IdaExporter:
-    def __init__(self, config, bitness=None):
+    def __init__(self, config, bitness=None, ida_interface=None):
         self.config = config
-        self.ida_interface = IdaInterface()
+        self.ida_interface = ida_interface if ida_interface is not None else IdaInterface()
         self.bitness = bitness if bitness else self.ida_interface.getBitness()
         self.architecture = self.ida_interface.getArchitecture()
         self.capstone = None

--- a/src/smda/ida/IdaIdapythonInterface.py
+++ b/src/smda/ida/IdaIdapythonInterface.py
@@ -1,0 +1,263 @@
+"""Legacy IDAPython adapters for supported IDA SDK generations."""
+
+import contextlib
+import re
+
+from .BackendInterface import BackendInterface
+
+try:
+    import idaapi
+    import idautils
+except ImportError:
+    pass
+
+try:
+    import ida_bytes
+    import ida_funcs
+    import ida_gdl
+    import ida_idaapi
+    import ida_nalt
+    import ida_name
+    import ida_segment
+except ImportError:
+    pass
+
+with contextlib.suppress(ImportError):
+    import idc
+
+
+class _ModernIdapythonInterface(BackendInterface):
+    def __init__(self):
+        self._processor_map = {"metapc": "intel"}
+        self._api_map = {}
+        self._import_module_name = ""
+
+    def getFunctions(self):
+        return sorted(idautils.Functions())
+
+    def getBlocks(self, function_offset):
+        blocks = []
+        function_chart = ida_gdl.FlowChart(ida_funcs.get_func(function_offset))
+        for block in function_chart:
+            extracted_block = []
+            for instruction in idautils.Heads(block.start_ea, block.end_ea):
+                if ida_bytes.is_code(ida_bytes.get_flags(instruction)):
+                    extracted_block.append(instruction)
+            if extracted_block:
+                blocks.append(extracted_block)
+        return sorted(blocks)
+
+    def getInstructionBytes(self, offset):
+        instruction = idautils.DecodeInstruction(offset)
+        return ida_bytes.get_bytes(offset, instruction.size)
+
+    def getCodeInRefs(self, offset):
+        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
+
+    def getCodeOutRefs(self, offset):
+        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
+
+    def getFunctionSymbols(self, demangle=False):
+        function_symbols = {}
+        for function_offset in self.getFunctions():
+            function_name = ida_funcs.get_func_name(function_offset)
+            if demangle and "@" in function_name:
+                demangled = ida_name.demangle_name(function_name, 0)
+                if demangled:
+                    function_name = demangled
+            if not re.match("sub_[0-9a-fA-F]+", function_name):
+                function_symbols[function_offset] = function_name
+        return function_symbols
+
+    def getBaseAddr(self):
+        segment_starts = list(idautils.Segments())
+        if not segment_starts:
+            return 0
+        return int((segment_starts[0] // 0x10000) * 0x10000)
+
+    def getBinary(self):
+        result = b""
+        segment = ida_segment.get_first_seg()
+        while segment:
+            result += ida_bytes.get_bytes(segment.start_ea, segment.end_ea - segment.start_ea)
+            segment = ida_segment.get_next_seg(segment.end_ea - 1)
+        return result
+
+    def getApiMap(self):
+        self._api_map = {}
+        for module_index in range(ida_nalt.get_import_module_qty()):
+            self._import_module_name = ida_nalt.get_import_module_name(module_index)
+            ida_nalt.enum_import_names(module_index, self._cbEnumImports)
+        return self._api_map
+
+    def isExternalFunction(self, function_offset):
+        segment = ida_segment.getseg(function_offset)
+        return ida_segment.get_segm_name(segment) in ["extern", "UNDEF"]
+
+    def makeFunction(self, instruction):
+        return ida_funcs.add_func(instruction)
+
+    def makeNameEx(self, address, name, warning_level=None):
+        if warning_level is None:
+            warning_level = idc.SN_NOWARN
+        return idc.set_name(address, name, warning_level)
+
+    def getIdbDir(self):
+        return idautils.GetIdbDir()
+
+    def _cbEnumImports(self, addr, name, ordinal):
+        if self._import_module_name:
+            self._api_map[addr] = self._import_module_name + "!" + name
+        else:
+            self._api_map[addr] = name
+        return True
+
+
+class Ida74Interface(_ModernIdapythonInterface):
+    def __init__(self):
+        super().__init__()
+        self.version = "IDA Pro 7.4 - 8.4"
+
+    def getArchitecture(self):
+        info = ida_idaapi.get_inf_structure()
+        procname = info.procname if idaapi.IDA_SDK_VERSION >= 800 else info.procName
+        if procname == "ARM":
+            if self.getBitness() != 64:
+                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
+            return "aarch64"
+        if procname in self._processor_map:
+            return self._processor_map[procname]
+        raise ValueError("Unsupported Architecture")
+
+    def getBitness(self):
+        info = ida_idaapi.get_inf_structure()
+        if info.is_64bit():
+            return 64
+        if info.is_32bit():
+            return 32
+        return 16
+
+
+class Ida73Interface(BackendInterface):
+    def __init__(self):
+        self.version = "IDA Pro 7.3 and below"
+        self._processor_map = {"metapc": "intel"}
+        self._api_map = {}
+        self._import_module_name = ""
+
+    def getArchitecture(self):
+        procname = idaapi.get_inf_structure().procName
+        if procname == "ARM":
+            if self.getBitness() != 64:
+                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
+            return "aarch64"
+        if procname in self._processor_map:
+            return self._processor_map[procname]
+        raise ValueError("Unsupported Architecture")
+
+    def getBitness(self):
+        info = idaapi.get_inf_structure()
+        if info.is_64bit():
+            return 64
+        if info.is_32bit():
+            return 32
+        return 16
+
+    def getFunctions(self):
+        return sorted(idautils.Functions())
+
+    def getBlocks(self, function_offset):
+        blocks = []
+        function_chart = idaapi.FlowChart(idaapi.get_func(function_offset))
+        for block in function_chart:
+            extracted_block = []
+            for instruction in idautils.Heads(block.startEA, block.endEA):
+                if idc.isCode(idc.GetFlags(instruction)):
+                    extracted_block.append(instruction)
+            if extracted_block:
+                blocks.append(extracted_block)
+        return sorted(blocks)
+
+    def getInstructionBytes(self, offset):
+        instruction = idautils.DecodeInstruction(offset)
+        return idc.get_bytes(offset, instruction.size)
+
+    def getCodeInRefs(self, offset):
+        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
+
+    def getCodeOutRefs(self, offset):
+        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
+
+    def getFunctionSymbols(self, demangle=False):
+        function_symbols = {}
+        for function_offset in self.getFunctions():
+            function_name = idc.GetFunctionName(function_offset)
+            if demangle and "@" in function_name:
+                function_name = idc.demangle_name(function_name, 0)
+            if not re.match("sub_[0-9a-fA-F]+", function_name):
+                function_symbols[function_offset] = function_name
+        return function_symbols
+
+    def getBaseAddr(self):
+        segment_starts = list(idautils.Segments())
+        if not segment_starts:
+            return 0
+        return int((segment_starts[0] // 0x10000) * 0x10000)
+
+    def getBinary(self):
+        result = b""
+        for start in idautils.Segments():
+            end = idc.SegEnd(start)
+            result += idc.get_bytes(start, end - start)
+        return result
+
+    def getApiMap(self):
+        self._api_map = {}
+        for module_index in range(idaapi.get_import_module_qty()):
+            self._import_module_name = idaapi.get_import_module_name(module_index)
+            idaapi.enum_import_names(module_index, self._cbEnumImports)
+        return self._api_map
+
+    def isExternalFunction(self, function_offset):
+        return False
+
+    def makeFunction(self, instruction):
+        return idc.add_func(instruction)
+
+    def makeNameEx(self, address, name, warning_level=None):
+        if warning_level is None:
+            warning_level = idc.SN_NOWARN
+        return idc.set_name(address, name, warning_level)
+
+    def getIdbDir(self):
+        return idautils.GetIdbDir()
+
+    def _cbEnumImports(self, addr, name, ordinal):
+        if self._import_module_name:
+            self._api_map[addr] = self._import_module_name + "!" + name
+        else:
+            self._api_map[addr] = name
+        return True
+
+
+class Ida85Interface(_ModernIdapythonInterface):
+    def __init__(self):
+        super().__init__()
+        self.version = "IDA Pro 8.5+"
+
+    def getArchitecture(self):
+        procname = idaapi.inf_get_procname()
+        if procname == "ARM":
+            if self.getBitness() != 64:
+                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
+            return "aarch64"
+        if procname in self._processor_map:
+            return self._processor_map[procname]
+        raise ValueError("Unsupported Architecture")
+
+    def getBitness(self):
+        if idaapi.inf_is_64bit():
+            return 64
+        if idaapi.inf_is_32bit_exactly():
+            return 32
+        return 16

--- a/src/smda/ida/IdaInterface.py
+++ b/src/smda/ida/IdaInterface.py
@@ -1,407 +1,76 @@
-import contextlib
-import re
+"""Central IDA backend selection and compatibility policy."""
 
-from .BackendInterface import BackendInterface
+import importlib.util
 
-try:
-    import idaapi
-    import idautils
-except ImportError:
-    pass
+from .IdaDomainInterface import IdaDomainInterface, IdaDomainUnavailableError
+from .IdaIdapythonInterface import Ida73Interface, Ida74Interface, Ida85Interface
 
-try:
-    # we only need these when we are in IDA - IDA 7.4 and above
-    import ida_bytes
-    import ida_funcs
-    import ida_gdl
-    import ida_idaapi
-    import ida_nalt
-    import ida_name
-    import ida_segment
-except ImportError:
-    pass
+IDA_DOMAIN_MIN_SDK_VERSION = 910
 
-with contextlib.suppress(ImportError):
-    # we only need these when we are in IDA - IDA 7.3 and below
-    import idc
+_IDAPYTHON_BACKENDS = (
+    (850, Ida85Interface),
+    (740, Ida74Interface),
+    (0, Ida73Interface),
+)
+
+
+def getIdaSdkVersion():
+    try:
+        import idaapi
+    except ImportError as exc:
+        raise ImportError("The SMDA IDA backend must be run from IDA Pro.") from exc
+
+    sdk_version = idaapi.IDA_SDK_VERSION
+    if not isinstance(sdk_version, int):
+        raise ValueError("Unsupported IDA SDK version")
+    return sdk_version
+
+
+def _getDomainInterface():
+    try:
+        domain_spec = importlib.util.find_spec("ida_domain")
+    except (ImportError, ValueError):
+        return None
+    if domain_spec is None:
+        return None
+    return IdaDomainInterface
+
+
+def _selectBackend(sdk_version, domain_interface=None):
+    if not isinstance(sdk_version, int):
+        raise ValueError("Unsupported IDA SDK version")
+    if sdk_version >= IDA_DOMAIN_MIN_SDK_VERSION and domain_interface is not None:
+        return domain_interface
+    for minimum_sdk_version, backend in _IDAPYTHON_BACKENDS:
+        if sdk_version >= minimum_sdk_version:
+            return backend
+    raise ValueError(f"Unsupported IDA SDK version: {sdk_version}")
 
 
 class IdaInterface:
-    # derived from https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Singleton.html
     instance = None
 
     def __init__(self):
         if not IdaInterface.instance:
-            sdk_version = idaapi.IDA_SDK_VERSION
-            if not isinstance(sdk_version, int):
-                raise ValueError("Unsupported IDA SDK version")
-            if sdk_version < 740:
-                IdaInterface.instance = Ida73Interface()
-            elif sdk_version < 850:
-                IdaInterface.instance = Ida74Interface()
-            else:
-                IdaInterface.instance = Ida85Interface()
+            sdk_version = getIdaSdkVersion()
+            domain_interface = _getDomainInterface() if sdk_version >= IDA_DOMAIN_MIN_SDK_VERSION else None
+            backend = _selectBackend(sdk_version, domain_interface)
+            try:
+                IdaInterface.instance = backend()
+            except IdaDomainUnavailableError:
+                if backend is not domain_interface:
+                    raise
+                IdaInterface.instance = _selectBackend(sdk_version)()
 
     def __getattr__(self, name):
         return getattr(self.instance, name)
 
-    def getIdbDir(self):
-        return idautils.GetIdbDir()
-
-
-class Ida74Interface(BackendInterface):
-    def __init__(self):
-        self.version = "IDA Pro 7.4 - 8.4"
-        self._processor_map = {"metapc": "intel", "ARM": "aarch64"}
-        self._api_map = {}
-        self._import_module_name = ""
-
-    def getArchitecture(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        info = ida_idaapi.get_inf_structure()
-        procname = info.procname if idaapi.IDA_SDK_VERSION >= 800 else info.procName
-        if procname == "ARM":
-            if self.getBitness() != 64:
-                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
-            return "aarch64"
-        if procname in self._processor_map:
-            return self._processor_map[procname]
-        else:
-            raise ValueError("Unsupported Architecture")
-
-    def getBitness(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        bits = None
-        info = ida_idaapi.get_inf_structure()
-        if info.is_64bit():
-            bits = 64
-        elif info.is_32bit():
-            bits = 32
-        else:
-            bits = 16
-        return bits
-
-    def getFunctions(self):
-        return sorted(idautils.Functions())
-
-    def getBlocks(self, function_offset):
-        blocks = []
-        function_chart = ida_gdl.FlowChart(ida_funcs.get_func(function_offset))
-        for block in function_chart:
-            extracted_block = []
-            for instruction in idautils.Heads(block.start_ea, block.end_ea):
-                if ida_bytes.is_code(ida_bytes.get_flags(instruction)):
-                    extracted_block.append(instruction)
-            if extracted_block:
-                blocks.append(extracted_block)
-        return sorted(blocks)
-
-    def getInstructionBytes(self, offset):
-        ins = idautils.DecodeInstruction(offset)
-        ins_bytes = ida_bytes.get_bytes(offset, ins.size)
-        return ins_bytes
-
-    def getCodeInRefs(self, offset):
-        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
-
-    def getCodeOutRefs(self, offset):
-        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
-
-    def getFunctionSymbols(self, demangle=False):
-        function_symbols = {}
-        function_offsets = self.getFunctions()
-        for function_offset in function_offsets:
-            function_name = ida_funcs.get_func_name(function_offset)
-            # apply demangling if required
-            if demangle and "@" in function_name:
-                demangled = ida_name.demangle_name(function_name, 0)
-                if demangled:
-                    function_name = demangled
-            if not re.match("sub_[0-9a-fA-F]+", function_name):
-                function_symbols[function_offset] = function_name
-        return function_symbols
-
-    def getBaseAddr(self):
-        base_addr = 0
-        segment_starts = list(idautils.Segments())
-        if segment_starts:
-            first_segment_start = segment_starts[0]
-            # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start // 0x10000) * 0x10000
-            base_addr = int(first_segment_start)
-        return base_addr
-
-    def getBinary(self):
-        result = b""
-        segment = ida_segment.get_first_seg()
-        while segment:
-            result += ida_bytes.get_bytes(segment.start_ea, segment.end_ea - segment.start_ea)
-            segment = ida_segment.get_next_seg(segment.end_ea - 1)
-        return result
-
-    def getApiMap(self):
-        self._api_map = {}
-        num_imports = ida_nalt.get_import_module_qty()
-        for i in range(num_imports):
-            self._import_module_name = ida_nalt.get_import_module_name(i)
-            ida_nalt.enum_import_names(i, self._cbEnumImports)
-        return self._api_map
-
-    def isExternalFunction(self, function_offset):
-        function_segment = ida_segment.getseg(function_offset)
-        function_segment_name = ida_segment.get_segm_name(function_segment)
-        is_extern = function_segment_name in ["extern", "UNDEF"]
-        return is_extern
-
-    def makeFunction(self, instruction):
-        return ida_funcs.add_func(instruction)
-
-    def makeNameEx(self, address, name, warning_level=None):
-        if warning_level is None:
-            warning_level = idc.SN_NOWARN
-        return idc.set_name(address, name, warning_level)
-
-    def _cbEnumImports(self, addr, name, ordinal):
-        # potentially use: idc.Name(addr)
-        if self._import_module_name:
-            self._api_map[addr] = self._import_module_name + "!" + name
-        else:
-            self._api_map[addr] = name
-        return True
-
-
-class Ida73Interface(BackendInterface):
-    def __init__(self):
-        self.version = "IDA Pro 7.3 and below"
-        self._processor_map = {"metapc": "intel"}
-        self._api_map = {}
-        self._import_module_name = ""
-
-    def getArchitecture(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        info = idaapi.get_inf_structure()
-        procname = info.procName
-        if procname == "ARM":
-            if self.getBitness() != 64:
-                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
-            return "aarch64"
-        if procname in self._processor_map:
-            return self._processor_map[procname]
-        else:
-            raise ValueError("Unsupported Architecture")
-
-    def getBitness(self):
-        # https://reverseengineering.stackexchange.com/a/11398
-        bits = None
-        info = idaapi.get_inf_structure()
-        if info.is_64bit():
-            bits = 64
-        elif info.is_32bit():
-            bits = 32
-        else:
-            bits = 16
-        return bits
-
-    def getFunctions(self):
-        return sorted(idautils.Functions())
-
-    def getBlocks(self, function_offset):
-        blocks = []
-        function_chart = idaapi.FlowChart(idaapi.get_func(function_offset))
-        for block in function_chart:
-            extracted_block = []
-            for instruction in idautils.Heads(block.startEA, block.endEA):
-                if idc.isCode(idc.GetFlags(instruction)):
-                    extracted_block.append(instruction)
-            if extracted_block:
-                blocks.append(extracted_block)
-        return sorted(blocks)
-
-    def getInstructionBytes(self, offset):
-        ins = idautils.DecodeInstruction(offset)
-        ins_bytes = idc.get_bytes(offset, ins.size)
-        return ins_bytes
-
-    def getCodeInRefs(self, offset):
-        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
-
-    def getCodeOutRefs(self, offset):
-        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
-
-    def getFunctionSymbols(self, demangle=False):
-        function_symbols = {}
-        function_offsets = self.getFunctions()
-        for function_offset in function_offsets:
-            function_name = idc.GetFunctionName(function_offset)
-            # apply demangling if required
-            if demangle and "@" in function_name:
-                function_name = idc.demangle_name(function_name, 0)
-            if not re.match("sub_[0-9a-fA-F]+", function_name):
-                function_symbols[function_offset] = function_name
-        return function_symbols
-
-    def getBaseAddr(self):
-        segment_starts = list(idautils.Segments())
-        if not segment_starts:
-            return 0
-        first_segment_start = segment_starts[0]
-        # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-        first_segment_start = (first_segment_start // 0x10000) * 0x10000
-        return int(first_segment_start)
-
-    def getBinary(self):
-        result = b""
-        segment_starts = list(idautils.Segments())
-        offsets = []
-        start_len = 0
-        for start in segment_starts:
-            end = idc.SegEnd(start)
-            result += idc.get_bytes(start, end - start)
-            offsets.append((start, start_len, len(result)))
-            start_len = len(result)
-        return result
-
-    def getApiMap(self):
-        self._api_map = {}
-        num_imports = idaapi.get_import_module_qty()
-        for i in range(num_imports):
-            self._import_module_name = idaapi.get_import_module_name(i)
-            idaapi.enum_import_names(i, self._cbEnumImports)
-        return self._api_map
-
-    def isExternalFunction(self, function_offset):
-        return False
-
-    def makeFunction(self, instruction):
-        return idc.add_func(instruction)
-
-    def makeNameEx(self, address, name, warning_level=None):
-        if warning_level is None:
-            warning_level = idc.SN_NOWARN
-        return idc.set_name(address, name, warning_level)
-
-    def _cbEnumImports(self, addr, name, ordinal):
-        # potentially use: idc.Name(addr)
-        if self._import_module_name:
-            self._api_map[addr] = self._import_module_name + "!" + name
-        else:
-            self._api_map[addr] = name
-        return True
-
-
-class Ida85Interface(BackendInterface):
-    def __init__(self):
-        self.version = "IDA Pro 8.5+"
-        self._processor_map = {"metapc": "intel"}
-        self._api_map = {}
-        self._import_module_name = ""
-
-    def getArchitecture(self):
-        procname = idaapi.inf_get_procname()
-        if procname == "ARM":
-            if self.getBitness() != 64:
-                raise ValueError(f"Unsupported Architecture: {procname} ({self.getBitness()}bit)")
-            return "aarch64"
-        if procname in self._processor_map:
-            return self._processor_map[procname]
-        else:
-            raise ValueError("Unsupported Architecture")
-
-    def getBitness(self):
-        # https://blog.junron.dev/IDAPython%20Research/IDAPython%208%20to%209.html#idaapi-get-inf-structure
-        bits = None
-        if idaapi.inf_is_64bit():
-            bits = 64
-        elif idaapi.inf_is_32bit_exactly():
-            bits = 32
-        else:
-            bits = 16
-        return bits
-
-    def getFunctions(self):
-        return sorted(idautils.Functions())
-
-    def getBlocks(self, function_offset):
-        blocks = []
-        function_chart = ida_gdl.FlowChart(ida_funcs.get_func(function_offset))
-        for block in function_chart:
-            extracted_block = []
-            for instruction in idautils.Heads(block.start_ea, block.end_ea):
-                if ida_bytes.is_code(ida_bytes.get_flags(instruction)):
-                    extracted_block.append(instruction)
-            if extracted_block:
-                blocks.append(extracted_block)
-        return sorted(blocks)
-
-    def getInstructionBytes(self, offset):
-        ins = idautils.DecodeInstruction(offset)
-        ins_bytes = ida_bytes.get_bytes(offset, ins.size)
-        return ins_bytes
-
-    def getCodeInRefs(self, offset):
-        return [(ref_from, offset) for ref_from in idautils.CodeRefsTo(offset, True)]
-
-    def getCodeOutRefs(self, offset):
-        return [(offset, ref_to) for ref_to in idautils.CodeRefsFrom(offset, True)]
-
-    def getFunctionSymbols(self, demangle=False):
-        function_symbols = {}
-        function_offsets = self.getFunctions()
-        for function_offset in function_offsets:
-            function_name = ida_funcs.get_func_name(function_offset)
-            # apply demangling if required
-            if demangle and "@" in function_name:
-                demangled = ida_name.demangle_name(function_name, 0)
-                if demangled:
-                    function_name = demangled
-            if not re.match("sub_[0-9a-fA-F]+", function_name):
-                function_symbols[function_offset] = function_name
-        return function_symbols
-
-    def getBaseAddr(self):
-        base_addr = 0
-        segment_starts = list(idautils.Segments())
-        if segment_starts:
-            first_segment_start = segment_starts[0]
-            # re-align by 0x10000 to reflect typically allocation behaviour for IDA-mapped binaries
-            first_segment_start = (first_segment_start // 0x10000) * 0x10000
-            base_addr = int(first_segment_start)
-        return base_addr
-
-    def getBinary(self):
-        result = b""
-        segment = ida_segment.get_first_seg()
-        while segment:
-            result += ida_bytes.get_bytes(segment.start_ea, segment.end_ea - segment.start_ea)
-            segment = ida_segment.get_next_seg(segment.end_ea - 1)
-        return result
-
-    def getApiMap(self):
-        self._api_map = {}
-        num_imports = ida_nalt.get_import_module_qty()
-        for i in range(num_imports):
-            self._import_module_name = ida_nalt.get_import_module_name(i)
-            ida_nalt.enum_import_names(i, self._cbEnumImports)
-        return self._api_map
-
-    def isExternalFunction(self, function_offset):
-        function_segment = ida_segment.getseg(function_offset)
-        function_segment_name = ida_segment.get_segm_name(function_segment)
-        is_extern = function_segment_name in ["extern", "UNDEF"]
-        return is_extern
-
-    def makeFunction(self, instruction):
-        return ida_funcs.add_func(instruction)
-
-    def makeNameEx(self, address, name, warning_level=None):
-        if warning_level is None:
-            warning_level = idc.SN_NOWARN
-        return idc.set_name(address, name, warning_level)
-
-    def _cbEnumImports(self, addr, name, ordinal):
-        # potentially use: idc.Name(addr)
-        if self._import_module_name:
-            self._api_map[addr] = self._import_module_name + "!" + name
-        else:
-            self._api_map[addr] = name
-        return True
+    @classmethod
+    def fromPath(cls, input_path, save_on_close=False):
+        domain_interface = _getDomainInterface()
+        if domain_interface is None:
+            raise ImportError(
+                "Headless IDA export requires IDA Pro 9.1+ and the optional ida-domain dependency. "
+                "Install it with 'pip install \"smda[ida]\"'."
+            )
+        return domain_interface.fromPath(input_path, save_on_close=save_on_close)

--- a/tests/testIdaInterface.py
+++ b/tests/testIdaInterface.py
@@ -1,0 +1,239 @@
+import types
+import unittest
+from unittest import mock
+
+from smda.ida import IdaDomainInterface as ida_domain_backend
+from smda.ida import IdaInterface as ida_compatibility
+from smda.ida.IdaDomainInterface import IdaDomainInterface
+from smda.ida.IdaIdapythonInterface import Ida73Interface, Ida74Interface, Ida85Interface
+
+
+class TestIdaBackendSelection(unittest.TestCase):
+    def tearDown(self):
+        ida_compatibility.IdaInterface.instance = None
+
+    def test_legacy_sdk_boundaries(self):
+        self.assertIs(ida_compatibility._selectBackend(739), Ida73Interface)
+        self.assertIs(ida_compatibility._selectBackend(740), Ida74Interface)
+        self.assertIs(ida_compatibility._selectBackend(849), Ida74Interface)
+        self.assertIs(ida_compatibility._selectBackend(850), Ida85Interface)
+        self.assertIs(ida_compatibility._selectBackend(900), Ida85Interface)
+
+    def test_domain_is_preferred_only_for_supported_sdk_versions(self):
+        class DomainBackend:
+            pass
+
+        self.assertIs(ida_compatibility._selectBackend(900, DomainBackend), Ida85Interface)
+        self.assertIs(ida_compatibility._selectBackend(910, DomainBackend), DomainBackend)
+        self.assertIs(ida_compatibility._selectBackend(940, DomainBackend), DomainBackend)
+
+    def test_new_ida_falls_back_to_idapython_without_domain(self):
+        self.assertIs(ida_compatibility._selectBackend(910), Ida85Interface)
+        self.assertIs(ida_compatibility._selectBackend(940), Ida85Interface)
+
+    def test_invalid_sdk_version_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported IDA SDK version"):
+            ida_compatibility._selectBackend("940")
+
+    def test_facade_uses_domain_when_available(self):
+        class DomainBackend:
+            pass
+
+        with (
+            mock.patch.object(ida_compatibility, "getIdaSdkVersion", return_value=940),
+            mock.patch.object(ida_compatibility, "_getDomainInterface", return_value=DomainBackend),
+        ):
+            interface = ida_compatibility.IdaInterface()
+        self.assertIsInstance(interface.instance, DomainBackend)
+
+    def test_facade_does_not_probe_domain_on_older_ida(self):
+        with (
+            mock.patch.object(ida_compatibility, "getIdaSdkVersion", return_value=850),
+            mock.patch.object(ida_compatibility, "_getDomainInterface") as get_domain,
+            mock.patch.object(ida_compatibility, "_selectBackend", return_value=mock.Mock),
+        ):
+            ida_compatibility.IdaInterface()
+        get_domain.assert_not_called()
+
+    def test_domain_probe_does_not_import_optional_package(self):
+        with (
+            mock.patch.object(ida_compatibility.importlib.util, "find_spec", return_value=object()),
+            mock.patch.object(ida_domain_backend.importlib, "import_module") as import_module,
+        ):
+            self.assertIs(ida_compatibility._getDomainInterface(), IdaDomainInterface)
+        import_module.assert_not_called()
+
+    def test_domain_probe_returns_none_when_package_is_missing(self):
+        with mock.patch.object(ida_compatibility.importlib.util, "find_spec", return_value=None):
+            self.assertIsNone(ida_compatibility._getDomainInterface())
+
+    def test_facade_falls_back_when_domain_cannot_initialize(self):
+        domain_backend = mock.Mock(side_effect=ida_domain_backend.IdaDomainUnavailableError("domain unavailable"))
+        legacy_backend = mock.Mock()
+        with (
+            mock.patch.object(ida_compatibility, "getIdaSdkVersion", return_value=940),
+            mock.patch.object(ida_compatibility, "_getDomainInterface", return_value=domain_backend),
+            mock.patch.object(ida_compatibility, "_selectBackend", side_effect=[domain_backend, legacy_backend]),
+        ):
+            ida_compatibility.IdaInterface()
+        legacy_backend.assert_called_once_with()
+
+    def test_facade_does_not_hide_unrelated_domain_import_errors(self):
+        domain_backend = mock.Mock(side_effect=ImportError("database failure"))
+        with (
+            mock.patch.object(ida_compatibility, "getIdaSdkVersion", return_value=940),
+            mock.patch.object(ida_compatibility, "_getDomainInterface", return_value=domain_backend),
+            mock.patch.object(ida_compatibility, "_selectBackend", return_value=domain_backend),
+            self.assertRaisesRegex(ImportError, "database failure"),
+        ):
+            ida_compatibility.IdaInterface()
+
+    def test_headless_export_has_clear_optional_dependency_error(self):
+        with (
+            mock.patch.object(ida_compatibility, "_getDomainInterface", return_value=None),
+            self.assertRaisesRegex(ImportError, r'pip install "smda\[ida\]"'),
+        ):
+            ida_compatibility.IdaInterface.fromPath("sample.i64")
+
+    def test_lazy_domain_import_has_clear_optional_dependency_error(self):
+        with (
+            mock.patch.object(ida_domain_backend.importlib, "import_module", side_effect=ImportError),
+            self.assertRaisesRegex(ImportError, r'pip install "smda\[ida\]"'),
+        ):
+            ida_domain_backend._getDatabaseClass()
+
+    def test_headless_export_owns_and_closes_database(self):
+        database = _FakeDatabase()
+        database_factory = mock.Mock()
+        database_factory.open.return_value = database
+        with (
+            mock.patch.object(ida_compatibility, "_getDomainInterface", return_value=IdaDomainInterface),
+            mock.patch.object(ida_domain_backend, "_getDatabaseClass", return_value=database_factory),
+        ):
+            interface = ida_compatibility.IdaInterface.fromPath("sample.i64", save_on_close=False)
+        database_factory.open.assert_called_once_with(path="sample.i64", save_on_close=False)
+        interface.close()
+        self.assertTrue(database.closed)
+
+
+class _FakeImports:
+    def get_all_imports(self):
+        return iter(
+            [
+                types.SimpleNamespace(address=0x1000, name="CreateFileW", ordinal=1, module_name="kernel32.dll"),
+                types.SimpleNamespace(address=0x2000, name=None, ordinal=7, module_name="test.dll"),
+                types.SimpleNamespace(address=0x3000, name="symbol", ordinal=0, module_name=""),
+            ]
+        )
+
+
+class _FakeFunctions:
+    def __init__(self):
+        self.function = types.SimpleNamespace(start_ea=0x1000)
+
+    def get_all(self):
+        return iter([self.function])
+
+    def get_at(self, offset):
+        return self.function if offset == self.function.start_ea else None
+
+    def get_flowchart(self, function):
+        instruction = types.SimpleNamespace(ea=0x1000)
+        block = types.SimpleNamespace(start_ea=0x1000, end_ea=0x1004, get_instructions=lambda: iter([instruction]))
+        return iter([block])
+
+    def get_name(self, function):
+        return "named_function"
+
+    def create(self, instruction):
+        return instruction == 0x1000
+
+
+class _FakeSegments:
+    def __init__(self):
+        self.code = types.SimpleNamespace(start_ea=0x12345, end_ea=0x12349, name="text")
+
+    def get_all(self):
+        return iter([self.code])
+
+    def get_at(self, offset):
+        return self.code if self.code.start_ea <= offset < self.code.end_ea else None
+
+    def get_bitness(self, segment):
+        return 64
+
+    def get_size(self, segment):
+        return segment.end_ea - segment.start_ea
+
+    def get_name(self, segment):
+        return segment.name
+
+
+class _FakeDatabase:
+    def __init__(self, architecture="metapc", bitness=64):
+        self.architecture = architecture
+        self.bitness = bitness
+        self.minimum_ea = 0x1000
+        self.path = "/tmp/input.bin"
+        self.functions = _FakeFunctions()
+        self.segments = _FakeSegments()
+        self.imports = _FakeImports()
+        self.instructions = types.SimpleNamespace(
+            get_at=lambda offset: types.SimpleNamespace(size=4) if offset == 0x1000 else None
+        )
+        self.bytes = types.SimpleNamespace(get_bytes_at=lambda offset, size: b"\x90" * size)
+        self.xrefs = types.SimpleNamespace(
+            code_refs_to_ea=lambda offset, flow=True: iter([0x900]),
+            code_refs_from_ea=lambda offset, flow=True: iter([0x1100]),
+        )
+        self.names = types.SimpleNamespace(
+            get_demangled_name=lambda offset: "demangled",
+            set_name=lambda address, name: bool(name),
+        )
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class TestIdaDomainInterface(unittest.TestCase):
+    def test_domain_uses_high_level_entities(self):
+        interface = IdaDomainInterface(database=_FakeDatabase())
+        self.assertEqual(interface.getArchitecture(), "intel")
+        self.assertEqual(interface.getBitness(), 64)
+        self.assertEqual(interface.getFunctions(), [0x1000])
+        self.assertEqual(interface.getBlocks(0x1000), [[0x1000]])
+        self.assertEqual(interface.getInstructionBytes(0x1000), b"\x90\x90\x90\x90")
+        self.assertEqual(interface.getInstructionBytes(0x2000), b"")
+        self.assertEqual(interface.getCodeInRefs(0x1000), [(0x900, 0x1000)])
+        self.assertEqual(interface.getCodeOutRefs(0x1000), [(0x1000, 0x1100)])
+        self.assertEqual(interface.getFunctionSymbols(), {0x1000: "named_function"})
+        self.assertEqual(interface.getBaseAddr(), 0x10000)
+        self.assertEqual(interface.getBinary(), b"\x90\x90\x90\x90")
+
+    def test_domain_maps_aarch64_and_rejects_arm32(self):
+        self.assertEqual(IdaDomainInterface(database=_FakeDatabase("ARM", 64)).getArchitecture(), "aarch64")
+        self.assertEqual(IdaDomainInterface(database=_FakeDatabase("aarch64", 64)).getArchitecture(), "aarch64")
+        with self.assertRaisesRegex(ValueError, r"Unsupported Architecture: ARM \(32bit\)"):
+            IdaDomainInterface(database=_FakeDatabase("ARM", 32)).getArchitecture()
+
+    def test_domain_import_map_preserves_named_and_ordinal_imports(self):
+        interface = IdaDomainInterface(database=_FakeDatabase())
+        self.assertEqual(
+            interface.getApiMap(),
+            {
+                0x1000: "kernel32.dll!CreateFileW",
+                0x2000: "test.dll!#7",
+                0x3000: "symbol",
+            },
+        )
+
+    def test_injected_database_is_not_closed(self):
+        database = _FakeDatabase()
+        interface = IdaDomainInterface(database=database)
+        interface.close()
+        self.assertFalse(database.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testIdaScripts.py
+++ b/tests/testIdaScripts.py
@@ -1,0 +1,73 @@
+import json
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import ida_analyze
+import ida_domain_export
+
+
+class TestIdaAnalyze(unittest.TestCase):
+    def test_analyze_runs_smda_and_augments_ida(self):
+        ida_interface = mock.Mock()
+        ida_interface.getBinary.return_value = b"\x90"
+        ida_interface.getBaseAddr.return_value = 0x1000
+        ida_interface.getArchitecture.return_value = "intel"
+        ida_interface.getBitness.return_value = 64
+        ida_interface.makeFunction.side_effect = [True, False]
+        ida_interface.makeNameEx.return_value = True
+        report = mock.Mock()
+        report.getFunctions.return_value = [
+            types.SimpleNamespace(offset=0x1000, function_name="entry"),
+            types.SimpleNamespace(offset=0x2000, function_name=""),
+        ]
+        disassembler = mock.Mock()
+        disassembler.disassembleBuffer.return_value = report
+
+        with (
+            mock.patch.object(ida_analyze, "IdaInterface", return_value=ida_interface),
+            mock.patch.object(ida_analyze, "Disassembler", return_value=disassembler) as disassembler_class,
+        ):
+            result = ida_analyze.analyze()
+
+        self.assertIs(result, report)
+        disassembler_class.assert_called_once_with(mock.ANY)
+        disassembler.disassembleBuffer.assert_called_once_with(b"\x90", 0x1000, bitness=64, architecture="intel")
+        self.assertEqual(ida_interface.makeFunction.call_count, 2)
+        ida_interface.makeNameEx.assert_called_once_with(0x1000, "entry")
+
+
+class TestIdaDomainExport(unittest.TestCase):
+    def test_export_database_uses_ida_exporter(self):
+        ida_interface = mock.Mock()
+        ida_interface.getBinary.return_value = b"\x90"
+        ida_interface.getBaseAddr.return_value = 0x1000
+        database_context = mock.MagicMock()
+        database_context.__enter__.return_value = ida_interface
+        report = mock.Mock(num_functions=1)
+        report.toDict.return_value = {"status": "ok"}
+        disassembler = mock.Mock()
+        disassembler.disassembleBuffer.return_value = report
+        ida_exporter = mock.Mock()
+        disassembler_class = mock.Mock(return_value=disassembler)
+        ida_exporter_class = mock.Mock(return_value=ida_exporter)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "report.smda"
+            with (
+                mock.patch.object(ida_domain_export.IdaInterface, "fromPath", return_value=database_context),
+                mock.patch.object(ida_domain_export, "Disassembler", disassembler_class),
+                mock.patch.object(ida_domain_export, "IdaExporter", ida_exporter_class),
+            ):
+                result = ida_domain_export.export_database("sample.i64", output_path)
+
+            self.assertEqual(json.loads(output_path.read_text()), {"status": "ok"})
+
+        self.assertIs(result, report)
+        self.assertIs(disassembler.disassembler, ida_exporter)
+        self.assertTrue(disassembler._explicit_backend)
+        self.assertEqual(disassembler_class.call_count, 1)
+        ida_exporter_class.assert_called_once_with(disassembler_class.call_args.args[0], ida_interface=ida_interface)
+        disassembler.disassembleBuffer.assert_called_once_with(b"\x90", 0x1000)


### PR DESCRIPTION
## Summary

Adds IDA Domain as an optional, preferred backend for compatible IDA 9.1+ installations while retaining the existing IDAPython adapters for legacy IDA users.

This addresses the maintainer feedback by preserving IDA 8.4/8.5 and older workflows, keeping `ida-domain` out of the core installation, and selecting Domain only when both the IDA SDK version and package availability permit it.

## Compatibility policy

| IDA SDK | Preferred backend | Fallback |
| --- | --- | --- |
| below 7.4 | existing IDAPython 7.3 adapter | n/a |
| 7.4-8.4 | existing IDAPython 7.4 adapter | n/a |
| 8.5-9.0 | existing IDAPython 8.5 adapter | n/a |
| 9.1+ | IDA Domain when installed | IDAPython 8.5 adapter |

The policy lives in one ordered backend table and one Domain threshold in `IdaInterface.py`. Callers no longer make their own version or dependency decisions. Adding or dropping a generation is therefore an explicit selector-table change plus its isolated adapter, rather than a repository-wide conditional cleanup.

## Changes

- Split the legacy implementations into `IdaIdapythonInterface.py` while preserving the public `Ida73Interface`, `Ida74Interface`, and `Ida85Interface` imports.
- Added an isolated `IdaDomainInterface` adapter and a central facade that prefers it only for SDK 9.1+ when `ida-domain` imports successfully.
- Made Domain availability probing side-effect free: importing the adapter no longer initializes IDA's licensed SWIG runtime, and GUI selection still falls back to IDAPython if lazy Domain initialization fails.
- Used IDA Domain 0.5 high-level functions, flowcharts, instructions, bytes, xrefs, names, imports, and segments APIs where they directly replace low-level traversal. The low-level `ida_loader` path call remains only for the IDB directory because `Database.path` identifies the input file, not the database file.
- Added the `ida` optional extra (`pip install "smda[ida]"`); ordinary SMDA installations remain unchanged.
- Added `ida_domain_export.py` for headless database/input export through IDA Domain/idalib.
- Restored `ida_analyze.py` as an independent SMDA recovery workflow that adds functions and names to the current IDA database. It no longer re-exports IDA's existing function set.
- Kept IDA 7.x support because the isolated adapters do not block the Domain design and removing them provides no practical benefit in this change.
- Added compatibility-boundary, fallback, lifecycle, architecture, import, flowchart, byte, xref, and script-role regression tests.
- Integrated the upstream exporter and AArch64 behavior that the Domain adapter builds on.

The implementation was checked against the official [IDA Domain documentation](https://ida-domain.docs.hex-rays.com/), its [LLM reference](https://ida-domain.docs.hex-rays.com/llms-full.txt), the [Domain API overview](https://hex-rays.com/blog/whats-new-in-the-ida-domain-api), and the [IDA 9.4 release notes](https://hex-rays.com/blog/ida-9.4-release-a-new-dyld-shared-cache-swift-analysis-new-teams-add-on-and-more-). Version 0.5 is used because its current high-level imports API and compatibility work provide concrete value without pulling decompiler/microcode APIs into this exporter.

## Validation

- `make lint` - passed
- `make test` - 471 passed, 1 skipped
- `python -m ruff format --check .` - passed
- `pre-commit run --all-files` - passed
- `python -m build` - passed
- built-wheel metadata inspection - `ida-domain>=0.5.0` appears only under `Provides-Extra: ida`
- focused IDA compatibility and script tests with warnings promoted to errors - 19 passed, no warnings
- repository-wide compatibility and script-role sweep - no caller-side version selection or stale `ida_domain_analyze.py` references remain
- live IDA Domain 0.5 / IDA Professional 9.3 headless export using `tests/pe_export_label_test_xored` - report loaded successfully, matched IDA's function set and memory-image hash, and preserved `exported_test_function` at `0x401000`

Licensed GUI and idalib execution across every supported IDA release cannot be automated in this repository. Legacy 7.x/8.x and IDA 9.4 behavior therefore remains source- and mock-verified, while the Domain path has additionally been exercised end to end on IDA 9.3.
