### PR TITLE
fix(loaders): derive ELF architecture from machine type

### DIFF
--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -44,11 +44,15 @@ def _resolve_elf_machine(elffile):
     width-ambiguous architectures (e.g. MIPS, RISC-V) it falls back to the ELF
     class so the reported bitness stays correct.
     """
-    if elffile is None:
+    # Guard against a missing header (failed parse, or an incomplete/mock
+    # object) so we report unsupported metadata instead of raising. We avoid a
+    # blanket try/except here so genuine parse/memory errors still surface.
+    if elffile is None or not hasattr(elffile, "header"):
         return "", 0, False
-    architecture, bitness, has_backend = _ELF_MACHINE_TYPES.get(elffile.header.machine_type, ("", 0, False))
+    header = elffile.header
+    architecture, bitness, has_backend = _ELF_MACHINE_TYPES.get(header.machine_type, ("", 0, False))
     if architecture and bitness == 0:
-        identity_class = elffile.header.identity_class
+        identity_class = header.identity_class
         if identity_class == lief.ELF.Header.CLASS.ELF64:
             bitness = 64
         elif identity_class == lief.ELF.Header.CLASS.ELF32:

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -15,6 +15,46 @@ LOGGER = logging.getLogger(__name__)
 # got None" (e.g. FileLoader saw lief.parse fail; do NOT retry).
 _NOT_PROVIDED = object()
 
+# Single source of truth mapping ELF machine types to (architecture, bitness,
+# has_backend). SMDA only ships an Intel disassembly backend, but reporting the
+# real architecture for recognized non-Intel ELFs keeps loader metadata honest
+# instead of pretending every ELF is x86. Architectures with has_backend=False
+# intentionally resolve to no disassembler later (controlled error report).
+# A bitness of 0 here means the machine type alone is width-ambiguous; it is
+# then resolved from the ELF class (identity_class) in _resolve_elf_machine().
+_ELF_MACHINE_TYPES = {
+    lief.ELF.ARCH.X86_64: ("intel", 64, True),
+    lief.ELF.ARCH.I386: ("intel", 32, True),
+    lief.ELF.ARCH.AARCH64: ("arm", 64, False),
+    lief.ELF.ARCH.ARM: ("arm", 32, False),
+    lief.ELF.ARCH.PPC64: ("ppc", 64, False),
+    lief.ELF.ARCH.PPC: ("ppc", 32, False),
+    lief.ELF.ARCH.SPARCV9: ("sparc", 64, False),
+    lief.ELF.ARCH.SPARC: ("sparc", 32, False),
+    lief.ELF.ARCH.MIPS: ("mips", 0, False),
+    lief.ELF.ARCH.RISCV: ("riscv", 0, False),
+}
+
+
+def _resolve_elf_machine(elffile):
+    """Return (architecture, bitness, has_backend) for a parsed ELF.
+
+    Architecture and support status come from the machine type. Bitness comes
+    from the same mapping when the machine type implies a fixed width; for
+    width-ambiguous architectures (e.g. MIPS, RISC-V) it falls back to the ELF
+    class so the reported bitness stays correct.
+    """
+    if elffile is None:
+        return "", 0, False
+    architecture, bitness, has_backend = _ELF_MACHINE_TYPES.get(elffile.header.machine_type, ("", 0, False))
+    if architecture and bitness == 0:
+        identity_class = elffile.header.identity_class
+        if identity_class == lief.ELF.Header.CLASS.ELF64:
+            bitness = 64
+        elif identity_class == lief.ELF.Header.CLASS.ELF32:
+            bitness = 32
+    return architecture, bitness, has_backend
+
 
 def align(v, alignment):
     remainder = v % alignment
@@ -246,21 +286,13 @@ class ElfFileLoader:
 
     @staticmethod
     def getArchitecture(binary, parsed=_NOT_PROVIDED):
-        del binary, parsed
-        return "intel"
+        elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
+        return _resolve_elf_machine(elffile)[0]
 
     @staticmethod
     def getBitness(binary, parsed=_NOT_PROVIDED):
-        # TODO add machine types whenever we add more architectures
         elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
-        if not elffile:
-            return 0
-        machine_type = elffile.header.machine_type
-        if machine_type == lief.ELF.ARCH.X86_64:
-            return 64
-        elif machine_type == lief.ELF.ARCH.I386:
-            return 32
-        return 0
+        return _resolve_elf_machine(elffile)[1]
 
     @staticmethod
     def mergeCodeAreas(code_areas):
@@ -268,7 +300,6 @@ class ElfFileLoader:
 
     @staticmethod
     def getCodeAreas(binary, parsed=_NOT_PROVIDED):
-        # TODO add machine types whenever we add more architectures
         elffile = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if elffile is None:
             return []

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -17,6 +17,7 @@ from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.SmdaConfig import SmdaConfig
+from smda.utility.ElfFileLoader import ElfFileLoader, _resolve_elf_machine
 from smda.utility.FileLoader import FileLoader
 
 from .context import config
@@ -216,6 +217,40 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
 
         self.assertEqual(provider.getFunctionSymbols(), {})
         self.assertIsNone(provider.getAddress("stale"))
+
+    @staticmethod
+    def _fake_elf(machine_type, identity_class):
+        return SimpleNamespace(header=SimpleNamespace(machine_type=machine_type, identity_class=identity_class))
+
+    def test_elf_machine_type_resolves_architecture_bitness_and_support(self):
+        # (machine_type, identity_class) -> (architecture, bitness, has_backend)
+        cases = [
+            (lief.ELF.ARCH.I386, lief.ELF.Header.CLASS.ELF32, ("intel", 32, True)),
+            (lief.ELF.ARCH.X86_64, lief.ELF.Header.CLASS.ELF64, ("intel", 64, True)),
+            # recognized but unsupported (no backend): metadata must stay accurate
+            (lief.ELF.ARCH.AARCH64, lief.ELF.Header.CLASS.ELF64, ("arm", 64, False)),
+            # width-ambiguous machine types: bitness comes from the ELF class
+            (lief.ELF.ARCH.MIPS, lief.ELF.Header.CLASS.ELF64, ("mips", 64, False)),
+            (lief.ELF.ARCH.MIPS, lief.ELF.Header.CLASS.ELF32, ("mips", 32, False)),
+            (lief.ELF.ARCH.RISCV, lief.ELF.Header.CLASS.ELF64, ("riscv", 64, False)),
+        ]
+        for machine_type, identity_class, expected in cases:
+            with self.subTest(machine_type=machine_type):
+                fake_elf = self._fake_elf(machine_type, identity_class)
+                self.assertEqual(_resolve_elf_machine(fake_elf), expected)
+                # public accessors must agree with the central resolver
+                self.assertEqual(ElfFileLoader.getArchitecture(b"", parsed=fake_elf), expected[0])
+                self.assertEqual(ElfFileLoader.getBitness(b"", parsed=fake_elf), expected[1])
+
+    def test_elf_unknown_machine_type_reports_empty_metadata(self):
+        # AVR is intentionally not in the mapping -> unsupported/empty, not "intel"
+        fake_elf = self._fake_elf(lief.ELF.ARCH.AVR, lief.ELF.Header.CLASS.ELF32)
+        self.assertEqual(ElfFileLoader.getArchitecture(b"", parsed=fake_elf), "")
+        self.assertEqual(ElfFileLoader.getBitness(b"", parsed=fake_elf), 0)
+
+    def test_elf_metadata_empty_when_parse_failed(self):
+        self.assertEqual(ElfFileLoader.getArchitecture(b"", parsed=None), "")
+        self.assertEqual(ElfFileLoader.getBitness(b"", parsed=None), 0)
 
 
 if __name__ == "__main__":

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -252,6 +252,13 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         self.assertEqual(ElfFileLoader.getArchitecture(b"", parsed=None), "")
         self.assertEqual(ElfFileLoader.getBitness(b"", parsed=None), 0)
 
+    def test_elf_metadata_empty_for_header_less_object(self):
+        # an incomplete/unexpected parse result without a header -> unsupported, no raise
+        header_less = SimpleNamespace(sections=[])
+        self.assertEqual(_resolve_elf_machine(header_less), ("", 0, False))
+        self.assertEqual(ElfFileLoader.getArchitecture(b"", parsed=header_less), "")
+        self.assertEqual(ElfFileLoader.getBitness(b"", parsed=header_less), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`ElfFileLoader.getArchitecture()` previously returned `"intel"` for **every** ELF file, so loader metadata was misleading for non-x86 inputs. This change derives ELF architecture, bitness, and backend-support status from a single machine-type mapping.

Addresses the remaining work in upstream issue [danielplohmann/smda#120](https://github.com/danielplohmann/smda/issues/120) (architecture reporting + centralized machine-type handling; bitness was already partly handled).

## Changes

- Add `_ELF_MACHINE_TYPES`: one mapping `lief.ELF.ARCH → (architecture, bitness, has_backend)`.
- Add `_resolve_elf_machine()` helper; `getArchitecture()` and `getBitness()` now both consume it.
- Width-ambiguous machine types (MIPS, RISC-V) resolve bitness from the ELF class (`identity_class`).
- Unknown machine types report `""` / `0` (explicit "unsupported") instead of `"intel"`.
- Drop the stale `# TODO add machine types` comments.

## Behavior

- **x86 / x86-64 unchanged** → still `("intel", 32/64)`.
- Recognized non-Intel ELFs (ARM/AArch64/PPC/SPARC/MIPS/RISC-V) now report their real architecture. SMDA only ships an Intel backend, so `Disassembler.initDisassembler` leaves the backend unset for these and `_disassemble` returns a **controlled error report** — it no longer mis-analyzes them as x86.
- A failed `lief.parse` now yields empty metadata (was `"intel"`), which likewise resolves to a controlled error report.

## Tests

`tests/testFileFormatParsers.py`: new mapping tests for x86, x86-64, AArch64 (recognized-but-unsupported), and MIPS/RISC-V (class-derived bitness), an unknown-machine-type case (AVR), and a failed-parse case. No new fixtures. The existing `bashlite_xored` (benign x86-64 `/bin/cat`) and `komplex` (x86-64) fixtures stay green.

## Validation

- `ruff check .` / `ruff format --check .` clean
- `make test` → 115 passed
- Reviewed by a Sonnet 4.6 subagent (extra-high reasoning); findings addressed (assert support flag, add RISC-V coverage).

Refs: #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)