### PR TITLE
fix(loaders): centralize Mach-O CPU type mapping

### DIFF
--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -48,7 +48,10 @@ def _resolve_macho_cpu(macho_file):
     """Return (architecture, bitness, has_backend) for a parsed Mach-O file,
     derived from its CPU type. Unknown CPU types report empty/unsupported
     metadata rather than guessing."""
-    if not macho_file:
+    # A FAT Mach-O parses to a lief.MachO.FatBinary, which has no ``header``;
+    # guard against that (and any incomplete object) so we report unsupported
+    # metadata instead of raising.
+    if not macho_file or not hasattr(macho_file, "header"):
         return "", 0, False
     return _MACHO_CPU_TYPES.get(macho_file.header.cpu_type, ("", 0, False))
 

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -20,6 +20,39 @@ except ImportError:
 _NOT_PROVIDED = object()
 
 
+def _build_macho_cpu_types():
+    # Single source of truth mapping Mach-O CPU types to
+    # (architecture, bitness, has_backend). Mach-O CPU types already encode
+    # the width (the 64-bit flag is part of the CPU type), so no extra lookup
+    # is needed to resolve bitness. SMDA only ships an Intel backend; recognized
+    # non-Intel CPU types are still reported accurately so loader metadata stays
+    # meaningful, but they intentionally resolve to no disassembler later
+    # (controlled error report) instead of being mis-analyzed as x86.
+    if not LIEF_AVAILABLE:
+        return {}
+    cpu = lief.MachO.Header.CPU_TYPE
+    return {
+        cpu.X86_64: ("intel", 64, True),
+        cpu.X86: ("intel", 32, True),
+        cpu.ARM64: ("arm", 64, False),
+        cpu.ARM: ("arm", 32, False),
+        cpu.POWERPC64: ("ppc", 64, False),
+        cpu.POWERPC: ("ppc", 32, False),
+    }
+
+
+_MACHO_CPU_TYPES = _build_macho_cpu_types()
+
+
+def _resolve_macho_cpu(macho_file):
+    """Return (architecture, bitness, has_backend) for a parsed Mach-O file,
+    derived from its CPU type. Unknown CPU types report empty/unsupported
+    metadata rather than guessing."""
+    if not macho_file:
+        return "", 0, False
+    return _MACHO_CPU_TYPES.get(macho_file.header.cpu_type, ("", 0, False))
+
+
 def align(v, alignment):
     remainder = v % alignment
     if remainder == 0:
@@ -180,37 +213,13 @@ class MachoFileLoader:
 
     @staticmethod
     def getArchitecture(binary, parsed=_NOT_PROVIDED):
-        # TODO add machine types whenever we add more architectures
         macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
-        if not macho_file:
-            return ""
-        machine_type = macho_file.header.cpu_type
-        if machine_type in [
-            lief.MachO.Header.CPU_TYPE.X86_64,
-            lief.MachO.Header.CPU_TYPE.X86,
-        ]:
-            return "intel"
-        elif machine_type in [
-            lief.MachO.Header.CPU_TYPE.ARM64,
-            lief.MachO.Header.CPU_TYPE.ARM,
-        ]:
-            return "arm"
-        raise NotImplementedError("SMDA does not support this architecture yet.")
+        return _resolve_macho_cpu(macho_file)[0]
 
     @staticmethod
     def getBitness(binary, parsed=_NOT_PROVIDED):
-        # TODO add machine types whenever we add more architectures
         macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
-        if not macho_file:
-            return 0
-        machine_type = macho_file.header.cpu_type
-        if machine_type == lief.MachO.Header.CPU_TYPE.X86_64:
-            return 64
-        elif machine_type == lief.MachO.Header.CPU_TYPE.X86:
-            return 32
-        elif machine_type == lief.MachO.Header.CPU_TYPE.ARM64:
-            raise NotImplementedError("SMDA does not support ARM yet.")
-        return 0
+        return _resolve_macho_cpu(macho_file)[1]
 
     @staticmethod
     def mergeCodeAreas(code_areas):
@@ -218,7 +227,6 @@ class MachoFileLoader:
 
     @staticmethod
     def getCodeAreas(binary, parsed=_NOT_PROVIDED):
-        # TODO add machine types whenever we add more architectures
         macho_file = lief.parse(binary) if parsed is _NOT_PROVIDED else parsed
         if not macho_file:
             return []

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -18,6 +18,7 @@ from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.SmdaConfig import SmdaConfig
 from smda.utility.FileLoader import FileLoader
+from smda.utility.MachoFileLoader import MachoFileLoader, _resolve_macho_cpu
 
 from .context import config
 
@@ -216,6 +217,39 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
 
         self.assertEqual(provider.getFunctionSymbols(), {})
         self.assertIsNone(provider.getAddress("stale"))
+
+    @staticmethod
+    def _fake_macho(cpu_type):
+        return SimpleNamespace(header=SimpleNamespace(cpu_type=cpu_type))
+
+    def test_macho_cpu_type_resolves_architecture_bitness_and_support(self):
+        cpu = lief.MachO.Header.CPU_TYPE
+        # cpu_type -> (architecture, bitness, has_backend)
+        cases = [
+            (cpu.X86, ("intel", 32, True)),
+            (cpu.X86_64, ("intel", 64, True)),
+            # recognized but unsupported (no backend): metadata must stay accurate
+            (cpu.ARM, ("arm", 32, False)),
+            (cpu.ARM64, ("arm", 64, False)),
+            (cpu.POWERPC, ("ppc", 32, False)),
+            (cpu.POWERPC64, ("ppc", 64, False)),
+        ]
+        for cpu_type, expected in cases:
+            with self.subTest(cpu_type=cpu_type):
+                fake_macho = self._fake_macho(cpu_type)
+                self.assertEqual(_resolve_macho_cpu(fake_macho), expected)
+                self.assertEqual(MachoFileLoader.getArchitecture(b"", parsed=fake_macho), expected[0])
+                self.assertEqual(MachoFileLoader.getBitness(b"", parsed=fake_macho), expected[1])
+
+    def test_macho_unknown_cpu_type_reports_empty_metadata(self):
+        # SPARC is intentionally not in the mapping -> unsupported/empty, no raise
+        fake_macho = self._fake_macho(lief.MachO.Header.CPU_TYPE.SPARC)
+        self.assertEqual(MachoFileLoader.getArchitecture(b"", parsed=fake_macho), "")
+        self.assertEqual(MachoFileLoader.getBitness(b"", parsed=fake_macho), 0)
+
+    def test_macho_metadata_empty_when_parse_failed(self):
+        self.assertEqual(MachoFileLoader.getArchitecture(b"", parsed=None), "")
+        self.assertEqual(MachoFileLoader.getBitness(b"", parsed=None), 0)
 
 
 if __name__ == "__main__":

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -251,6 +251,13 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         self.assertEqual(MachoFileLoader.getArchitecture(b"", parsed=None), "")
         self.assertEqual(MachoFileLoader.getBitness(b"", parsed=None), 0)
 
+    def test_macho_fat_binary_without_header_reports_empty_metadata(self):
+        # a FAT Mach-O parses to a header-less FatBinary -> unsupported, no raise
+        fat_binary = SimpleNamespace(architectures=[])
+        self.assertEqual(_resolve_macho_cpu(fat_binary), ("", 0, False))
+        self.assertEqual(MachoFileLoader.getArchitecture(b"", parsed=fat_binary), "")
+        self.assertEqual(MachoFileLoader.getBitness(b"", parsed=fat_binary), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`MachoFileLoader` duplicated CPU-type knowledge across `getArchitecture()`, `getBitness()`, and `getCodeAreas()`, with only partial ARM handling and per-method `NotImplementedError` raises. This centralizes that knowledge behind a single mapping + helper.

Addresses the remaining work in upstream issue [danielplohmann/smda#118](https://github.com/danielplohmann/smda/issues/118) (centralized CPU mapping + consistent metadata for recognized-but-unsupported architectures).

## Changes

- Add `_MACHO_CPU_TYPES`: one mapping `lief.MachO.Header.CPU_TYPE → (architecture, bitness, has_backend)`, built lazily via `_build_macho_cpu_types()` so the module still imports when LIEF is unavailable (consistent with the existing `LIEF_AVAILABLE` guard).
- Add `_resolve_macho_cpu()`; `getArchitecture()` and `getBitness()` both consume it.
- Drop the stale `# TODO add machine types` comments.

## Behavior

- **x86 / x86-64 unchanged** → `("intel", 32/64)`.
- Recognized non-Intel CPU types now report real metadata instead of raising: ARM → `("arm", 32)`, ARM64 → `("arm", 64)` (previously `getBitness` *raised* for ARM64), PPC/PPC64 → `("ppc", 32/64)`.
- Unknown CPU types report `""` / `0` instead of raising `NotImplementedError`.
- SMDA only ships an Intel backend, so unsupported architectures resolve to no disassembler → **controlled error report** (same end result the old raises produced, since `NotImplementedError` was already swallowed by `_handleDisassemblyException`).

## Tests

`tests/testFileFormatParsers.py`: mapping tests for X86, X86_64, ARM, ARM64, PPC, PPC64 (arch + bitness + support), an unknown-CPU case (SPARC), and a failed-parse case. No new fixtures. Existing `komplex` (x86-64) fixture stays green.

## Validation

- `ruff check .` / `ruff format --check .` clean
- `make test` → 115 passed
- Reviewed by a Sonnet 4.6 subagent (extra-high reasoning); LOW findings addressed (PPC32 coverage, falsy-guard consistency). Confirmed the raise→return change is safe (`NotImplementedError` was already caught into an error report).

Refs: #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)