### PR TITLE
fix(intel): add safeguards against candidate-identification memory explosion (#85)

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -34,6 +34,11 @@ class SmdaConfig:
     RESOLVE_REGISTER_CALLS = True
     # limit this to avoid blowing up analysis time for weird samples
     MAX_INDIRECT_CALLS_PER_BASIC_BLOCK = 50
+    # backstops against memory usage explosion during candidate identification on pathological/junk samples
+    # maximum number of function candidates to track; 0 == unlimited. Normal binaries have orders of magnitude fewer.
+    MAX_FUNCTION_CANDIDATES = 200000
+    # maximum number of inbound call references tracked per candidate; 0 == unlimited. Bounds set growth and rescoring.
+    MAX_CALL_REFS_PER_CANDIDATE = 2000
     HIGH_ACCURACY = True
     RESOLVE_TAILCALLS = False
     # optional metadata generation options

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -633,10 +633,11 @@ class FunctionCandidateManager:
                 stub_addr = self.disassembly.binary_info.base_addr + block.start() + match.start()
                 if not self._passesCodeFilter(stub_addr):
                     continue
-                self.addPrologueCandidate(stub_addr & self.getBitMask())
-                self.setInitialCandidate(stub_addr & self.getBitMask())
-                if stub_addr in self.candidates:
-                    self.candidates[stub_addr].setIsStub(True)
+                stub_addr_masked = stub_addr & self.getBitMask()
+                self.addPrologueCandidate(stub_addr_masked)
+                self.setInitialCandidate(stub_addr_masked)
+                if stub_addr_masked in self.candidates:
+                    self.candidates[stub_addr_masked].setIsStub(True)
         # structure for plt entries is similar but interleaved with additional code not considered functions
         for block in re.finditer(
             b"(?P<block>(\xff\x25[\\S\\s]{4}\x68[\\S\\s]{4}\xe9[\\S\\s]{4}){2,})",
@@ -646,10 +647,11 @@ class FunctionCandidateManager:
                 stub_addr = self.disassembly.binary_info.base_addr + block.start() + match.start()
                 if not self._passesCodeFilter(stub_addr):
                     continue
-                self.addPrologueCandidate(stub_addr & self.getBitMask())
-                self.setInitialCandidate(stub_addr & self.getBitMask())
-                if stub_addr in self.candidates:
-                    self.candidates[stub_addr].setIsStub(True)
+                stub_addr_masked = stub_addr & self.getBitMask()
+                self.addPrologueCandidate(stub_addr_masked)
+                self.setInitialCandidate(stub_addr_masked)
+                if stub_addr_masked in self.candidates:
+                    self.candidates[stub_addr_masked].setIsStub(True)
                 # define data bytes inbetween
                 for offset in range(10):
                     self.disassembly.data_map.add(stub_addr + 6 + offset)
@@ -681,10 +683,11 @@ class FunctionCandidateManager:
                 stub_addr = self.disassembly.binary_info.base_addr + block.start() + match.start()
                 if not self._passesCodeFilter(stub_addr):
                     continue
-                self.addPrologueCandidate(stub_addr & self.getBitMask())
-                self.setInitialCandidate(stub_addr & self.getBitMask())
-                if stub_addr in self.candidates:
-                    self.candidates[stub_addr].setIsStub(True)
+                stub_addr_masked = stub_addr & self.getBitMask()
+                self.addPrologueCandidate(stub_addr_masked)
+                self.setInitialCandidate(stub_addr_masked)
+                if stub_addr_masked in self.candidates:
+                    self.candidates[stub_addr_masked].setIsStub(True)
                 # define data bytes inbetween
                 for offset in range(5):
                     self.disassembly.data_map.add(stub_addr + 7 + offset)

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -39,11 +39,15 @@ class FunctionCandidateManager:
         self.gap_pointer = None
         self.previously_analyzed_gap = 0
         self.capstone = None
+        # backstop against memory usage explosion during candidate identification
+        self._candidate_cap_logged = False
+        self._cb_analysis_timeout = None
 
-    def init(self, disassembly):
+    def init(self, disassembly, cbAnalysisTimeout=None):
         if disassembly.binary_info.code_areas:
             self._code_areas = disassembly.binary_info.code_areas
         self.disassembly = disassembly
+        self._cb_analysis_timeout = cbAnalysisTimeout
         self.lang_analyzer = LanguageAnalyzer(disassembly)
         self.disassembly.language = self.lang_analyzer.identify()
         self.bitness = disassembly.binary_info.bitness
@@ -105,13 +109,21 @@ class FunctionCandidateManager:
                     self.candidate_queue.update(self.candidates[candidate_addr])
                 self.candidate_queue.update()
 
+    def _addCappedCallRef(self, candidate, source_ref):
+        """add an inbound call reference, honoring MAX_CALL_REFS_PER_CANDIDATE to bound set growth and rescoring."""
+        cap = getattr(self.config, "MAX_CALL_REFS_PER_CANDIDATE", 0)
+        if cap == 0 or len(candidate.call_ref_sources) < cap:
+            candidate.addCallRef(source_ref)
+
     def addCandidate(self, addr, is_gap=False, reference_source=None):
         if not self._passesCodeFilter(addr):
             return False
         self.ensureCandidate(addr)
+        if addr not in self.candidates:
+            return False
         self.candidates[addr].setIsGapCandidate(is_gap)
         if reference_source:
-            self.candidates[addr].addCallRef(reference_source)
+            self._addCappedCallRef(self.candidates[addr], reference_source)
         self.candidate_queue.add(self.candidates[addr])
         self.candidate_queue.update()
 
@@ -348,6 +360,16 @@ class FunctionCandidateManager:
     def ensureCandidate(self, addr):
         """create candidate if it does not exist yet, returns True if newly created, else False"""
         if addr not in self.candidates:
+            cap = getattr(self.config, "MAX_FUNCTION_CANDIDATES", 0)
+            if cap and len(self.candidates) >= cap:
+                if not self._candidate_cap_logged:
+                    LOGGER.warning(
+                        "MAX_FUNCTION_CANDIDATES cap (%d) reached during candidate identification; "
+                        "refusing further candidates to bound memory usage.",
+                        cap,
+                    )
+                    self._candidate_cap_logged = True
+                return False
             self.candidates[addr] = FunctionCandidate(self.disassembly.binary_info, addr)
             return True
         return False
@@ -356,26 +378,30 @@ class FunctionCandidateManager:
         if not self._passesCodeFilter(addr):
             return False
         self.ensureCandidate(addr)
-        self.candidates[addr].setIsGapCandidate(True)
+        if addr in self.candidates:
+            self.candidates[addr].setIsGapCandidate(True)
 
     def addTailcallCandidate(self, addr):
         if not self._passesCodeFilter(addr):
             return False
         self.ensureCandidate(addr)
-        self.candidates[addr].setIsTailcallCandidate(True)
+        if addr in self.candidates:
+            self.candidates[addr].setIsTailcallCandidate(True)
 
     def addReferenceCandidate(self, addr, source_ref):
         if not self._passesCodeFilter(addr):
             return False
         if self.ensureCandidate(addr):
             self._all_call_refs[source_ref] = addr
-        self.candidates[addr].addCallRef(source_ref)
+        if addr in self.candidates:
+            self._addCappedCallRef(self.candidates[addr], source_ref)
 
     def addLanguageSpecCandidate(self, addr, lang_spec):
         if not self._passesCodeFilter(addr):
             return False
         self.ensureCandidate(addr)
-        self.candidates[addr].setLanguageSpec(lang_spec)
+        if addr in self.candidates:
+            self.candidates[addr].setLanguageSpec(lang_spec)
 
     def addPrologueCandidate(self, addr):
         if not self._passesCodeFilter(addr):
@@ -386,15 +412,17 @@ class FunctionCandidateManager:
         if not self._passesCodeFilter(addr):
             return False
         self.ensureCandidate(addr)
-        self.candidates[addr].setIsSymbol(True)
-        self.candidates[addr].setInitialCandidate(True)
+        if addr in self.candidates:
+            self.candidates[addr].setIsSymbol(True)
+            self.candidates[addr].setInitialCandidate(True)
 
     def addExceptionCandidate(self, addr):
         if not self._passesCodeFilter(addr):
             return False
         self.ensureCandidate(addr)
-        self.candidates[addr].setIsExceptionHandler(True)
-        self.candidates[addr].setInitialCandidate(True)
+        if addr in self.candidates:
+            self.candidates[addr].setIsExceptionHandler(True)
+            self.candidates[addr].setInitialCandidate(True)
 
     def resolvePointerReference(self, offset):
         if self.bitness == 32:
@@ -437,13 +465,35 @@ class FunctionCandidateManager:
                     identified_alignment = 16
         return identified_alignment
 
+    def _candidateTimeoutTripped(self):
+        """returns True once the wall-clock analysis timeout has been hit during candidate identification."""
+        if self.disassembly is not None and self.disassembly.analysis_timeout:
+            return True
+        if self._cb_analysis_timeout is not None and self._cb_analysis_timeout():
+            if self.disassembly is not None:
+                self.disassembly.analysis_timeout = True
+            return True
+        return False
+
     def locateCandidates(self):
+        # add guaranteed / high-value starts first so that, if the candidate cap is hit, the most reliable
+        # candidates are retained before the high-volume prologue and stub-chain scans can consume the budget.
         self.locateSymbolCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locateReferenceCandidates()
-        self.locatePrologueCandidates()
-        self.locateLangSpecCandidates()
-        self.locateStubChainCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locateExceptionHandlerCandidates()
+        if self._candidateTimeoutTripped():
+            return
+        self.locateLangSpecCandidates()
+        if self._candidateTimeoutTripped():
+            return
+        self.locatePrologueCandidates()
+        if self._candidateTimeoutTripped():
+            return
+        self.locateStubChainCandidates()
         self.identified_alignment = self._identifyAlignment()
 
     def _buildQueue(self):
@@ -464,7 +514,9 @@ class FunctionCandidateManager:
 
     def locateReferenceCandidates(self):
         # check for potential call instructions and check if their destinations have a common function prologue
-        for call_match in re.finditer(b"\xe8", self.disassembly.binary_info.binary):
+        for match_count, call_match in enumerate(re.finditer(b"\xe8", self.disassembly.binary_info.binary)):
+            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                return
             if not self._passesCodeFilter(self.disassembly.binary_info.base_addr + call_match.start()):
                 continue
             if len(self.disassembly.binary_info.binary) - call_match.start() > 5:
@@ -484,7 +536,9 @@ class FunctionCandidateManager:
                     self.setInitialCandidate(call_destination)
         # also check for "jmp dword ptr <offset>", as they sometimes point to local functions (i.e. non-API)
         if self.bitness == 32:
-            for match in re.finditer(b"\xff\x25", self.disassembly.binary_info.binary):
+            for match_count, match in enumerate(re.finditer(b"\xff\x25", self.disassembly.binary_info.binary)):
+                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                    return
                 function_addr = self.resolvePointerReference(match.start())
                 if not self._passesCodeFilter(function_addr):
                     continue
@@ -495,7 +549,9 @@ class FunctionCandidateManager:
                     )
                     self.setInitialCandidate(function_addr)
             # also check for "call dword ptr <offset>", as they sometimes point to local functions (i.e. non-API)
-            for match in re.finditer(b"\xff\x15", self.disassembly.binary_info.binary):
+            for match_count, match in enumerate(re.finditer(b"\xff\x15", self.disassembly.binary_info.binary)):
+                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                    return
                 function_addr = self.resolvePointerReference(match.start())
                 if not self._passesCodeFilter(function_addr):
                     continue
@@ -509,7 +565,11 @@ class FunctionCandidateManager:
     def locatePrologueCandidates(self):
         # next check for the default function prologue regardless of references
         for re_prologue in DEFAULT_PROLOGUES:
-            for prologue_match in re.finditer(re.escape(re_prologue), self.disassembly.binary_info.binary):
+            for match_count, prologue_match in enumerate(
+                re.finditer(re.escape(re_prologue), self.disassembly.binary_info.binary)
+            ):
+                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                    return
                 if not self._passesCodeFilter(self.disassembly.binary_info.base_addr + prologue_match.start()):
                     continue
                 self.addPrologueCandidate(
@@ -575,7 +635,8 @@ class FunctionCandidateManager:
                     continue
                 self.addPrologueCandidate(stub_addr & self.getBitMask())
                 self.setInitialCandidate(stub_addr & self.getBitMask())
-                self.candidates[stub_addr].setIsStub(True)
+                if stub_addr in self.candidates:
+                    self.candidates[stub_addr].setIsStub(True)
         # structure for plt entries is similar but interleaved with additional code not considered functions
         for block in re.finditer(
             b"(?P<block>(\xff\x25[\\S\\s]{4}\x68[\\S\\s]{4}\xe9[\\S\\s]{4}){2,})",
@@ -587,7 +648,8 @@ class FunctionCandidateManager:
                     continue
                 self.addPrologueCandidate(stub_addr & self.getBitMask())
                 self.setInitialCandidate(stub_addr & self.getBitMask())
-                self.candidates[stub_addr].setIsStub(True)
+                if stub_addr in self.candidates:
+                    self.candidates[stub_addr].setIsStub(True)
                 # define data bytes inbetween
                 for offset in range(10):
                     self.disassembly.data_map.add(stub_addr + 6 + offset)
@@ -621,7 +683,8 @@ class FunctionCandidateManager:
                     continue
                 self.addPrologueCandidate(stub_addr & self.getBitMask())
                 self.setInitialCandidate(stub_addr & self.getBitMask())
-                self.candidates[stub_addr].setIsStub(True)
+                if stub_addr in self.candidates:
+                    self.candidates[stub_addr].setIsStub(True)
                 # define data bytes inbetween
                 for offset in range(5):
                     self.disassembly.data_map.add(stub_addr + 7 + offset)

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -599,7 +599,7 @@ class IntelDisassembler:
         # once we are initialized, add OEP
         if binary_info.oep is not None:
             self.fc_manager.symbol_addresses.append(binary_info.base_addr + binary_info.oep)
-        self.fc_manager.init(self.disassembly)
+        self.fc_manager.init(self.disassembly, cbAnalysisTimeout)
         self._initCapstone()
         self._initTfIdf()
         LOGGER.debug("Starting heuristical analysis.")

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -1,0 +1,81 @@
+#!/usr/bin/python
+
+import logging
+import types
+import unittest
+
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+
+logging.disable(logging.CRITICAL)
+
+
+def _make_manager(config, binary=b"\x55\x8b\xec" * 1024, base_addr=0x1000, bitness=32):
+    """build a minimal FunctionCandidateManager wired with just enough state to exercise the caps."""
+    manager = FunctionCandidateManager(config)
+    binary_info = types.SimpleNamespace(bitness=bitness, base_addr=base_addr, binary=binary)
+    manager.disassembly = types.SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+    manager.bitness = bitness
+    return manager
+
+
+class CandidateSafeguardsTestSuite(unittest.TestCase):
+    """Tests for the memory-usage-explosion safeguards added for issue #85."""
+
+    def test_max_function_candidates_cap_is_honored(self):
+        config = SmdaConfig()
+        config.MAX_FUNCTION_CANDIDATES = 10
+        manager = _make_manager(config)
+        # request far more candidates than the cap allows
+        for offset in range(1000):
+            manager.ensureCandidate(0x1000 + offset)
+        self.assertEqual(len(manager.candidates), 10)
+
+    def test_refused_candidate_does_not_raise_keyerror(self):
+        config = SmdaConfig()
+        config.MAX_FUNCTION_CANDIDATES = 1
+        manager = _make_manager(config)
+        # the first candidate is accepted, every later distinct address is refused; none of the
+        # add-helpers must raise a KeyError when their candidate gets refused.
+        for offset in range(5):
+            addr = 0x1000 + offset * 4
+            manager.addReferenceCandidate(addr, 0x2000 + offset)
+            manager.addGapCandidate(addr + 1)
+            manager.addTailcallCandidate(addr + 2)
+            manager.addSymbolCandidate(addr + 3)
+            manager.addExceptionCandidate(addr + 3)
+            manager.addLanguageSpecCandidate(addr + 3, "go")
+        self.assertEqual(len(manager.candidates), 1)
+
+    def test_unlimited_when_cap_is_zero(self):
+        config = SmdaConfig()
+        config.MAX_FUNCTION_CANDIDATES = 0
+        manager = _make_manager(config)
+        for offset in range(500):
+            manager.ensureCandidate(0x1000 + offset)
+        self.assertEqual(len(manager.candidates), 500)
+
+    def test_max_call_refs_per_candidate_cap_is_honored(self):
+        config = SmdaConfig()
+        config.MAX_CALL_REFS_PER_CANDIDATE = 5
+        manager = _make_manager(config)
+        for source in range(1000):
+            manager.addReferenceCandidate(0x1000, 0x9000 + source)
+        self.assertEqual(len(manager.candidates[0x1000].call_ref_sources), 5)
+
+    def test_call_refs_unlimited_when_cap_is_zero(self):
+        config = SmdaConfig()
+        config.MAX_CALL_REFS_PER_CANDIDATE = 0
+        manager = _make_manager(config)
+        for source in range(200):
+            manager.addReferenceCandidate(0x1000, 0x9000 + source)
+        self.assertEqual(len(manager.candidates[0x1000].call_ref_sources), 200)
+
+    def test_default_config_values(self):
+        config = SmdaConfig()
+        self.assertEqual(config.MAX_FUNCTION_CANDIDATES, 200000)
+        self.assertEqual(config.MAX_CALL_REFS_PER_CANDIDATE, 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version_history.md
+++ b/version_history.md
@@ -1,4 +1,5 @@
 # Full Version History
+ * 2026-06-01: v3.0.2 - Added safeguards against memory usage explosion during candidate identification on pathological/junk samples (issue #85): new SmdaConfig backstops `MAX_FUNCTION_CANDIDATES` (default 200000) and `MAX_CALL_REFS_PER_CANDIDATE` (default 2000), the high-volume reference/prologue locators now honor the existing wall-clock TIMEOUT, and high-value candidate locators run before the cap can be exhausted.
  * 2025-02-24: v1.14.3 - PicHashing can now be disabled via SmdaConfig to save some processing time. (THX to @Nalexander-hanel!)
  * 2025-02-24: v1.14.2 - We are Python 3.8+ compatible again (changed UTC usage) and (DWARF) PE symbols for PE files should be extracted again (THX to @N0fix for the update!)
  * 2025-02-21: v1.14.1 - Fixed changed field names in LIEF usage that broke ELF parsing, added tests for ELF+macOS parsing (THX to @N0fix for the update!)


### PR DESCRIPTION
## Summary

Adds bounded, low-risk safeguards so the **candidate-identification phase** of the intel backend can no longer explode memory on pathological / junk-code samples (issue [#85](https://github.com/danielplohmann/smda/issues/85), documented example `win.minijunk/f54fccb2…2f3c0f8_unpacked`), without regressing accuracy on normal binaries.

> Note on branch: this work was committed to `claude/loving-hamilton-9kqyh` (the branch this session was provisioned with). The task text mentioned `claude/keen-thompson-6M6jt`; I followed the provisioned branch and am flagging the discrepancy here.

## Root cause

`IntelDisassembler.analyzeBuffer()` calls `fc_manager.init()` → `locateCandidates()` **before any timeout check**. The existing wall-clock `TIMEOUT` (`cbAnalysisTimeout`) was only consulted inside the two analysis loops, so candidate identification was **uncapped in both count and time**:

- `locatePrologueCandidates` runs `re.finditer` over very short `DEFAULT_PROLOGUES` (incl. the 3-byte `U��`) → on junk code this creates **millions** of candidates, each funneled into `self.candidates`.
- `locateReferenceCandidates` scans every `�` CALL and accumulates per-candidate inbound refs into an unbounded `call_ref_sources` set, invalidating the score cache on every add.
- No config caps existed for candidate count or per-candidate refs.

Only the intel backend uses `FunctionCandidateManager` (CIL/Dalvik don't), so the fix is intel-scoped.

## Changes

**`SmdaConfig`** — two backstops near `MAX_INDIRECT_CALLS_PER_BASIC_BLOCK` (`0` = unlimited):
- `MAX_FUNCTION_CANDIDATES = 200000` — generous cap; real binaries have orders of magnitude fewer.
- `MAX_CALL_REFS_PER_CANDIDATE = 2000` — bounds per-candidate inbound-ref set growth and repeated rescoring.

**`FunctionCandidateManager`**
- `ensureCandidate()` refuses new candidates once `MAX_FUNCTION_CANDIDATES` is reached (logged once).
- **Every** post-add `self.candidates[addr]` dereference is hardened with `if addr in self.candidates:` so a refused candidate can never raise `KeyError` (`addCandidate`, `addGapCandidate`, `addTailcallCandidate`, `addReferenceCandidate`, `addLanguageSpecCandidate`, `addSymbolCandidate`, `addExceptionCandidate`, and the three `locateStubChainCandidates` `setIsStub` sites).
- New `_addCappedCallRef()` enforces `MAX_CALL_REFS_PER_CANDIDATE` in the manager (where `self.config` lives — no plumbing into `FunctionCandidate`). Scoring stays monotonic (`calculateScore` already saturates the ref contribution) and `_identifyAlignment`'s `len(...) > 1` test is unaffected.
- `init()` accepts `cbAnalysisTimeout`; the high-volume `locateReferenceCandidates` / `locatePrologueCandidates` loops check it every ~4096 matches, set `disassembly.analysis_timeout = True`, and `return` early (never `raise`). `locateCandidates` checks the tripped flag between locators and returns; `_buildQueue()` still runs, so partial results stay valid.
- `locateCandidates` **reordered** so guaranteed / high-value starts are collected before the high-volume scans can exhaust the cap: symbols → references → exception-handlers → langspec → prologues → stub-chains.

**`IntelDisassembler`** — passes `cbAnalysisTimeout` into `fc_manager.init()`.

## Before / after (documented sample, 28.7 MB PE32+ DLL)

| scenario | result |
|---|---|
| **End-to-end, unpatched, `TIMEOUT=600`** | **OOM-killed at ~13.5 GB RSS** (analysis ran uncapped in time) |
| **End-to-end, patched, default `TIMEOUT=300`** | stays bounded, never approaches OOM |
| **Candidate phase, uncapped** | 8,464 candidates, **max 16,033** inbound refs on one target, 25,452 total refs |
| **Candidate phase, capped (defaults)** | 8,464 candidates, **max 2,000** refs (capped), 11,419 total refs |

The candidate **count** cap is not even reached for this real binary (8,464 ≪ 200,000) — the active safeguard here is the **call-ref cap** (16,033 → 2,000), which also eliminates ~14 k redundant score-cache invalidations, plus the new wall-clock bounding of candidate ID.

### Synthetic junk reproduction (the `MAX_FUNCTION_CANDIDATES` path)

An 8 MB buffer dense in the 3-byte `U��` prologue (modelling junk code like the minijunk family), candidate-phase only:

| | candidates | tracemalloc peak |
|---|---|---|
| uncapped (master) | **2,796,202** | **1,472 MB** |
| capped (default 200,000) | 200,000 | **110 MB** |

→ **~13× candidate-phase memory reduction** with the cap enforced.

## Verification

- `python3 -m pytest tests/test*` → **117 passed** (+79 subtests). The asprox integration test still asserts exactly **105 functions** — no accuracy regression with the new defaults.
- New `tests/testCandidateSafeguards.py` (6 tests): caps honored, refused candidates never raise `KeyError`, `0` = unlimited, and defaults are `200000` / `2000`.
- `version_history.md`: added `3.0.2` entry.

## Risks & mitigations
- **KeyError from refused candidates** → every `self.candidates[addr]` deref after an add-helper is guarded (enumerated above) and covered by a test.
- **Accuracy regression** → defaults are far above realistic counts; high-value locators run before the cap; asprox fixture unchanged.

https://claude.ai/code/session_01HK2iDrXoJxWu9h8sS4Ay6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK2iDrXoJxWu9h8sS4Ay6M)_