### PR TITLE
fix(intel): correctness fixes for CFG recovery surfaced during engine-refactor review

### DIFF
--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -188,7 +188,11 @@ class IntelDisassembler:
             current_byte = self.disassembly.getByte(current_offset)
             if isinstance(current_byte, str):
                 current_byte = ord(current_byte)
-            while current_byte < size and current_offset not in self.fc_manager.getFunctionStartCandidates():
+            while (
+                current_byte is not None
+                and current_byte < size
+                and current_offset not in self.fc_manager.getFunctionStartCandidates()
+            ):
                 indirect_switch_bytes.append(current_offset)
                 current_offset += 1
                 current_byte = self.disassembly.getByte(current_offset)
@@ -240,7 +244,8 @@ class IntelDisassembler:
             state.call_register_ins.append(i_address)
 
     def _handleCallTarget(self, state, from_addr, to_addr):
-        if to_addr and self.disassembly.isAddrWithinMemoryImage(to_addr):
+        # explicit None check: address 0 is valid in base-0 buffers
+        if to_addr is not None and self.disassembly.isAddrWithinMemoryImage(to_addr):
             state.addCodeRef(from_addr, to_addr)
         if state.start_addr == to_addr:
             state.setRecursion(True)
@@ -431,7 +436,7 @@ class IntelDisassembler:
                             "  analyzeFunction() found ending instruction @0x%08x",
                             i_address,
                         )
-                        if previous_address and previous_mnemonic == "push":
+                        if previous_address is not None and previous_mnemonic == "push":
                             push_ret_destination = self.getReferencedAddr(previous_op_str)
                             if self.disassembly.isAddrWithinMemoryImage(push_ret_destination):
                                 LOGGER.debug(
@@ -447,7 +452,7 @@ class IntelDisassembler:
                             i_address,
                         )
                     elif i_mnemonic_noprefix in ["syscall"]:
-                        if previous_address and previous_mnemonic == "mov":
+                        if previous_address is not None and previous_mnemonic == "mov":
                             prev_operands = previous_op_str.split(",")
                             if len(prev_operands) == 2:
                                 reg = prev_operands[0].strip().lower()
@@ -470,7 +475,7 @@ class IntelDisassembler:
                                             "  analyzeFunction() found program ending instruction @0x%08x",
                                             i_address,
                                         )
-                    elif previous_address and i_address != start_addr and previous_mnemonic == "call":
+                    elif previous_address is not None and i_address != start_addr and previous_mnemonic == "call":
                         instruction_sequence = list(
                             self.capstone.disasm(self._getDisasmWindowBuffer(i_address), i_address)
                         )

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -219,9 +219,17 @@ class IntelDisassembler:
             rip = i_address + i_size
             call_destination = rip + self.getReferencedAddr(i_op_str)
             dereferenced = self.disassembly.dereferenceQword(call_destination)
-            state.addCodeRef(i_address, call_destination)
-            if dereferenced is not None:
+            if dereferenced is not None and self.disassembly.isAddrWithinMemoryImage(dereferenced):
+                # the slot holds an in-image target (thunk/local function): book the call
+                # against the real destination, like the 32-bit dword-ptr path does
+                state.addCodeRef(i_address, dereferenced)
+                self._handleCallTarget(state, i_address, dereferenced)
                 self._handleApiTarget(i_address, call_destination, dereferenced)
+            else:
+                # import-like case: keep the reference on the slot itself
+                state.addCodeRef(i_address, call_destination)
+                if dereferenced is not None:
+                    self._handleApiTarget(i_address, call_destination, dereferenced)
         elif i_op_str.startswith("0x"):
             # case = "DIRECT"
             self._handleCallTarget(state, i_address, call_destination)

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -168,9 +168,12 @@ class IntelDisassembler:
         return list(symbol_offsets)
 
     def getReferencedAddr(self, op_str):
-        referenced_addr = re.search(r"0x[a-fA-F0-9]+", op_str)
+        # preserve a leading sign so that negative displacements (e.g. "qword ptr [rip - 0x20]")
+        # resolve to the correct address instead of being treated as positive
+        referenced_addr = re.search(r"(?P<sign>[+-])?\s*0x(?P<value>[a-fA-F0-9]+)", op_str)
         if referenced_addr:
-            return int(referenced_addr.group(), 16)
+            value = int(referenced_addr.group("value"), 16)
+            return -value if referenced_addr.group("sign") == "-" else value
         return 0
 
     def resolveIndirectSwitch(self, addr_switch_array, size):

--- a/src/smda/intel/IntelDisassembler.py
+++ b/src/smda/intel/IntelDisassembler.py
@@ -287,6 +287,8 @@ class IntelDisassembler:
         i_address, i_size, i_mnemonic, i_op_str = i
         jump_destination = self.getReferencedAddr(i_op_str)
         if jump_destination:
+            # loops are conditional branches: queue the taken edge as well
+            state.addBlockToQueue(jump_destination)
             state.addCodeRef(i_address, int(i_op_str, 16), by_jump=True)
         # loops have two exits and should thus be handled as block ending instruction
         state.addBlockToQueue(i_address + i_size)

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -86,10 +86,8 @@ class JumpTableAnalyzer:
                 if target_register and target_register not in instr[3]:
                     continue
                 data_ref_instruction_addr = instr[0]
+                # getReferencedAddr() preserves the displacement sign
                 offset = self.disassembler.getReferencedAddr(instr[3])
-                rip_sign = "+" if "+" in instr[3] else "-"
-                if rip_sign == "-":
-                    offset = offset * -1
                 off_jumptable = instr[0] + instr[1] + offset
                 state.addDataRef(data_ref_instruction_addr, off_jumptable, size=4)
                 # print("  0x%x: _addHandler() found potential jump table offset (mov) with backtracking: 0x%x (%s %s)" % (instr[0], off_jumptable, instr[2], instr[3]))

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -175,6 +175,45 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(result.ins2fn.get(0x100E), 0x1000)
 
+    def test_resolve_indirect_switch_stops_at_image_end(self):
+        disassembler = IntelDisassembler.__new__(IntelDisassembler)
+        disassembler.disassembly = SimpleNamespace(
+            isAddrWithinMemoryImage=lambda addr: 0x1000 <= addr < 0x1008,
+            getByte=lambda addr: 0 if 0x1000 <= addr < 0x1008 else None,
+        )
+        disassembler.fc_manager = SimpleNamespace(getFunctionStartCandidates=lambda: set())
+
+        # walks from 0x1004 past the image end without raising on the None byte
+        self.assertEqual(
+            disassembler.resolveIndirectSwitch(0x1000, 1),
+            list(range(0x1004, 0x1008)),
+        )
+
+    def test_push_ret_obfuscation_detected_at_address_zero(self):
+        # a push at address 0 (base-0 buffer) must not disable push-ret detection;
+        # the stub at 0x0 becomes a candidate through the call in the second function
+        buf = (
+            b"\x68\x10\x00\x00\x00"  # 0x0: push 0x10
+            + b"\xc3"  # 0x5: ret
+            + b"\xcc" * 10  # 0x6: padding
+            + b"\x31\xc0"  # 0x10: xor eax, eax (push-ret destination)
+            + b"\xc3"  # 0x12: ret
+            + b"\x55"  # 0x13: push ebp
+            + b"\x89\xe5"  # 0x14: mov ebp, esp
+            + b"\xe8\xe5\xff\xff\xff"  # 0x16: call 0x0
+            + b"\x5d"  # 0x1b: pop ebp
+            + b"\xc3"  # 0x1c: ret
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertIn(0x0, result.functions)
+        self.assertEqual(result.ins2fn.get(0x10), 0x0)
+
     def test_accepts_missing_timeout_callback(self):
         binary_info = BinaryInfo(b"\x90\xc3")
         binary_info.base_addr = 0

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -96,6 +96,36 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(manager.resolvePointerReference(0x20), 0x1028)
 
+    def test_get_referenced_addr_preserves_sign(self):
+        disassembler = IntelDisassembler.__new__(IntelDisassembler)
+        self.assertEqual(disassembler.getReferencedAddr("qword ptr [rip - 0x20]"), -0x20)
+        self.assertEqual(disassembler.getReferencedAddr("qword ptr [rip + 0x20]"), 0x20)
+        self.assertEqual(disassembler.getReferencedAddr("dword ptr [0x401000]"), 0x401000)
+        self.assertEqual(disassembler.getReferencedAddr("0x401000"), 0x401000)
+        self.assertEqual(disassembler.getReferencedAddr("eax"), 0)
+
+    def test_rip_relative_call_negative_displacement_resolves_correct_slot(self):
+        # 8-byte import-like slot at 0x1000 (value outside the image), then a function
+        # at 0x1008 that calls through the slot with a negative RIP-relative displacement
+        buf = (
+            (0x7FFF12345678).to_bytes(8, "little")  # 0x1000: slot
+            + b"\x55"  # 0x1008: push rbp
+            + b"\x48\x89\xe5"  # 0x1009: mov rbp, rsp
+            + b"\xff\x15\xee\xff\xff\xff"  # 0x100c: call qword ptr [rip - 0x12] -> 0x1000
+            + b"\x5d"  # 0x1012: pop rbp
+            + b"\xc3"  # 0x1013: ret
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 64
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertIn(0x1008, result.functions)
+        # the call must reference the slot at 0x1000, not a bogus positive displacement target
+        self.assertIn(0x1000, result.code_refs_from.get(0x100C, set()))
+
     def test_accepts_missing_timeout_callback(self):
         binary_info = BinaryInfo(b"\x90\xc3")
         binary_info.base_addr = 0

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -152,6 +152,29 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertIn(0x1028, result.functions)
         self.assertIn(0x1028, result.code_refs_from.get(0x100C, set()))
 
+    def test_loop_taken_edge_is_disassembled(self):
+        # a forward loop target is only reachable via the taken edge; it must end up
+        # as a block of the same function
+        buf = (
+            b"\x55"  # 0x1000: push ebp
+            + b"\x89\xe5"  # 0x1001: mov ebp, esp
+            + b"\xb9\x03\x00\x00\x00"  # 0x1003: mov ecx, 3
+            + b"\xe2\x04"  # 0x1008: loop 0x100e
+            + b"\x31\xc0"  # 0x100a: xor eax, eax
+            + b"\x5d"  # 0x100c: pop ebp
+            + b"\xc3"  # 0x100d: ret
+            + b"\x89\xc0"  # 0x100e: mov eax, eax (loop target)
+            + b"\xeb\xf8"  # 0x1010: jmp 0x100a
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertEqual(result.ins2fn.get(0x100E), 0x1000)
+
     def test_accepts_missing_timeout_callback(self):
         binary_info = BinaryInfo(b"\x90\xc3")
         binary_info.base_addr = 0

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -126,6 +126,32 @@ class TestIntelDisassembler(unittest.TestCase):
         # the call must reference the slot at 0x1000, not a bogus positive displacement target
         self.assertIn(0x1000, result.code_refs_from.get(0x100C, set()))
 
+    def test_rip_relative_call_through_in_image_slot_reaches_target(self):
+        # the slot at 0x1000 points at a second function inside the image: the call must
+        # be booked against the dereferenced target so recursion reaches the real function
+        buf = (
+            (0x1028).to_bytes(8, "little")  # 0x1000: slot -> in-image function
+            + b"\x55"  # 0x1008: push rbp
+            + b"\x48\x89\xe5"  # 0x1009: mov rbp, rsp
+            + b"\xff\x15\xee\xff\xff\xff"  # 0x100c: call qword ptr [rip - 0x12] -> 0x1000
+            + b"\x5d"  # 0x1012: pop rbp
+            + b"\xc3"  # 0x1013: ret
+            + b"\xcc" * 20  # 0x1014: padding
+            + b"\x55"  # 0x1028: push rbp
+            + b"\x48\x89\xe5"  # 0x1029: mov rbp, rsp
+            + b"\x5d"  # 0x102c: pop rbp
+            + b"\xc3"  # 0x102d: ret
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 64
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertIn(0x1028, result.functions)
+        self.assertIn(0x1028, result.code_refs_from.get(0x100C, set()))
+
     def test_accepts_missing_timeout_callback(self):
         binary_info = BinaryInfo(b"\x90\xc3")
         binary_info.base_addr = 0


### PR DESCRIPTION
## Summary

Four small correctness fixes for x86/x64 CFG recovery. All of them are long-standing issues in
`master` that were surfaced by automated review (CodeRabbit / gemini-code-assist) while reviewing
the engine refactor in #140 — the refactor moves these lines verbatim, so the bugs themselves
pre-date it and are fixed here independently, against `master`.

One commit per issue:

### 1. `getReferencedAddr()` drops the sign of negative displacements

`qword ptr [rip - 0x20]` was parsed as `+0x20` because the helper only extracted the hex literal.
The x64 RIP-relative call/jmp paths build their dereference slot address from this value, so
negative displacements resolved to the wrong slot and corrupted CFG/API recovery.
`JumpTableAnalyzer._x64Handler` previously compensated for the missing sign manually; that
compensation is dropped in the same commit (no double negation).

### 2. RIP-relative call slots pointing back into the image are never followed

For `call qword ptr [rip + X]` the slot was dereferenced, but the bookkeeping stayed on the slot
address — recursion never reached an in-image target (thunk / local function / dispatch slot)
behind the indirection. The call is now booked against the dereferenced target when it lies within
the memory image, exactly like the 32-bit `call dword ptr [0x...]` path already does. Import-like
slots (value outside the image / unreadable) keep the existing slot/API-only behavior.

The analogous *jmp* path intentionally stays slot-based: the 32-bit jmp path behaves the same way,
and redirecting it would interact with tailcall analysis — out of scope for this fix.

### 3. `loop`/`loope`/`loopne` taken edge is never enqueued

These are conditional branches with two successors, but only the fallthrough block was queued; a
forward loop target was never disassembled unless another path happened to reach it. The taken
edge is now queued like it is for conditional jumps. (`jcxz`-family already lives in `CJMP_INS`
and was unaffected.)

### 4. Robustness: address-0 truthiness and out-of-image switch walk

- `if previous_address` / `if to_addr` truthiness checks treated the valid address `0` (base-0
  buffers) as "absent", silently disabling push-ret obfuscation detection, syscall-exit detection
  and the alignment-after-call cut. Now explicit `is not None` checks.
- `resolveIndirectSwitch()` compared `getByte()` output against the table size without handling
  the `None` returned once the walk leaves the memory image (`TypeError` instead of terminating
  the scan).

## Validation

- 6 new tests in `tests/testIntelDisassembler.py`; each was verified to **fail before** its fix and
  pass after (capstone-encoded buffers: backwards RIP-relative call through a slot, in-image slot
  target discovery, forward `loop` edge, base-0 push-ret, out-of-image switch walk).
- `make lint` clean; `make test`: **117 passed**, including the byte-exact SHA-256 integration
  baselines — the fixture samples do not exercise these paths, so reference hashes are unchanged
  (no re-baselining noise in this PR).
- Instruction semantics (capstone op_str formats incl. `bnd` prefix, `[rip]` zero-displacement,
  negative-immediate formatting, `i_size` covering prefixes) verified empirically against the
  pinned capstone.

## Interaction with #140

Independent of, but related to #140: the refactor currently moves the *old* versions of these
lines into the new engine/backend files. If this PR merges first, #140 will be rebased to carry
these fixes into the new layout (the port is already prepared); if #140 merges first, this PR will
be reworked onto the new file layout instead.
