### PR TITLE
fix(intel): track all call refs for conflict cleanup

### DIFF
--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -111,6 +111,7 @@ class FunctionCandidateManager:
         self.ensureCandidate(addr)
         self.candidates[addr].setIsGapCandidate(is_gap)
         if reference_source:
+            self._all_call_refs[reference_source] = addr
             self.candidates[addr].addCallRef(reference_source)
         self.candidate_queue.add(self.candidates[addr])
         self.candidate_queue.update()
@@ -367,9 +368,10 @@ class FunctionCandidateManager:
     def addReferenceCandidate(self, addr, source_ref):
         if not self._passesCodeFilter(addr):
             return False
-        if self.ensureCandidate(addr):
+        self.ensureCandidate(addr)
+        if addr in self.candidates:
             self._all_call_refs[source_ref] = addr
-        self.candidates[addr].addCallRef(source_ref)
+            self.candidates[addr].addCallRef(source_ref)
 
     def addLanguageSpecCandidate(self, addr, lang_spec):
         if not self._passesCodeFilter(addr):

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 
 from smda.common.BinaryInfo import BinaryInfo
+from smda.intel.FunctionAnalysisState import FunctionAnalysisState
 from smda.intel.FunctionCandidate import FunctionCandidate
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.intel.IntelDisassembler import IntelDisassembler
@@ -105,6 +106,50 @@ class TestIntelDisassembler(unittest.TestCase):
         result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
 
         self.assertFalse(result.analysis_timeout)
+
+    def test_repeated_reference_candidates_participate_in_conflict_resolution(self):
+        config = SmdaConfig()
+        config.HIGH_ACCURACY = True
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = SimpleNamespace(binary_info=binary_info)
+        manager.bitness = 32
+        manager.addReferenceCandidate(0x1010, 0x1000)
+        manager.addReferenceCandidate(0x1010, 0x1005)
+        manager._buildQueue()
+
+        state = FunctionAnalysisState(0x1000, SimpleNamespace())
+        state.instruction_start_bytes = {0x1000}
+        state.processed_bytes = {0x1000, 0x1001, 0x1002, 0x1003, 0x1004, 0x1005}
+
+        manager.updateCandidates(state)
+
+        self.assertEqual(manager.candidates[0x1010].call_ref_sources, {0x1000})
+
+    def test_late_reference_candidates_participate_in_conflict_resolution(self):
+        config = SmdaConfig()
+        config.HIGH_ACCURACY = True
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = SimpleNamespace(binary_info=binary_info)
+        manager.bitness = 32
+        manager._buildQueue()
+        manager.addCandidate(0x1010, reference_source=0x1000)
+        manager.addCandidate(0x1010, reference_source=0x1005)
+
+        state = FunctionAnalysisState(0x1000, SimpleNamespace())
+        state.instruction_start_bytes = {0x1000}
+        state.processed_bytes = {0x1000, 0x1001, 0x1002, 0x1003, 0x1004, 0x1005}
+
+        manager.updateCandidates(state)
+
+        self.assertEqual(manager.candidates[0x1010].call_ref_sources, {0x1000})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Track every incoming call reference in `_all_call_refs` for active Intel function candidates.
- Cover both initial reference discovery and late candidates added with `reference_source`.
- Add focused regression tests proving high-accuracy conflict cleanup removes repeated refs that land inside an analyzed instruction.

## Root Cause
`FunctionCandidateManager.updateCandidates()` asks `FunctionAnalysisState.identifyCallConflicts()` to inspect `_all_call_refs`, but `_all_call_refs` only captured the first reference that created a candidate. Later references were still stored on `FunctionCandidate.call_ref_sources`, so scoring could see them, but conflict cleanup could not.

The requested `smda-pattern-scanner` pass found one same-family sibling: `addCandidate(..., reference_source=...)` also stored refs on the candidate without updating `_all_call_refs`. This patch fixes both paths.

## Validation
- `python -m ruff check .`
- `python -m pytest tests/test*` - 113 passed
- `python -m pytest tests/testIndirectCallAnalyzer.py tests/testIntelDisassembler.py -q` - 12 passed
- `git diff --check`
- Local master-vs-branch fixture compare across all bundled `tests/*_xored` samples: no stable-counter diffs for status, architecture, bitness, base address, SHA-256, function count, instruction count, or API-call count.

## Pattern Scan
- Pattern: PAT-SMDA-ALL-CALL-REFS
- Instances fixed: 2 in `src/smda/intel/FunctionCandidateManager.py`
- Partitions covered: P-intel, P-tests

## Residual Risk
The scanner also noted a related-but-different `_candidate_offsets` stale-cache risk for candidates added after `_buildQueue()`. I left that out of this PR because it is not the same `_all_call_refs` conflict-resolution bug class and would change a separate candidate-indexing behavior.