### PR TITLE
fix(labels): align PE/ELF Tier-1 metadata and import parity

### DIFF
--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -85,7 +85,7 @@ class BinaryInfo:
             if lief_type == "PE":
                 self.oep = lief_result.optional_header.addressof_entrypoint
             elif lief_type == "ELF":
-                self.oep = lief_result.header.entrypoint
+                self.oep = lief_result.header.entrypoint - self.base_addr
             elif lief_type == "MACH_O":
                 macho_binary = self._symbol_provider._get_macho_binary(lief_result)
                 if macho_binary and hasattr(macho_binary, "entrypoint"):
@@ -97,7 +97,9 @@ class BinaryInfo:
         if self.exported_functions is None:
             lief_result = self.getLiefBinary()
             lief_type = self._getLiefType()
-            if lief_type in ("PE", "ELF", "MACH_O"):
+            if lief_type == "PE":
+                self.exported_functions = self._symbol_provider.parseExports(lief_result, self.base_addr)
+            elif lief_type in ("ELF", "MACH_O"):
                 self.exported_functions = self._symbol_provider.parseExports(lief_result)
         return self.exported_functions
 
@@ -106,10 +108,8 @@ class BinaryInfo:
             lief_result = self.getLiefBinary()
             lief_type = self._getLiefType()
             if lief_type == "PE":
-                self.imported_functions = self._symbol_provider.parseImports(lief_result)
-            elif lief_type == "ELF":
-                self.imported_functions = self._symbol_provider.parseSymbols(lief_result.dynamic_symbols)
-            elif lief_type == "MACH_O":
+                self.imported_functions = self._symbol_provider.parseImports(lief_result, self.base_addr)
+            elif lief_type in ("ELF", "MACH_O"):
                 self.imported_functions = self._symbol_provider.parseImports(lief_result)
         return self.imported_functions
 
@@ -118,9 +118,9 @@ class BinaryInfo:
             lief_result = self.getLiefBinary()
             lief_type = self._getLiefType()
             if lief_type == "PE":
-                self.symbols = self._symbol_provider.parseSymbols(lief_result)
+                self.symbols = self._symbol_provider.collectSymbols(lief_result, self.base_addr)
             elif lief_type == "ELF":
-                self.symbols = self._symbol_provider.parseSymbols(lief_result.dynamic_symbols)
+                self.symbols = self._symbol_provider.collectSymbols(lief_result)
             elif lief_type == "MACH_O":
                 symbols = self._symbol_provider.parseSymbols(lief_result)
                 self.symbols = self._symbol_provider._filter_symbols_to_code(symbols, self)

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -85,7 +85,7 @@ class BinaryInfo:
             if lief_type == "PE":
                 self.oep = lief_result.optional_header.addressof_entrypoint
             elif lief_type == "ELF":
-                self.oep = lief_result.header.entrypoint - self.base_addr
+                self.oep = lief_result.header.entrypoint - (self.base_addr or 0)
             elif lief_type == "MACH_O":
                 macho_binary = self._symbol_provider._get_macho_binary(lief_result)
                 if macho_binary and hasattr(macho_binary, "entrypoint"):

--- a/src/smda/common/labelprovider/ElfApiResolver.py
+++ b/src/smda/common/labelprovider/ElfApiResolver.py
@@ -2,6 +2,7 @@
 import lief
 
 from .AbstractLabelProvider import AbstractLabelProvider
+from .ElfSymbolProvider import parse_relocation_imports
 
 lief.logging.disable()
 
@@ -16,31 +17,12 @@ class ElfApiResolver(AbstractLabelProvider):
         # Gate on the parsed ELF type rather than is_buffer: a memory dump / raw buffer that LIEF
         # parses as an ELF still exposes its relocation table, so imported APIs remain resolvable
         # here. Non-ELF input (raw shellcode, PE, DEX) fails the isinstance check and is skipped.
+        self._api_map["lief"] = {}
         lief_binary = binary_info.getLiefBinary()
         if not isinstance(lief_binary, lief.ELF.Binary):
             return
 
-        for relocation in lief_binary.relocations:
-            if not relocation.has_symbol:
-                continue
-            symbol = relocation.symbol
-            if symbol is None:
-                continue
-            if not symbol.imported or not symbol.is_function:
-                continue
-
-            # we can't really say what library the symbol came from
-            # however, we can treat the version (if present) as relevant metadata?
-            # note: this only works for GNU binaries, such as for Linux
-            lib = None
-            if symbol.has_version and symbol.symbol_version.has_auxiliary_version:
-                # like "GLIBC_2.2.5"
-                lib = symbol.symbol_version.symbol_version_auxiliary.name
-
-            name = symbol.name
-            address = relocation.address
-
-            self._api_map["lief"][address] = (lib, name)
+        self._api_map["lief"] = parse_relocation_imports(lief_binary)
 
     def isApiProvider(self):
         """Returns whether the get_api(..) function of the AbstractLabelProvider is functional"""

--- a/src/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/src/smda/common/labelprovider/ElfSymbolProvider.py
@@ -10,6 +10,28 @@ lief.logging.disable()
 LOGGER = logging.getLogger(__name__)
 
 
+def parse_relocation_imports(lief_binary):
+    """Build import map keyed by relocation slot address: addr -> (lib, name)."""
+    if not isinstance(lief_binary, lief.ELF.Binary):
+        return {}
+    import_symbols = {}
+    for relocation in lief_binary.relocations:
+        if not relocation.has_symbol:
+            continue
+        symbol = relocation.symbol
+        if symbol is None:
+            continue
+        if not symbol.imported or not symbol.is_function:
+            continue
+
+        lib = None
+        if symbol.has_version and symbol.symbol_version.has_auxiliary_version:
+            lib = symbol.symbol_version.symbol_version_auxiliary.name
+
+        import_symbols[relocation.address] = (lib, symbol.name)
+    return import_symbols
+
+
 class ElfSymbolProvider(AbstractLabelProvider):
     """Minimal resolver for ELF symbols"""
 
@@ -25,14 +47,14 @@ class ElfSymbolProvider(AbstractLabelProvider):
         return False
 
     def getApi(self, to_addr, absolute_addr=None):
-        return ("", "")
+        return (None, None)
 
     def _parseOep(self, lief_result):
+        # Symbol map keys use absolute VAs; BinaryInfo.getOep() stores a base-relative offset.
         if lief_result:
             self._func_symbols[lief_result.header.entrypoint] = "original_entry_point"
 
     def update(self, binary_info):
-        # works both for PE and ELF
         self._func_symbols = {}
 
         lief_binary = binary_info.getLiefBinary()
@@ -63,6 +85,20 @@ class ElfSymbolProvider(AbstractLabelProvider):
                 func_name = getattr(symbol, "demangled_name", None) or symbol.name
                 function_symbols[symbol.value] = func_name
         return function_symbols
+
+    def parseImports(self, lief_binary):
+        if not isinstance(lief_binary, lief.ELF.Binary):
+            return {}
+        return parse_relocation_imports(lief_binary)
+
+    def collectSymbols(self, lief_binary):
+        if not isinstance(lief_binary, lief.ELF.Binary):
+            return {}
+        symbols = {}
+        symbols.update(self.parseExports(lief_binary))
+        symbols.update(self.parseSymbols(lief_binary.symtab_symbols))
+        symbols.update(self.parseSymbols(lief_binary.dynamic_symbols))
+        return symbols
 
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")

--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -91,19 +91,20 @@ class PeSymbolProvider(AbstractLabelProvider):
                         function_symbols[function_offset] = function_name
         return function_symbols
 
-    def parseImports(self, lief_binary, base_addr=0):
+    def parseImports(self, lief_binary, base_addr=None):
+        active_base = self._resolve_base_addr(lief_binary, base_addr)
         import_symbols = {}
         for imported_library in lief_binary.imports:
             for func in imported_library.entries:
                 if func.name:
-                    import_symbols[func.iat_address + base_addr] = (
+                    import_symbols[func.iat_address + active_base] = (
                         imported_library.name.lower(),
                         func.name,
                     )
                 elif func.is_ordinal:
                     resolved_ordinal = OrdinalHelper.resolveOrdinal(imported_library.name.lower(), func.ordinal)
                     ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
-                    import_symbols[func.iat_address + base_addr] = (
+                    import_symbols[func.iat_address + active_base] = (
                         imported_library.name.lower(),
                         ordinal_name,
                     )

--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -28,25 +28,33 @@ class PeSymbolProvider(AbstractLabelProvider):
         return False
 
     def getApi(self, to_addr, absolute_addr=None):
-        return ("", "")
+        return (None, None)
 
-    def _parseOep(self, lief_result):
-        if lief_result:
-            self._func_symbols[lief_result.entrypoint] = "original_entry_point"
+    def _resolve_base_addr(self, lief_binary, base_addr):
+        if base_addr is None:
+            return getattr(lief_binary, "imagebase", 0)
+        return base_addr
+
+    def _parseOep(self, lief_binary, base_addr=None):
+        if lief_binary:
+            active_base = self._resolve_base_addr(lief_binary, base_addr)
+            oep_rva = lief_binary.optional_header.addressof_entrypoint
+            self._func_symbols[active_base + oep_rva] = "original_entry_point"
 
     def update(self, binary_info):
-        # works both for PE and ELF
         self._func_symbols = {}
 
         lief_binary = binary_info.getLiefBinary()
         if not isinstance(lief_binary, lief.PE.Binary):
             return
 
-        self._parseOep(lief_binary)
-        self._func_symbols.update(self.parseExports(lief_binary))
-        self._func_symbols.update(self.parseSymbols(lief_binary))
+        active_base = binary_info.base_addr
+        self._parseOep(lief_binary, active_base)
+        self._func_symbols.update(self.parseExports(lief_binary, active_base))
+        self._func_symbols.update(self.parseSymbols(lief_binary, active_base))
 
-    def parseExports(self, lief_binary):
+    def parseExports(self, lief_binary, base_addr=None):
+        active_base = self._resolve_base_addr(lief_binary, base_addr)
         function_symbols = {}
         for function in lief_binary.exported_functions:
             function_name = ""
@@ -55,16 +63,17 @@ class PeSymbolProvider(AbstractLabelProvider):
                 # UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
                 function_name = function.name
             if function_name and all(ord(c) in range(0x20, 0x7F) for c in function_name):
-                function_symbols[lief_binary.imagebase + function.address] = function_name
+                function_symbols[active_base + function.address] = function_name
         return function_symbols
 
-    def parseSymbols(self, lief_binary):
+    def parseSymbols(self, lief_binary, base_addr=None):
+        active_base = self._resolve_base_addr(lief_binary, base_addr)
         # find VA of first code section
         function_symbols = {}
         code_base_address = None
         for section in lief_binary.sections:
             if section.characteristics & 0x20000000:
-                code_base_address = lief_binary.imagebase + section.virtual_address
+                code_base_address = active_base + section.virtual_address
                 break
         if code_base_address is None:
             return function_symbols
@@ -82,23 +91,29 @@ class PeSymbolProvider(AbstractLabelProvider):
                         function_symbols[function_offset] = function_name
         return function_symbols
 
-    def parseImports(self, lief_binary):
+    def parseImports(self, lief_binary, base_addr=0):
         import_symbols = {}
         for imported_library in lief_binary.imports:
             for func in imported_library.entries:
                 if func.name:
-                    import_symbols[func.iat_address + lief_binary.imagebase] = (
+                    import_symbols[func.iat_address + base_addr] = (
                         imported_library.name.lower(),
                         func.name,
                     )
                 elif func.is_ordinal:
                     resolved_ordinal = OrdinalHelper.resolveOrdinal(imported_library.name.lower(), func.ordinal)
                     ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
-                    import_symbols[func.iat_address + lief_binary.imagebase] = (
+                    import_symbols[func.iat_address + base_addr] = (
                         imported_library.name.lower(),
                         ordinal_name,
                     )
         return import_symbols
+
+    def collectSymbols(self, lief_binary, base_addr=None):
+        symbols = {}
+        symbols.update(self.parseExports(lief_binary, base_addr))
+        symbols.update(self.parseSymbols(lief_binary, base_addr))
+        return symbols
 
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -8,9 +8,8 @@ import lief
 
 lief.logging.disable()
 
-from smda.common.labelprovider.OrdinalHelper import OrdinalHelper  # noqa: E402
-
 from .AbstractLabelProvider import AbstractLabelProvider  # noqa: E402
+from .PeSymbolProvider import PeSymbolProvider  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,20 +40,7 @@ class WinApiResolver(AbstractLabelProvider):
             lief_binary = binary_info.getLiefBinary()
             if not isinstance(lief_binary, lief.PE.Binary):
                 return
-            for imported_library in lief_binary.imports:
-                for func in imported_library.entries:
-                    if func.name:
-                        self._api_map["lief"][func.iat_address + binary_info.base_addr] = (
-                            imported_library.name.lower(),
-                            func.name,
-                        )
-                    elif func.is_ordinal:
-                        resolved_ordinal = OrdinalHelper.resolveOrdinal(imported_library.name.lower(), func.ordinal)
-                        ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
-                        self._api_map["lief"][func.iat_address + binary_info.base_addr] = (
-                            imported_library.name.lower(),
-                            ordinal_name,
-                        )
+            self._api_map["lief"] = PeSymbolProvider(None).parseImports(lief_binary, binary_info.base_addr)
 
     def setOsName(self, os_name):
         self._os_name = os_name

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -926,7 +926,7 @@ class TestAArch64StaticFixture(unittest.TestCase):
         self.assertEqual(self.report.architecture, "aarch64")
         self.assertEqual(self.report.bitness, 64)
         self.assertEqual(self.report.base_addr, 0x400000)
-        self.assertEqual(self.report.oep, 0x400534)
+        self.assertEqual(self.report.oep, 0x534)
         self.assertEqual(len(self.report.xcfg), 278)
         self.assertEqual(sum(1 for f in self.report.getFunctions() for _ in f.getInstructions()), 19881)
         self.assertEqual(sum(1 for f in self.report.getFunctions() for _ in f.getBlocks()), 3525)
@@ -978,7 +978,7 @@ class TestAArch64StaticFixture(unittest.TestCase):
         self.assertEqual(roundtrip.status, "ok")
         self.assertEqual(roundtrip.architecture, "aarch64")
         self.assertEqual(roundtrip.bitness, 64)
-        self.assertEqual(roundtrip.oep, 0x400534)
+        self.assertEqual(roundtrip.oep, 0x534)
         self.assertEqual(len(roundtrip.xcfg), 278)
 
 

--- a/tests/testElfSymbolProvider.py
+++ b/tests/testElfSymbolProvider.py
@@ -2,6 +2,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+from smda.common.BinaryInfo import BinaryInfo
 from smda.common.labelprovider.ElfApiResolver import ElfApiResolver
 from smda.common.labelprovider.ElfSymbolProvider import ElfSymbolProvider
 
@@ -107,11 +108,74 @@ class TestElfApiSymbolSeparation(unittest.TestCase):
             resolver.update(SimpleNamespace(is_buffer=True, getLiefBinary=lambda: object()))
         self.assertFalse(resolver.is_active())
 
+    def test_api_resolver_clears_stale_imports_on_non_elf_update(self):
+        resolver = ElfApiResolver(None)
+        with mock.patch("lief.ELF.Binary", _MockElfBinary):
+            resolver.update(_binary_info(MOCK_ELF))
+        self.assertEqual(resolver.getApi(0x4000), (None, "printf"))
+        with mock.patch("lief.ELF.Binary", _MockElfBinary):
+            resolver.update(SimpleNamespace(is_buffer=True, getLiefBinary=lambda: object()))
+        self.assertFalse(resolver.is_active())
+        self.assertEqual(resolver.getApi(0x4000), (None, None))
+
     def test_symbol_provider_inactive_for_non_elf(self):
         provider = ElfSymbolProvider(None)
         with mock.patch("lief.ELF.Binary", _MockElfBinary):
             provider.update(SimpleNamespace(is_buffer=False, getLiefBinary=lambda: object()))
         self.assertFalse(provider.is_active())
+
+    def test_parse_imports_matches_api_resolver_relocation_slots(self):
+        provider = ElfSymbolProvider(None)
+        with mock.patch("lief.ELF.Binary", _MockElfBinary):
+            imports = provider.parseImports(MOCK_ELF)
+        self.assertEqual(imports, {0x4000: (None, "printf")})
+
+    def test_collect_symbols_merges_symtab_dynamic_and_exports(self):
+        provider = ElfSymbolProvider(None)
+        with mock.patch("lief.ELF.Binary", _MockElfBinary):
+            symbols = provider.collectSymbols(MOCK_ELF)
+        self.assertEqual(symbols[0x1000], "exported_func")
+        self.assertEqual(symbols[0x2000], "local_func")
+        self.assertEqual(symbols[0x3000], "dyn_defined")
+        self.assertNotIn("printf", symbols.values())
+        self.assertNotIn(0x4000, symbols)
+
+    def test_binary_info_elf_imported_functions_use_relocation_slots(self):
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=MOCK_ELF),
+            mock.patch("lief.ELF.Binary", _MockElfBinary),
+        ):
+            imported = binary_info.getImportedFunctions()
+        self.assertEqual(imported, {0x4000: (None, "printf")})
+
+    def test_binary_info_elf_symbols_merge_symtab_sources(self):
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=MOCK_ELF),
+            mock.patch("lief.ELF.Binary", _MockElfBinary),
+        ):
+            symbols = binary_info.getSymbols()
+        self.assertEqual(symbols[0x2000], "local_func")
+        self.assertNotIn(0x4000, symbols)
+
+    def test_binary_info_elf_oep_is_base_relative_offset(self):
+        elf = _MockElfBinary(
+            exported_functions=[],
+            symtab_symbols=[],
+            dynamic_symbols=[],
+            relocations=[],
+            entrypoint=0x400534,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=elf),
+            mock.patch("lief.ELF.Binary", _MockElfBinary),
+        ):
+            self.assertEqual(binary_info.getOep(), 0x534)
 
 
 if __name__ == "__main__":

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -1,0 +1,153 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
+from smda.common.labelprovider.WinApiResolver import WinApiResolver
+
+
+class _MockImportEntry:
+    def __init__(self, name, iat_address, *, is_ordinal=False, ordinal=0):
+        self.name = name
+        self.iat_address = iat_address
+        self.is_ordinal = is_ordinal
+        self.ordinal = ordinal
+
+
+class _MockImportLibrary:
+    def __init__(self, name, entries):
+        self.name = name
+        self.entries = entries
+
+
+class _MockExport:
+    def __init__(self, name, address):
+        self.name = name
+        self.address = address
+
+
+class _MockSection:
+    def __init__(self, characteristics, virtual_address):
+        self.characteristics = characteristics
+        self.virtual_address = virtual_address
+
+
+class _MockSymbol:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+        self.complex_type = SimpleNamespace(name="FUNCTION")
+
+
+class _MockPeBinary:
+    def __init__(
+        self,
+        *,
+        imports=None,
+        exported_functions=None,
+        sections=None,
+        symbols=None,
+        imagebase=0x140000000,
+        addressof_entrypoint=0x1000,
+    ):
+        self.imports = imports or []
+        self.exported_functions = exported_functions or []
+        self.sections = sections or []
+        self.symbols = symbols or []
+        self.imagebase = imagebase
+        self.optional_header = SimpleNamespace(addressof_entrypoint=addressof_entrypoint)
+
+
+class TestPeSymbolProviderImports(unittest.TestCase):
+    def test_parse_imports_uses_active_base_addr_not_imagebase(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("CreateFileW", 0x3000)])],
+            imagebase=0x140000000,
+        )
+        imports = provider.parseImports(pe_binary, base_addr=0x400000)
+        self.assertEqual(imports, {0x403000: ("kernel32.dll", "CreateFileW")})
+        self.assertNotIn(0x140003000, imports)
+
+    def test_parse_imports_defaults_to_zero_base(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("ExitProcess", 0x2000)])],
+        )
+        imports = provider.parseImports(pe_binary)
+        self.assertEqual(imports, {0x2000: ("kernel32.dll", "ExitProcess")})
+
+    def test_win_api_resolver_matches_parse_imports(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("CreateFileW", 0x3000)])],
+            imagebase=0x140000000,
+        )
+        expected = provider.parseImports(pe_binary, base_addr=0x400000)
+
+        resolver = WinApiResolver(SimpleNamespace(API_COLLECTION_FILES={}))
+        with mock.patch("lief.PE.Binary", _MockPeBinary):
+            resolver.update(
+                SimpleNamespace(
+                    is_buffer=False,
+                    base_addr=0x400000,
+                    getLiefBinary=lambda: pe_binary,
+                )
+            )
+        self.assertEqual(resolver._api_map["lief"], expected)
+
+
+class TestPeSymbolProviderMetadata(unittest.TestCase):
+    def test_collect_symbols_merges_exports_and_coff_symbols(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(
+            exported_functions=[_MockExport("exported_func", 0x1000)],
+            sections=[_MockSection(0x20000000, 0x1000)],
+            symbols=[_MockSymbol("local_func", 0x200)],
+            imagebase=0x140000000,
+        )
+        symbols = provider.collectSymbols(pe_binary, base_addr=0x400000)
+        self.assertEqual(symbols[0x401000], "exported_func")
+        self.assertEqual(symbols[0x401200], "local_func")
+
+    def test_parse_oep_uses_base_addr_plus_rva(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(imagebase=0x140000000, addressof_entrypoint=0x1730)
+        provider._parseOep(pe_binary, base_addr=0x400000)
+        self.assertEqual(provider.getFunctionSymbols()[0x401730], "original_entry_point")
+
+    def test_binary_info_pe_imported_functions_use_base_addr(self):
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("ExitProcess", 0x2000)])],
+            imagebase=0x140000000,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=pe_binary),
+            mock.patch("lief.PE.Binary", _MockPeBinary),
+        ):
+            imported = binary_info.getImportedFunctions()
+        self.assertEqual(imported, {0x402000: ("kernel32.dll", "ExitProcess")})
+
+    def test_binary_info_pe_symbols_merge_exports_and_coff(self):
+        pe_binary = _MockPeBinary(
+            exported_functions=[_MockExport("exported_func", 0x1000)],
+            sections=[_MockSection(0x20000000, 0x1000)],
+            symbols=[_MockSymbol("local_func", 0x200)],
+            imagebase=0x140000000,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=pe_binary),
+            mock.patch("lief.PE.Binary", _MockPeBinary),
+        ):
+            symbols = binary_info.getSymbols()
+        self.assertEqual(symbols[0x401000], "exported_func")
+        self.assertEqual(symbols[0x401200], "local_func")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -70,13 +70,14 @@ class TestPeSymbolProviderImports(unittest.TestCase):
         self.assertEqual(imports, {0x403000: ("kernel32.dll", "CreateFileW")})
         self.assertNotIn(0x140003000, imports)
 
-    def test_parse_imports_defaults_to_zero_base(self):
+    def test_parse_imports_defaults_to_imagebase(self):
         provider = PeSymbolProvider(None)
         pe_binary = _MockPeBinary(
             imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("ExitProcess", 0x2000)])],
+            imagebase=0x140000000,
         )
         imports = provider.parseImports(pe_binary)
-        self.assertEqual(imports, {0x2000: ("kernel32.dll", "ExitProcess")})
+        self.assertEqual(imports, {0x140002000: ("kernel32.dll", "ExitProcess")})
 
     def test_win_api_resolver_matches_parse_imports(self):
         provider = PeSymbolProvider(None)


### PR DESCRIPTION
## Summary

Aligns PE/ELF `BinaryInfo` xmetadata and label-provider contracts so imports, symbols, and OEP behave consistently with runtime API/symbol resolution.

Builds on Mach-O symbol-provider work already merged upstream in PR #146.

## Changes

### ELF
- Add shared `parse_relocation_imports()` used by `ElfSymbolProvider.parseImports()` and `ElfApiResolver`.
- `BinaryInfo.getImportedFunctions()` uses relocation slots (not dynamic symtab names).
- `BinaryInfo.getSymbols()` merges exports + symtab + dynamic via `collectSymbols()`.
- `BinaryInfo.getOep()` returns base-relative offset (`entrypoint - base_addr`).
- Reset `ElfApiResolver._api_map["lief"]` on every `update()` to avoid stale imports.

### PE
- `parseImports`, `parseExports`, `parseSymbols`, and OEP labeling use `binary_info.base_addr` (fallback: LIEF `imagebase`).
- Add `PeSymbolProvider.collectSymbols()`; wire `BinaryInfo.getSymbols()` for PE.
- `WinApiResolver` delegates PE imports to `PeSymbolProvider.parseImports()`.

### Tests
- Extend `testElfSymbolProvider.py` (imports, symbols, OEP, cache reset).
- Add `testPeSymbolProvider.py` (base_addr imports, collectSymbols, WinApiResolver parity, BinaryInfo PE paths).
- Update AArch64 static fixture OEP expectation to base-relative `0x534`.

## Validation

```bash
make lint
make test
```

Results: lint clean, **285 tests passed**.

## Residual / Tier-2

- `RustSymbolProvider` PE export/symbol addressing still uses `imagebase`.
- Mach-O `collectSymbols` / xmetadata schema parity with PE/ELF not addressed here.
- ELF relocation import keys remain absolute VAs (no `base_addr` rebasing for exotic dumps).
