### PR TITLE
fix: resolve file format parse error and late candidate conflict resolution in tests

### DIFF
--- a/src/smda/intel/FunctionAnalysisState.py
+++ b/src/smda/intel/FunctionAnalysisState.py
@@ -112,8 +112,12 @@ class FunctionAnalysisState:
     def identifyCallConflicts(self, all_refs):
         conflicts = {}
         non_instruction_start_bytes = self.processed_bytes.difference(self.instruction_start_bytes)
-        conflict_addrs = set(all_refs.keys()).intersection(non_instruction_start_bytes)
-        for candidate_source_ref in conflict_addrs:
+        # iterate this function's processed bytes (bounded by the function size)
+        # instead of rebuilding a set from the whole-binary all_refs on every call;
+        # same conflict set, but avoids an O(total_refs) copy per analyzed function.
+        for candidate_source_ref in non_instruction_start_bytes:
+            if candidate_source_ref not in all_refs:
+                continue
             candidate = all_refs[candidate_source_ref]
             if candidate not in conflicts:
                 conflicts[candidate] = []

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -123,6 +123,7 @@ class FunctionCandidateManager:
             return False
         self.candidates[addr].setIsGapCandidate(is_gap)
         if reference_source:
+            self._all_call_refs[reference_source] = addr
             self._addCappedCallRef(self.candidates[addr], reference_source)
         self.candidate_queue.add(self.candidates[addr])
         self.candidate_queue.update()

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -259,6 +259,7 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         self.assertEqual(MachoFileLoader.getArchitecture(b"", parsed=fat_binary), "")
         self.assertEqual(MachoFileLoader.getBitness(b"", parsed=fat_binary), 0)
 
+    @staticmethod
     def _fake_elf(machine_type, identity_class):
         return SimpleNamespace(header=SimpleNamespace(machine_type=machine_type, identity_class=identity_class))
 


### PR DESCRIPTION
# Description

This PR resolves all currently failing unit and integration tests in the `master` branch, and keeps the conflict-resolution fix performance-neutral.

## Root Cause & Motivation

1. **TypeError in ELF parser tests**: The `_fake_elf` helper method inside `tests/testFileFormatParsers.py` was defined as `def _fake_elf(machine_type, identity_class)` without `self` or a `@staticmethod` decorator. Calls like `self._fake_elf(...)` implicitly passed `self`, causing a crash because 3 arguments were supplied to a method expecting 2.
2. **Conflict resolution omission for late candidates**: In `src/smda/intel/FunctionCandidateManager.py`, `addCandidate` accepted a `reference_source` argument but failed to register it inside the `self._all_call_refs` dictionary. Since this mapping was missing, the conflict resolution routine `identifyCallConflicts` could not track or resolve call conflicts for late reference candidates.
3. **Performance cost of that registration**: `identifyCallConflicts` runs after every analyzed function under `HIGH_ACCURACY` and rebuilt `set(all_refs.keys())` on each call — an `O(total_refs)` copy of the whole-binary ref map that scales with the binary, i.e. `O(functions x total_refs)` overall. Re-populating `_all_call_refs` (fix #2) enlarges that map, so without a change here the fix would measurably slow large-binary analysis.

## Changed Behavior

- Added the `@staticmethod` decorator to the `_fake_elf` helper in `tests/testFileFormatParsers.py`.
- Registered `reference_source` in `self._all_call_refs` within `addCandidate` in `src/smda/intel/FunctionCandidateManager.py`.
- Reworked `identifyCallConflicts` in `src/smda/intel/FunctionAnalysisState.py` to iterate the current function's processed bytes (bounded by the function size) and probe `all_refs` membership, instead of copying the whole-binary `all_refs` into a set on every call. The resulting conflict set is identical; only the per-function copy is removed.

## Validation

- `python -m pytest tests/test*` — 172 tests passed.
- `python -m ruff check .` — all checks passed.
- `python -m ruff format --check .` — clean.
- The conflict set produced by `identifyCallConflicts` is unchanged (it is the same intersection, computed without materializing `set(all_refs.keys())`); the full suite — including the `HIGH_ACCURACY` disassembler tests — passes unchanged.
