### PR TITLE
fix(common): make getDetailed span-consistent for WAIT-prefixed x87 instructions

### DIFF
--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -16,6 +16,10 @@ class SmdaInstruction:
     operands = None
     detailed = None
     _data_refs = None
+    # x87 instructions have explicit-WAIT and no-WAIT encodings (e.g. FSTCW vs FNSTCW).
+    # For the WAIT-prefixed form Capstone decodes the 0x9b prefix as a standalone
+    # `wait`/`fwait` instruction, so it must be skipped when picking the operation detail.
+    _WAIT_PREFIX_MNEMONICS = frozenset({"wait", "fwait"})
 
     def __init__(self, ins_list=None, smda_function=None):
         self.smda_function = smda_function
@@ -68,28 +72,28 @@ class SmdaInstruction:
         if self.detailed is None:
             capstone = self.smda_function.smda_report.getCapstone()
             with_details = list(capstone.disasm(bytes.fromhex(self.bytes), self.offset))
-            # TODO
-            # this may diverge on instructions like
-            # 9bd93c24 -
-            # <CsInsn 0x4d3f1f0 [9b]: wait >
-            # 1 wait
-            # <CsInsn 0x4d3f1f1 [d93c24]: fnstcw word ptr [esp]>
-            # 3 fnstcw word ptr [esp]
-            # which is split by capstone but treated as one / prefix by IDA
-            # https://fragglet.github.io/dos-help-files/alang.hlp/FLDCW.html
-            # FSTCW has wait and no-wait versions. The wait version (FSTCW)
-            # checks for unmasked numeric errors; the no-wait version (FNSTCW)
-            # does not. When the .8087 directive is used, the assembler puts the
-            # WAIT instruction before the wait version and the NOP instruction
-            # before the no-wait version.
-            if len(with_details) > 1:
-                LOGGER.warning(
-                    f"Sequence {self.bytes} disassembles to {len(with_details)} instructions but expected one - taking the last instruction only!"
-                )
-                self.detailed = with_details[-1]
-            else:
-                assert len(with_details) == 1
+            if not with_details:
+                raise ValueError(f"Capstone could not disassemble stored bytes '{self.bytes}' at 0x{self.offset:x}")
+            if len(with_details) == 1:
                 self.detailed = with_details[0]
+            else:
+                # Capstone can split a single SMDA/IDA instruction whose bytes carry an x87
+                # WAIT prefix, e.g. `9bd93c24` -> `wait` + `fnstcw word ptr [esp]`. The trailing
+                # operation carries the operands and its (address + size) still reaches the end of
+                # the stored byte span, so it is the span-consistent detail to return. We drop any
+                # standalone WAIT/FWAIT prefix instruction(s) before selecting it.
+                # See https://fragglet.github.io/dos-help-files/alang.hlp/FLDCW.html
+                operation_insns = [insn for insn in with_details if insn.mnemonic not in self._WAIT_PREFIX_MNEMONICS]
+                self.detailed = (operation_insns or with_details)[-1]
+                if len(operation_insns) != 1:
+                    # not the known WAIT-prefix pattern - surface the unexpected split
+                    LOGGER.warning(
+                        "Sequence %s disassembled to %d instructions (%s) but expected one - using '%s'.",
+                        self.bytes,
+                        len(with_details),
+                        ", ".join(insn.mnemonic for insn in with_details),
+                        self.detailed.mnemonic,
+                    )
         return self.detailed
 
     def getMnemonicGroup(self, escaper):

--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -2281,7 +2281,9 @@ class IntelInstructionEscaper:
             try:
                 if ins.getDetailed().disp_size == 8:
                     pack_format = "<Q"
-            except (AttributeError, AssertionError, NotImplementedError):
+            except (AttributeError, AssertionError, NotImplementedError, ValueError):
+                # ValueError: getDetailed() raises it when the stored bytes do not decode;
+                # fall back to the default 32-bit pack_format rather than crash here.
                 pass
             try:
                 packed_hex = str(codecs.encode(struct.pack(pack_format, offset), "hex").decode("ascii"))

--- a/tests/testSmdaInstructionDetail.py
+++ b/tests/testSmdaInstructionDetail.py
@@ -1,0 +1,48 @@
+import logging
+import unittest
+from types import SimpleNamespace
+
+from smda.common.SmdaInstruction import SmdaInstruction
+from smda.common.SmdaReport import SmdaReport
+
+
+def _intel_instruction(offset, raw_bytes, mnemonic, operands, bitness=32):
+    report = SmdaReport(None)
+    report.architecture = "intel"
+    report.bitness = bitness
+    smda_function = SimpleNamespace(smda_report=report)
+    return SmdaInstruction([offset, raw_bytes, mnemonic, operands], smda_function=smda_function)
+
+
+class TestGetDetailed(unittest.TestCase):
+    def test_single_instruction_is_returned_unchanged(self):
+        detailed = _intel_instruction(0x1000, "90", "nop", "").getDetailed()
+        self.assertEqual(detailed.mnemonic, "nop")
+        self.assertEqual(detailed.address, 0x1000)
+        self.assertEqual(detailed.size, 1)
+
+    def test_wait_prefixed_x87_returns_span_consistent_operation(self):
+        # `9bd93c24` is the WAIT-prefixed FSTCW that IDA/SMDA store as one instruction, but
+        # Capstone splits into `wait` + `fnstcw word ptr [esp]`. getDetailed() must return the
+        # x87 operation, with its memory operand and an (address + size) reaching the byte span end.
+        offset = 0x4D3F1F0
+        ins = _intel_instruction(offset, "9bd93c24", "fstcw", "word ptr [esp]")
+        with self.assertNoLogs(logger="smda.common.SmdaInstruction", level=logging.WARNING):
+            detailed = ins.getDetailed()
+        self.assertEqual(detailed.mnemonic, "fnstcw")
+        self.assertEqual(detailed.address + detailed.size, offset + 4)
+        self.assertTrue(detailed.operands)
+
+    def test_empty_bytes_raise_value_error(self):
+        with self.assertRaises(ValueError):
+            _intel_instruction(0x1000, "", "nop", "").getDetailed()
+
+    def test_non_intel_architecture_raises(self):
+        ins = _intel_instruction(0x1000, "90", "nop", "")
+        ins.smda_function.smda_report.architecture = "dalvik"
+        with self.assertRaises(NotImplementedError):
+            ins.getDetailed()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testSmdaInstructionDetail.py
+++ b/tests/testSmdaInstructionDetail.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from smda.common.SmdaInstruction import SmdaInstruction
 from smda.common.SmdaReport import SmdaReport
+from smda.intel.IntelInstructionEscaper import IntelInstructionEscaper
 
 
 def _intel_instruction(offset, raw_bytes, mnemonic, operands, bitness=32):
@@ -42,6 +43,13 @@ class TestGetDetailed(unittest.TestCase):
         ins.smda_function.smda_report.architecture = "dalvik"
         with self.assertRaises(NotImplementedError):
             ins.getDetailed()
+
+    def test_escaper_tolerates_undecodable_bytes(self):
+        # getDetailed() now raises ValueError (not AssertionError) on undecodable bytes;
+        # escapeBinaryPtrRef must still swallow it and fall back rather than crash.
+        ins = _intel_instruction(0x1000, "", "mov", "eax, dword ptr [0x401000]")
+        result = IntelInstructionEscaper.escapeBinaryPtrRef(ins)
+        self.assertIsInstance(result, str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Addresses **danielplohmann/smda#114**. `SmdaInstruction.getDetailed()` re-disassembles the stored instruction bytes with Capstone, which can split a single SMDA/IDA instruction into two. The classic case is a WAIT-prefixed x87 op:

```
9bd93c24  ->  wait                       (1 byte)
              fnstcw word ptr [esp]       (3 bytes)
```

The old code took `with_details[-1]` and logged a warning **every time**. That happened to return the right detail here, but only by luck, and it would mis-select for any non-trailing split.

## Fix

- Drop standalone `wait`/`fwait` prefix instructions, then return the trailing **operation** instruction. Its operands and its `address + size` line up with the end of the stored byte span (`0x4d3f1f1 + 3 == 0x4d3f1f0 + 4`), so the returned detail is span-consistent.
- The known WAIT-prefix pattern is now **silent**; a warning is emitted only for genuinely unexpected splits (0 or >1 non-prefix instructions), and it now names the mnemonics involved.
- Replaced the bare `assert len(...) == 1` (strippable under `python -O`) with an explicit `ValueError` for the zero-instruction case.
- Removed the stale TODO comment block.

## Tests

New `tests/testSmdaInstructionDetail.py`:
- ordinary single instruction returned unchanged
- **`9bd93c24` regression**: returns `fnstcw`, carries the memory operand, `address + size` reaches the span end, and emits **no warning**
- empty bytes raise `ValueError`
- non-Intel architecture raises `NotImplementedError`

`make test` green locally (incl. `testIntegration`, which exercises `getDetailed()` via data-ref recovery); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved instruction decoding to correctly handle x87 floating-point wait instructions that may be decoded as separate operations
  * Enhanced error handling for cases where instruction bytes cannot be decoded

* **Tests**
  * Added test coverage for instruction detail extraction and related edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->