### PR TITLE
fix(intel): resolve syscall numbers via basic-block backtracking

### DIFF
--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -60,6 +60,7 @@ SYSCALL_IMPLICIT_RAX_WRITERS = {
     "rdtscp",
     "rdmsr",
     "rdpmc",
+    "xgetbv",
     "lodsb",
     "lodsw",
     "lodsd",

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -38,6 +38,18 @@ from .MnemonicTfIdf import MnemonicTfIdf
 
 LOGGER = logging.getLogger(__name__)
 
+# Mnemonics that terminate basic-block-local backtracking when resolving a
+# syscall number: any branch/call/return or a further syscall/interrupt marks a
+# control-flow boundary that we must not cross, so value recovery stays local.
+SYSCALL_BACKTRACK_BOUNDARY = (
+    set(CALL_INS)
+    | set(JMP_INS)
+    | set(CJMP_INS)
+    | set(LOOP_INS)
+    | set(RET_INS)
+    | {"syscall", "sysenter", "int", "int3", "hlt"}
+)
+
 
 class SimpleIns:
     address = None
@@ -342,6 +354,54 @@ class IntelDisassembler:
         relative_end = relative_start + 15
         return self.disassembly.binary_info.binary[relative_start:relative_end]
 
+    def _resolveSyscallNumber(self, preceding_instructions, bitness):
+        """Conservatively recover the syscall-number register (rax on 64-bit,
+        eax on 32-bit) by backtracking over the preceding block-local
+        instructions.
+
+        ``preceding_instructions`` is the list of ``(address, size, mnemonic,
+        op_str)`` tuples already analyzed in the current block before the
+        ``syscall``, in execution order. We walk them in reverse and:
+
+        * return the integer value of the first ``mov <target_reg>, <imm>`` that
+          sets the register, or
+        * return ``None`` if the register is written by anything we cannot track
+          (computed value, register/memory source, sub-register write) or if a
+          control-flow boundary is reached first.
+
+        Returning ``None`` rather than guessing keeps speculative value recovery
+        from introducing false process endings.
+        """
+        if bitness == 64:
+            # a 32-bit write (e.g. ``mov eax, 0x3c``) zero-extends into rax,
+            # so eax also carries the syscall number on 64-bit.
+            target_regs = ("rax", "eax")
+            clobber_regs = ("rax", "eax", "ax", "al", "ah")
+        else:
+            target_regs = ("eax",)
+            clobber_regs = ("eax", "ax", "al", "ah")
+        for instruction in reversed(preceding_instructions):
+            mnemonic = instruction[2].split(" ")[-1]
+            if mnemonic in SYSCALL_BACKTRACK_BOUNDARY or mnemonic.startswith("j"):
+                return None
+            operands = [operand.strip().lower() for operand in instruction[3].split(",") if operand.strip()]
+            if not operands:
+                continue
+            destination = operands[0]
+            if destination not in clobber_regs:
+                # this instruction does not touch the syscall register; keep going
+                continue
+            if mnemonic in ("mov", "movabs") and len(operands) == 2 and destination in target_regs:
+                try:
+                    # base 0 handles capstone's 0x-prefixed hex as well as decimal
+                    return int(operands[1], 0)
+                except ValueError:
+                    # source is a register, memory operand, or expression -> unresolved
+                    return None
+            # any other write to the register family cannot be tracked conservatively
+            return None
+        return None
+
     def analyzeFunction(self, start_addr, as_gap=False):
         LOGGER.debug("analyzeFunction() starting analysis of candidate @0x%08x", start_addr)
         self.tailcall_analyzer.initFunction()
@@ -367,6 +427,10 @@ class IntelDisassembler:
             previous_address = None
             previous_mnemonic = None
             previous_op_str = None
+            # instructions analyzed so far in the current block, accumulated across
+            # cache-window refills so syscall-number backtracking stays block-local
+            # (the cache itself is only a small look-ahead window).
+            block_instructions = []
             while True:
                 for i in cache:
                     i_address, i_size, i_mnemonic, i_op_str = i
@@ -434,29 +498,24 @@ class IntelDisassembler:
                             i_address,
                         )
                     elif i_mnemonic_noprefix in ["syscall"]:
-                        if previous_address and previous_mnemonic == "mov":
-                            prev_operands = previous_op_str.split(",")
-                            if len(prev_operands) == 2:
-                                reg = prev_operands[0].strip().lower()
-                                if (self.disassembly.binary_info.bitness == 64 and reg == "rax") or (
-                                    self.disassembly.binary_info.bitness == 32 and reg == "eax"
-                                ):
-                                    try:
-                                        syscall_number_str = int(prev_operands[1].strip(), 16)
-                                    except ValueError:
-                                        # TODO we should do backtracking on the basic block to resolve the value properly
-                                        LOGGER.debug(
-                                            "failed to extract syscall number from: %s at 0x%x",
-                                            prev_operands,
-                                            i_address,
-                                        )
-                                        syscall_number_str = None
-                                    if syscall_number_str == 60:
-                                        self._analyzeEndInstruction(state)
-                                        LOGGER.debug(
-                                            "  analyzeFunction() found program ending instruction @0x%08x",
-                                            i_address,
-                                        )
+                        # Resolve the syscall number register (rax/eax) by backtracking
+                        # over the preceding block-local instructions, so we still detect
+                        # the process-ending exit syscall (60) when its number is not set
+                        # by the directly preceding instruction.
+                        syscall_number = self._resolveSyscallNumber(
+                            block_instructions, self.disassembly.binary_info.bitness
+                        )
+                        if syscall_number == 60:
+                            self._analyzeEndInstruction(state)
+                            LOGGER.debug(
+                                "  analyzeFunction() found program ending instruction @0x%08x",
+                                i_address,
+                            )
+                        elif syscall_number is None:
+                            LOGGER.debug(
+                                "could not resolve syscall number for syscall @0x%x",
+                                i_address,
+                            )
                     elif previous_address and i_address != start_addr and previous_mnemonic == "call":
                         instruction_sequence = list(
                             self.capstone.disasm(self._getDisasmWindowBuffer(i_address), i_address)
@@ -499,6 +558,7 @@ class IntelDisassembler:
                     previous_address = i_address
                     previous_mnemonic = i_mnemonic_noprefix
                     previous_op_str = i_op_str
+                    block_instructions.append(i)
                     if (
                         i_address not in self.disassembly.code_map
                         and i_address not in self.disassembly.data_map

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -50,6 +50,50 @@ SYSCALL_BACKTRACK_BOUNDARY = (
     | {"syscall", "sysenter", "int", "int3", "hlt"}
 )
 
+# Instructions that implicitly write the rax/eax register family without naming
+# it as their (first) explicit operand. capstone's disasm_lite shows no rax
+# destination for these, so syscall-number backtracking must treat them as
+# clobbers and stop, otherwise a stale value could be read past a real write.
+SYSCALL_IMPLICIT_RAX_WRITERS = {
+    "cpuid",
+    "rdtsc",
+    "rdtscp",
+    "rdmsr",
+    "rdpmc",
+    "lodsb",
+    "lodsw",
+    "lodsd",
+    "lodsq",
+    "cbw",
+    "cwde",
+    "cdqe",
+    "lahf",
+    "xlat",
+    "xlatb",
+    "mul",
+    "div",
+    "idiv",
+    "in",
+    "ins",
+    "insb",
+    "insw",
+    "insd",
+    "cmpxchg",
+    "cmpxchg8b",
+    "cmpxchg16b",
+    "aaa",
+    "aas",
+    "aad",
+    "aam",
+    "daa",
+    "das",
+}
+
+# Instructions whose first operand is a source rather than a destination, so the
+# target register appearing there is read, not clobbered: backtracking may
+# continue past them.
+SYSCALL_READ_ONLY_INS = {"cmp", "test", "push", "bt"}
+
 
 class SimpleIns:
     address = None
@@ -384,8 +428,24 @@ class IntelDisassembler:
             mnemonic = instruction[2].split(" ")[-1]
             if mnemonic in SYSCALL_BACKTRACK_BOUNDARY or mnemonic.startswith("j"):
                 return None
+            # instructions that implicitly modify rax/eax (no explicit destination
+            # operand) must stop resolution, or a write could be silently skipped
+            if mnemonic in SYSCALL_IMPLICIT_RAX_WRITERS:
+                return None
             operands = [operand.strip().lower() for operand in instruction[3].split(",") if operand.strip()]
+            # single-operand imul writes rdx:rax implicitly (the multi-operand
+            # forms write only their explicit destination, handled below)
+            if mnemonic == "imul" and len(operands) == 1:
+                return None
+            # xchg writes both operands, so the target register being written is
+            # not necessarily the first operand
+            if mnemonic == "xchg" and any(operand in clobber_regs for operand in operands):
+                return None
+            # read-only instructions whose first operand is a source do not clobber
+            if mnemonic in SYSCALL_READ_ONLY_INS:
+                continue
             if not operands:
+                # operand-less and not a known implicit writer (nop, cld, leave, ...)
                 continue
             destination = operands[0]
             if destination not in clobber_regs:

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -149,6 +149,33 @@ class TestIntelDisassembler(unittest.TestCase):
         # no preceding instructions at all
         self.assertIsNone(disassembler._resolveSyscallNumber([], 64))
 
+    def test_syscall_number_continues_past_read_only_instructions(self):
+        disassembler = self._create_disassembler()
+        # cmp/test/push read rax as a source but do not clobber it -> still resolves
+        for read_only in (self._ins("cmp", "rax, 1"), self._ins("test", "rax, rax"), self._ins("push", "rax")):
+            preceding = [self._ins("mov", "rax, 0x3c"), read_only]
+            self.assertEqual(disassembler._resolveSyscallNumber(preceding, 64), 60)
+
+    def test_syscall_number_unresolved_on_implicit_rax_clobber(self):
+        disassembler = self._create_disassembler()
+        # instructions that implicitly write rax/eax must stop resolution (no false 60)
+        for implicit in (
+            self._ins("cpuid", ""),  # operand-less implicit write
+            self._ins("rdtsc", ""),
+            self._ins("lodsq", ""),
+            self._ins("cdqe", ""),
+            self._ins("div", "rcx"),  # implicit rax:rdx write with an explicit operand
+            self._ins("imul", "rcx"),  # one-operand form writes rdx:rax
+        ):
+            preceding = [self._ins("mov", "rax, 0x3c"), implicit]
+            self.assertIsNone(disassembler._resolveSyscallNumber(preceding, 64))
+        # xchg writes both operands, even when rax is the second one
+        xchg_second = [self._ins("mov", "rax, 0x3c"), self._ins("xchg", "qword ptr [rdi], rax")]
+        self.assertIsNone(disassembler._resolveSyscallNumber(xchg_second, 64))
+        # multi-operand imul to an unrelated register does not clobber rax
+        imul_other = [self._ins("mov", "rax, 0x3c"), self._ins("imul", "rbx, rcx, 2")]
+        self.assertEqual(disassembler._resolveSyscallNumber(imul_other, 64), 60)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -162,6 +162,7 @@ class TestIntelDisassembler(unittest.TestCase):
         for implicit in (
             self._ins("cpuid", ""),  # operand-less implicit write
             self._ins("rdtsc", ""),
+            self._ins("xgetbv", ""),  # operand-less, writes edx:eax
             self._ins("lodsq", ""),
             self._ins("cdqe", ""),
             self._ins("div", "rcx"),  # implicit rax:rdx write with an explicit operand

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -106,6 +106,49 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertFalse(result.analysis_timeout)
 
+    @staticmethod
+    def _ins(mnemonic, op_str, address=0x1000, size=0):
+        # (address, size, mnemonic, op_str) as produced by capstone disasm_lite
+        return (address, size, mnemonic, op_str)
+
+    def test_syscall_number_resolved_from_direct_mov(self):
+        disassembler = self._create_disassembler()
+        # mov rax, 0x3c ; syscall  -> exit (60)
+        preceding = [self._ins("mov", "rax, 0x3c")]
+        self.assertEqual(disassembler._resolveSyscallNumber(preceding, 64), 60)
+        # 32-bit eax variant
+        preceding32 = [self._ins("mov", "eax, 0x1")]
+        self.assertEqual(disassembler._resolveSyscallNumber(preceding32, 32), 1)
+
+    def test_syscall_number_backtracks_over_unrelated_instructions(self):
+        disassembler = self._create_disassembler()
+        # mov rax, 0x3c ; xor edi, edi ; syscall  -> still resolves to 60
+        preceding = [self._ins("mov", "rax, 0x3c"), self._ins("xor", "edi, edi")]
+        self.assertEqual(disassembler._resolveSyscallNumber(preceding, 64), 60)
+        # 64-bit also honors a zero-extending eax write
+        preceding_eax = [self._ins("mov", "eax, 0x3c"), self._ins("mov", "rsi, 0x0")]
+        self.assertEqual(disassembler._resolveSyscallNumber(preceding_eax, 64), 60)
+        # movabs (capstone's mnemonic for the imm64 mov encoding) is honored
+        preceding_movabs = [self._ins("movabs", "rax, 0x3c")]
+        self.assertEqual(disassembler._resolveSyscallNumber(preceding_movabs, 64), 60)
+
+    def test_syscall_number_unresolved_on_clobber_or_boundary(self):
+        disassembler = self._create_disassembler()
+        # rax overwritten by an untrackable instruction after the mov -> None
+        clobbered = [self._ins("mov", "rax, 0x3c"), self._ins("xor", "rax, rax")]
+        self.assertIsNone(disassembler._resolveSyscallNumber(clobbered, 64))
+        # a control-flow boundary between the mov and the syscall stops backtracking
+        across_boundary = [self._ins("mov", "rax, 0x3c"), self._ins("call", "0x401000")]
+        self.assertIsNone(disassembler._resolveSyscallNumber(across_boundary, 64))
+        # prefixed boundary mnemonic ("bnd ret") is still recognized after prefix split
+        across_prefixed_boundary = [self._ins("mov", "rax, 0x3c"), self._ins("bnd ret", "")]
+        self.assertIsNone(disassembler._resolveSyscallNumber(across_prefixed_boundary, 64))
+        # value sourced from a register/memory operand is not a parseable immediate
+        from_register = [self._ins("mov", "rax, rbx")]
+        self.assertIsNone(disassembler._resolveSyscallNumber(from_register, 64))
+        # no preceding instructions at all
+        self.assertIsNone(disassembler._resolveSyscallNumber([], 64))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

SMDA's Intel backend classifies a Linux `syscall` as process-ending only when the syscall number register (`rax`==60, i.e. `exit`) is set by the **immediately preceding** `mov rax/eax, <imm>`. If the number is set a little less directly, the old code logged a debug message and gave up — that was the standing TODO in the `except ValueError` path.

Addresses upstream issue [danielplohmann/smda#119](https://github.com/danielplohmann/smda/issues/119).

## Changes

- Add `_resolveSyscallNumber(preceding_instructions, bitness)` in `src/smda/intel/IntelDisassembler.py`: a conservative, **block-local** backtracking resolver that walks the already-analyzed block instructions in reverse to find the `mov`/`movabs` that sets the syscall register.
- Add `SYSCALL_BACKTRACK_BOUNDARY` (reuses the existing `CALL/JMP/CJMP/LOOP/RET` sets + `syscall/sysenter/int/int3/hlt`) so backtracking never crosses a control-flow edge.
- Accumulate `block_instructions` across cache look-ahead refills (the disasm cache is only a ~15-byte window), so resolution isn't limited to one window and the direct case is preserved across refills.
- Replace the inline immediate parse (and its TODO) with a call to the resolver.

## Conservatism (no false endings)

The resolver returns `None` — never a guess — when the register is written by anything it can't track:
- non-`mov` writes (`xor eax, eax`, `lea`, `pop rax`, …),
- sub-register writes (`al`/`ah`/`ax`),
- register/memory/expression sources (`mov rax, rbx`, `mov rax, [rbp-8]`),
- or when a control-flow boundary is reached first.

So it only ever reports "process ending" when an actual `mov/movabs <rax|eax>, 0x3c` precedes the `syscall` in the same block. 64-bit honors the zero-extending `mov eax, 0x3c`; immediates are parsed with base 0 (handles capstone's `0x..` hex and decimal).

## Tests

`tests/testIntelDisassembler.py`: unit tests for the direct case (64- and 32-bit), backtracking over unrelated instructions, the `movabs` and zero-extending-`eax` forms, and the unresolved paths (clobber, control-flow boundary incl. a prefixed `bnd ret`, register source, empty input).

## Validation

- `ruff check .` / `ruff format --check .` clean
- `make test` → 116 passed
- Reviewed by a Sonnet 4.6 subagent (extra-high reasoning). Findings addressed: fixed a cross-cache-refill regression by accumulating `block_instructions` (instead of slicing the look-ahead window), added `movabs` handling, and switched to base-0 immediate parsing.

Refs: #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved syscall detection with conservative backtracking for more accurate identification of program termination within basic blocks.

* **Tests**
  * Added comprehensive test coverage for syscall resolution across various instruction patterns and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->