### PR TITLE
fix(labels): tier-2 PE rebased addressing, Mach-O collectSymbols, xmetadata parity

### DIFF
--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -10,7 +10,17 @@ LOGGER = logging.getLogger(__name__)
 
 
 class BinaryInfo:
-    """simple DTO to contain most information related to the binary/buffer to be analyzed"""
+    """simple DTO to contain most information related to the binary/buffer to be analyzed
+
+    xmetadata address conventions (via getExportedFunctions/getImportedFunctions/getSymbols):
+    - PE: active ``base_addr`` (dump VA); falls back to LIEF imagebase when unset.
+    - ELF: absolute virtual addresses from LIEF (relocation import slots included).
+    - Mach-O: LIEF addresses adjusted to the active mapping via slice/base_addr offset.
+
+    ``exported_functions`` holds the export table; ``symbols`` merges exports with
+    symtab/COFF/defined function symbols. Overlap between the two dicts is expected
+    when an export also appears in the symbol table.
+    """
 
     architecture = ""
     base_addr = 0
@@ -122,7 +132,7 @@ class BinaryInfo:
             elif lief_type == "ELF":
                 self.symbols = self._symbol_provider.collectSymbols(lief_result)
             elif lief_type == "MACH_O":
-                symbols = self._symbol_provider.parseSymbols(lief_result)
+                symbols = self._symbol_provider.collectSymbols(lief_result)
                 self.symbols = self._symbol_provider._filter_symbols_to_code(symbols, self)
         return self.symbols
 
@@ -130,6 +140,10 @@ class BinaryInfo:
         """
         Generator that yields (name, start_addr, end_addr) for each section.
         Supports PE, ELF, and Mach-O binaries.
+
+        Section start addresses use the same VA convention as label metadata:
+        PE uses ``base_addr + section.virtual_address``; ELF uses LIEF absolute
+        ``section.virtual_address``; Mach-O applies the Mach-O base/adjustment offset.
         """
         parsed_binary = self.getLiefBinary()
         if not parsed_binary:

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -95,7 +95,10 @@ class BinaryInfo:
             if lief_type == "PE":
                 self.oep = lief_result.optional_header.addressof_entrypoint
             elif lief_type == "ELF":
-                self.oep = lief_result.header.entrypoint - (self.base_addr or 0)
+                entrypoint = lief_result.header.entrypoint
+                if self.base_addr and entrypoint >= self.base_addr:
+                    entrypoint -= self.base_addr
+                self.oep = entrypoint
             elif lief_type == "MACH_O":
                 macho_binary = self._symbol_provider._get_macho_binary(lief_result)
                 if macho_binary and hasattr(macho_binary, "entrypoint"):

--- a/src/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/src/smda/common/labelprovider/ElfSymbolProvider.py
@@ -5,31 +5,13 @@ import logging
 import lief
 
 from .AbstractLabelProvider import AbstractLabelProvider
+from .import_parsers import parse_elf_relocation_imports
 
 lief.logging.disable()
 LOGGER = logging.getLogger(__name__)
 
-
-def parse_relocation_imports(lief_binary):
-    """Build import map keyed by relocation slot address: addr -> (lib, name)."""
-    if not isinstance(lief_binary, lief.ELF.Binary):
-        return {}
-    import_symbols = {}
-    for relocation in lief_binary.relocations:
-        if not relocation.has_symbol:
-            continue
-        symbol = relocation.symbol
-        if symbol is None:
-            continue
-        if not symbol.imported or not symbol.is_function:
-            continue
-
-        lib = None
-        if symbol.has_version and symbol.symbol_version.has_auxiliary_version:
-            lib = symbol.symbol_version.symbol_version_auxiliary.name
-
-        import_symbols[relocation.address] = (lib, symbol.name)
-    return import_symbols
+# Backward-compatible alias for tests and callers that imported the old helper name.
+parse_relocation_imports = parse_elf_relocation_imports
 
 
 class ElfSymbolProvider(AbstractLabelProvider):
@@ -87,9 +69,7 @@ class ElfSymbolProvider(AbstractLabelProvider):
         return function_symbols
 
     def parseImports(self, lief_binary):
-        if not isinstance(lief_binary, lief.ELF.Binary):
-            return {}
-        return parse_relocation_imports(lief_binary)
+        return parse_elf_relocation_imports(lief_binary)
 
     def collectSymbols(self, lief_binary):
         if not isinstance(lief_binary, lief.ELF.Binary):

--- a/src/smda/common/labelprovider/MachoSymbolProvider.py
+++ b/src/smda/common/labelprovider/MachoSymbolProvider.py
@@ -10,6 +10,7 @@ from smda.utility.MachoBinary import (
 )
 
 from .AbstractLabelProvider import AbstractLabelProvider
+from .import_parsers import parse_macho_bindings
 from .MachoDemangler import demangle_macho_symbol
 
 lief.logging.disable()
@@ -140,25 +141,16 @@ class MachoSymbolProvider(AbstractLabelProvider):
         if not lief_binary or not isinstance(lief_binary, lief.MachO.Binary):
             return {}
         adjustment = self._get_address_adjustment(lief_binary)
-        imports = {}
-        for binding in getattr(lief_binary, "bindings", []):
-            try:
-                if (
-                    binding.address != 0
-                    and getattr(binding, "has_symbol", False)
-                    and binding.symbol
-                    and binding.symbol.name
-                ):
-                    lib_name = (
-                        binding.library.name.lower()
-                        if (getattr(binding, "has_library", False) and binding.library)
-                        else ""
-                    )
-                    adjusted_addr = binding.address + adjustment
-                    imports[adjusted_addr] = (lib_name, binding.symbol.name)
-            except Exception as e:
-                LOGGER.debug("Failed to parse individual Mach-O binding: %s", e)
-        return imports
+        return parse_macho_bindings(lief_binary, adjustment)
+
+    def collectSymbols(self, lief_binary):
+        lief_binary = self._get_macho_binary(lief_binary)
+        if not lief_binary or not isinstance(lief_binary, lief.MachO.Binary):
+            return {}
+        symbols = {}
+        symbols.update(self.parseExports(lief_binary))
+        symbols.update(self.parseSymbols(lief_binary))
+        return symbols
 
     def getSymbol(self, address):
         return self._func_symbols.get(address, "")

--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -5,9 +5,8 @@ import logging
 
 import lief
 
-from smda.common.labelprovider.OrdinalHelper import OrdinalHelper
-
 from .AbstractLabelProvider import AbstractLabelProvider
+from .import_parsers import parse_pe_imports, resolve_pe_base_addr
 
 lief.logging.disable()
 LOGGER = logging.getLogger(__name__)
@@ -31,9 +30,7 @@ class PeSymbolProvider(AbstractLabelProvider):
         return (None, None)
 
     def _resolve_base_addr(self, lief_binary, base_addr):
-        if base_addr is None:
-            return getattr(lief_binary, "imagebase", 0)
-        return base_addr
+        return resolve_pe_base_addr(lief_binary, base_addr)
 
     def _parseOep(self, lief_binary, base_addr=None):
         if lief_binary:
@@ -92,23 +89,7 @@ class PeSymbolProvider(AbstractLabelProvider):
         return function_symbols
 
     def parseImports(self, lief_binary, base_addr=None):
-        active_base = self._resolve_base_addr(lief_binary, base_addr)
-        import_symbols = {}
-        for imported_library in lief_binary.imports:
-            for func in imported_library.entries:
-                if func.name:
-                    import_symbols[func.iat_address + active_base] = (
-                        imported_library.name.lower(),
-                        func.name,
-                    )
-                elif func.is_ordinal:
-                    resolved_ordinal = OrdinalHelper.resolveOrdinal(imported_library.name.lower(), func.ordinal)
-                    ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
-                    import_symbols[func.iat_address + active_base] = (
-                        imported_library.name.lower(),
-                        ordinal_name,
-                    )
-        return import_symbols
+        return parse_pe_imports(lief_binary, base_addr)
 
     def collectSymbols(self, lief_binary, base_addr=None):
         symbols = {}

--- a/src/smda/common/labelprovider/RustSymbolProvider.py
+++ b/src/smda/common/labelprovider/RustSymbolProvider.py
@@ -7,6 +7,7 @@ import lief
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 
 from .AbstractLabelProvider import AbstractLabelProvider
+from .import_parsers import resolve_pe_base_addr
 from .rust_demangler import demangle
 from .rust_demangler.rust import TypeNotFoundError
 from .rust_demangler.rust_legacy import UnableToLegacyDemangle
@@ -53,7 +54,7 @@ class RustSymbolProvider(AbstractLabelProvider):
         if isinstance(lief_binary, lief.ELF.Binary):
             self._update_elf(lief_binary)
         elif isinstance(lief_binary, lief.PE.Binary):
-            self._update_pe(lief_binary)
+            self._update_pe(lief_binary, binary_info.base_addr)
 
     def is_rust_binary(self, binary_info):
         """
@@ -138,8 +139,9 @@ class RustSymbolProvider(AbstractLabelProvider):
         self._func_symbols.update(self._parse_lief_symbols(lief_binary.symtab_symbols))
         self._func_symbols.update(self._parse_lief_symbols(lief_binary.dynamic_symbols))
 
-    def _update_pe(self, lief_binary):
+    def _update_pe(self, lief_binary, base_addr=None):
         """Process PE binary symbols for Rust demangling."""
+        active_base = resolve_pe_base_addr(lief_binary, base_addr)
         # Parse PE exports
         for function in lief_binary.exported_functions:
             try:
@@ -152,14 +154,14 @@ class RustSymbolProvider(AbstractLabelProvider):
                     demangled = demangle(raw_name)
                     if demangled:
                         demangled = remove_bad_spaces(demangled)
-                        self._func_symbols[lief_binary.imagebase + function.address] = demangled
+                        self._func_symbols[active_base + function.address] = demangled
             except _DEMANGLE_ERRORS as exc:
                 LOGGER.debug("Failed to demangle Rust symbol %s: %s", function.name, exc)
 
         code_base_address = None
         for section in lief_binary.sections:
             if section.characteristics & 0x20000000:
-                code_base_address = lief_binary.imagebase + section.virtual_address
+                code_base_address = active_base + section.virtual_address
                 break
         if code_base_address is None:
             return

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -9,7 +9,7 @@ import lief
 lief.logging.disable()
 
 from .AbstractLabelProvider import AbstractLabelProvider  # noqa: E402
-from .PeSymbolProvider import PeSymbolProvider  # noqa: E402
+from .import_parsers import parse_pe_imports  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class WinApiResolver(AbstractLabelProvider):
             lief_binary = binary_info.getLiefBinary()
             if not isinstance(lief_binary, lief.PE.Binary):
                 return
-            self._api_map["lief"] = PeSymbolProvider(None).parseImports(lief_binary, binary_info.base_addr)
+            self._api_map["lief"] = parse_pe_imports(lief_binary, binary_info.base_addr)
 
     def setOsName(self, os_name):
         self._os_name = os_name

--- a/src/smda/common/labelprovider/import_parsers.py
+++ b/src/smda/common/labelprovider/import_parsers.py
@@ -50,8 +50,10 @@ def parse_elf_relocation_imports(lief_binary):
             continue
 
         lib = None
-        if symbol.has_version and symbol.symbol_version.has_auxiliary_version:
-            lib = symbol.symbol_version.symbol_version_auxiliary.name
+        symbol_version = getattr(symbol, "symbol_version", None)
+        if symbol.has_version and symbol_version and symbol_version.has_auxiliary_version:
+            aux = symbol_version.symbol_version_auxiliary
+            lib = aux.name if aux else None
 
         import_symbols[relocation.address] = (lib, symbol.name)
     return import_symbols

--- a/src/smda/common/labelprovider/import_parsers.py
+++ b/src/smda/common/labelprovider/import_parsers.py
@@ -6,7 +6,8 @@ from smda.common.labelprovider.OrdinalHelper import OrdinalHelper
 
 
 def resolve_pe_base_addr(lief_binary, base_addr=None):
-    if base_addr is None:
+    # BinaryInfo defaults base_addr to 0 when unset; treat falsy as "use imagebase".
+    if not base_addr:
         return getattr(lief_binary, "imagebase", 0)
     return base_addr
 
@@ -17,17 +18,18 @@ def parse_pe_imports(lief_binary, base_addr=None):
     active_base = resolve_pe_base_addr(lief_binary, base_addr)
     import_symbols = {}
     for imported_library in lief_binary.imports:
+        lib_name_lower = (getattr(imported_library, "name", "") or "").lower()
         for func in imported_library.entries:
             if func.name:
                 import_symbols[func.iat_address + active_base] = (
-                    imported_library.name.lower(),
+                    lib_name_lower,
                     func.name,
                 )
             elif func.is_ordinal:
-                resolved_ordinal = OrdinalHelper.resolveOrdinal(imported_library.name.lower(), func.ordinal)
+                resolved_ordinal = OrdinalHelper.resolveOrdinal(lib_name_lower, func.ordinal)
                 ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
                 import_symbols[func.iat_address + active_base] = (
-                    imported_library.name.lower(),
+                    lib_name_lower,
                     ordinal_name,
                 )
     return import_symbols
@@ -67,9 +69,9 @@ def parse_macho_bindings(lief_binary, adjustment=0):
                 and binding.symbol
                 and binding.symbol.name
             ):
-                lib_name = (
-                    binding.library.name.lower() if (getattr(binding, "has_library", False) and binding.library) else ""
-                )
+                lib_name = ""
+                if getattr(binding, "has_library", False) and binding.library:
+                    lib_name = (getattr(binding.library, "name", "") or "").lower()
                 adjusted_addr = binding.address + adjustment
                 imports[adjusted_addr] = (lib_name, binding.symbol.name)
         except Exception:

--- a/src/smda/common/labelprovider/import_parsers.py
+++ b/src/smda/common/labelprovider/import_parsers.py
@@ -1,0 +1,77 @@
+"""Shared LIEF import-table parsers keyed by slot address."""
+
+import lief
+
+from smda.common.labelprovider.OrdinalHelper import OrdinalHelper
+
+
+def resolve_pe_base_addr(lief_binary, base_addr=None):
+    if base_addr is None:
+        return getattr(lief_binary, "imagebase", 0)
+    return base_addr
+
+
+def parse_pe_imports(lief_binary, base_addr=None):
+    if not hasattr(lief_binary, "imports"):
+        return {}
+    active_base = resolve_pe_base_addr(lief_binary, base_addr)
+    import_symbols = {}
+    for imported_library in lief_binary.imports:
+        for func in imported_library.entries:
+            if func.name:
+                import_symbols[func.iat_address + active_base] = (
+                    imported_library.name.lower(),
+                    func.name,
+                )
+            elif func.is_ordinal:
+                resolved_ordinal = OrdinalHelper.resolveOrdinal(imported_library.name.lower(), func.ordinal)
+                ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
+                import_symbols[func.iat_address + active_base] = (
+                    imported_library.name.lower(),
+                    ordinal_name,
+                )
+    return import_symbols
+
+
+def parse_elf_relocation_imports(lief_binary):
+    """Build import map keyed by relocation slot address: addr -> (lib, name)."""
+    if not isinstance(lief_binary, lief.ELF.Binary):
+        return {}
+    import_symbols = {}
+    for relocation in lief_binary.relocations:
+        if not relocation.has_symbol:
+            continue
+        symbol = relocation.symbol
+        if symbol is None:
+            continue
+        if not symbol.imported or not symbol.is_function:
+            continue
+
+        lib = None
+        if symbol.has_version and symbol.symbol_version.has_auxiliary_version:
+            lib = symbol.symbol_version.symbol_version_auxiliary.name
+
+        import_symbols[relocation.address] = (lib, symbol.name)
+    return import_symbols
+
+
+def parse_macho_bindings(lief_binary, adjustment=0):
+    if not isinstance(lief_binary, lief.MachO.Binary):
+        return {}
+    imports = {}
+    for binding in getattr(lief_binary, "bindings", []):
+        try:
+            if (
+                binding.address != 0
+                and getattr(binding, "has_symbol", False)
+                and binding.symbol
+                and binding.symbol.name
+            ):
+                lib_name = (
+                    binding.library.name.lower() if (getattr(binding, "has_library", False) and binding.library) else ""
+                )
+                adjusted_addr = binding.address + adjustment
+                imports[adjusted_addr] = (lib_name, binding.symbol.name)
+        except Exception:
+            continue
+    return imports

--- a/tests/testElfSymbolProvider.py
+++ b/tests/testElfSymbolProvider.py
@@ -130,6 +130,25 @@ class TestElfApiSymbolSeparation(unittest.TestCase):
             imports = provider.parseImports(MOCK_ELF)
         self.assertEqual(imports, {0x4000: (None, "printf")})
 
+    def test_parse_imports_handles_missing_symbol_version_auxiliary(self):
+        imported = _MockSymbol("puts", value=0, imported=True)
+        imported.has_version = True
+        imported.symbol_version = SimpleNamespace(
+            has_auxiliary_version=True,
+            symbol_version_auxiliary=None,
+        )
+        elf = _MockElfBinary(
+            exported_functions=[],
+            symtab_symbols=[],
+            dynamic_symbols=[imported],
+            relocations=[_MockReloc(0x5000, imported)],
+            entrypoint=0,
+        )
+        provider = ElfSymbolProvider(None)
+        with mock.patch("lief.ELF.Binary", _MockElfBinary):
+            imports = provider.parseImports(elf)
+        self.assertEqual(imports, {0x5000: (None, "puts")})
+
     def test_collect_symbols_merges_symtab_dynamic_and_exports(self):
         provider = ElfSymbolProvider(None)
         with mock.patch("lief.ELF.Binary", _MockElfBinary):
@@ -176,6 +195,22 @@ class TestElfApiSymbolSeparation(unittest.TestCase):
             mock.patch("lief.ELF.Binary", _MockElfBinary),
         ):
             self.assertEqual(binary_info.getOep(), 0x534)
+
+    def test_binary_info_elf_pie_oep_preserves_base_relative_offset(self):
+        elf = _MockElfBinary(
+            exported_functions=[],
+            symtab_symbols=[],
+            dynamic_symbols=[],
+            relocations=[],
+            entrypoint=0x1050,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x555555554000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=elf),
+            mock.patch("lief.ELF.Binary", _MockElfBinary),
+        ):
+            self.assertEqual(binary_info.getOep(), 0x1050)
 
 
 if __name__ == "__main__":

--- a/tests/testMachoSymbolProvider.py
+++ b/tests/testMachoSymbolProvider.py
@@ -80,6 +80,18 @@ class TestMachoDemangler(unittest.TestCase):
 
 
 class TestMachoSymbolProviderBehavior(unittest.TestCase):
+    def test_collect_symbols_merges_exports_and_symtab(self):
+        _, raw, loader = _load_fixture("objective-see/bluenoroff")
+        binary_info = _binary_info(raw, loader)
+        provider = MachoSymbolProvider(None)
+        provider._binary_info = binary_info
+        symbols = provider.collectSymbols(binary_info.getLiefBinary())
+        exported = provider.parseExports(binary_info.getLiefBinary())
+        self.assertIn(0x100003F08, symbols)
+        self.assertEqual(symbols[0x100003F08], "_main")
+        for addr, name in exported.items():
+            self.assertEqual(symbols.get(addr), name)
+
     def test_xmetadata_symbols_are_filtered_to_code_areas(self):
         _, raw, loader = _load_fixture("objective-see/turtle")
         binary_info = _binary_info(raw, loader)

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -132,6 +132,34 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
             imported = binary_info.getImportedFunctions()
         self.assertEqual(imported, {0x402000: ("kernel32.dll", "ExitProcess")})
 
+    def test_rebased_dump_xmetadata_and_api_parity(self):
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("CreateFileW", 0x3000)])],
+            exported_functions=[_MockExport("exported_func", 0x1000)],
+            sections=[_MockSection(0x20000000, 0x1000)],
+            symbols=[_MockSymbol("local_func", 0x200)],
+            imagebase=0x140000000,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        resolver = WinApiResolver(SimpleNamespace(API_COLLECTION_FILES={}))
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=pe_binary),
+            mock.patch("lief.PE.Binary", _MockPeBinary),
+        ):
+            exported = binary_info.getExportedFunctions()
+            imported = binary_info.getImportedFunctions()
+            symbols = binary_info.getSymbols()
+            resolver.update(binary_info)
+
+        self.assertEqual(exported, {0x401000: "exported_func"})
+        self.assertEqual(imported, {0x403000: ("kernel32.dll", "CreateFileW")})
+        self.assertEqual(symbols[0x401000], "exported_func")
+        self.assertEqual(symbols[0x401200], "local_func")
+        self.assertNotIn(0x140001000, exported)
+        self.assertNotIn(0x140003000, imported)
+        self.assertEqual(resolver._api_map["lief"], imported)
+
     def test_binary_info_pe_symbols_merge_exports_and_coff(self):
         pe_binary = _MockPeBinary(
             exported_functions=[_MockExport("exported_func", 0x1000)],

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -237,6 +237,23 @@ class TestRustSymbolProvider(unittest.TestCase):
         provider = RustSymbolProvider(None)
         self.assertTrue(provider.isSymbolProvider())
 
+    def test_pe_rust_symbols_use_base_addr_not_imagebase(self):
+        provider = RustSymbolProvider(None)
+        mock_binary = MockLiefBinary(
+            [MockSymbol("_ZN3foo3barE", 0x200)],
+            exported_functions=[MockExport("_RNvC6_123foo3bar", 0x1000)],
+        )
+        mock_binary.imagebase = 0x140000000
+        mock_binary.sections = [MockSection(0x20000000, 0x1000)]
+
+        with mock.patch("lief.PE.Binary", MockLiefBinary):
+            provider._update_pe(mock_binary, base_addr=0x400000)
+
+        self.assertEqual(provider.getSymbol(0x401000), "123foo::bar")
+        self.assertEqual(provider.getSymbol(0x401200), "foo::bar")
+        self.assertNotIn(0x140001000, provider.getFunctionSymbols())
+        self.assertNotIn(0x140001200, provider.getFunctionSymbols())
+
     def test_detection_logic(self):
         """Test Rust binary detection based on signatures."""
         provider = RustSymbolProvider(None)

--- a/tests/testXmetadataNormalization.py
+++ b/tests/testXmetadataNormalization.py
@@ -1,0 +1,120 @@
+import unittest
+from unittest import mock
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider.ElfSymbolProvider import ElfSymbolProvider
+from smda.common.labelprovider.MachoSymbolProvider import MachoSymbolProvider
+from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
+from smda.common.SmdaReport import SmdaReport
+from tests.testElfSymbolProvider import MOCK_ELF, _MockElfBinary
+from tests.testPeSymbolProvider import (
+    _MockExport,
+    _MockImportEntry,
+    _MockImportLibrary,
+    _MockPeBinary,
+    _MockSection,
+    _MockSymbol,
+)
+
+
+def _expected_xmetadata_keys():
+    return {"exported_functions", "imported_functions", "symbols"}
+
+
+class TestXmetadataShape(unittest.TestCase):
+    def test_pe_xmetadata_keys_and_address_convention(self):
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("ExitProcess", 0x2000)])],
+            exported_functions=[_MockExport("exported_func", 0x1000)],
+            sections=[_MockSection(0x20000000, 0x1000)],
+            symbols=[_MockSymbol("local_func", 0x200)],
+            imagebase=0x140000000,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=pe_binary),
+            mock.patch("lief.PE.Binary", _MockPeBinary),
+        ):
+            xmetadata = {
+                "exported_functions": binary_info.getExportedFunctions(),
+                "imported_functions": binary_info.getImportedFunctions(),
+                "symbols": binary_info.getSymbols(),
+            }
+
+        self.assertEqual(set(xmetadata), _expected_xmetadata_keys())
+        self.assertIn(0x401000, xmetadata["exported_functions"])
+        self.assertIn(0x401000, xmetadata["symbols"])
+        self.assertIn(0x402000, xmetadata["imported_functions"])
+
+    def test_elf_xmetadata_keys_and_overlap_contract(self):
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=MOCK_ELF),
+            mock.patch("lief.ELF.Binary", _MockElfBinary),
+        ):
+            xmetadata = {
+                "exported_functions": binary_info.getExportedFunctions(),
+                "imported_functions": binary_info.getImportedFunctions(),
+                "symbols": binary_info.getSymbols(),
+            }
+
+        self.assertEqual(set(xmetadata), _expected_xmetadata_keys())
+        self.assertEqual(xmetadata["exported_functions"][0x1000], "exported_func")
+        self.assertEqual(xmetadata["symbols"][0x1000], "exported_func")
+        self.assertNotIn(0x4000, xmetadata["symbols"])
+        self.assertIn(0x4000, xmetadata["imported_functions"])
+
+    def test_provider_collect_symbols_parity(self):
+        pe_binary = _MockPeBinary(
+            exported_functions=[_MockExport("exported_func", 0x1000)],
+            sections=[_MockSection(0x20000000, 0x1000)],
+            symbols=[_MockSymbol("local_func", 0x200)],
+            imagebase=0x140000000,
+        )
+        pe_provider = PeSymbolProvider(None)
+        elf_provider = ElfSymbolProvider(None)
+        with mock.patch("lief.ELF.Binary", _MockElfBinary):
+            elf_symbols = elf_provider.collectSymbols(MOCK_ELF)
+        pe_symbols = pe_provider.collectSymbols(pe_binary, base_addr=0x400000)
+        self.assertIn(0x401000, pe_symbols)
+        self.assertIn(0x1000, elf_symbols)
+
+
+class TestXmetadataRoundtrip(unittest.TestCase):
+    def test_smda_report_preserves_xmetadata_dicts(self):
+        xmetadata = {
+            "exported_functions": {0x401000: "exported_func"},
+            "imported_functions": {0x402000: ("kernel32.dll", "ExitProcess")},
+            "symbols": {0x401000: "exported_func", 0x401200: "local_func"},
+        }
+        report = SmdaReport()
+        report.xmetadata = xmetadata
+        report.status = "ok"
+        report.architecture = "intel"
+        report.base_addr = 0x400000
+        report.xcfg = {}
+
+        restored = SmdaReport.fromDict(report.toDict())
+        self.assertEqual(restored.xmetadata, xmetadata)
+        self.assertEqual(set(restored.xmetadata), _expected_xmetadata_keys())
+
+
+class TestMachoImportKeyConsistency(unittest.TestCase):
+    def test_parse_imports_matches_provider_api_map_keys(self):
+        from tests.testMachoSymbolProvider import _binary_info, _load_fixture
+
+        _, raw, loader = _load_fixture("objective-see/bluenoroff")
+        binary_info = _binary_info(raw, loader)
+        provider = MachoSymbolProvider(None)
+        provider._binary_info = binary_info
+        provider.update(binary_info)
+        imports = provider.parseImports(binary_info.getLiefBinary())
+        self.assertEqual(set(imports), set(provider._api_map))
+        for slot, entry in imports.items():
+            self.assertEqual(provider.getApi(slot), entry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Tier-2 label parity follow-up to PR #84: finish PE rebased-dump addressing, Mach-O
`collectSymbols` parity with PE/ELF, shared import parsers, and documented xmetadata
address conventions.

## Motivation

Tier-1 aligned PE/ELF import `base_addr` handling and Mach-O symbol hardening, but left
residual gaps: `RustSymbolProvider` still keyed PE exports/COFF symbols on LIEF
`imagebase`, Mach-O `BinaryInfo.getSymbols()` only used symtab (not exports), and import
parsing logic was duplicated across three providers.

## Changes

- **PE rebased dumps:** `RustSymbolProvider._update_pe()` uses `resolve_pe_base_addr()`
  (active `base_addr`, imagebase fallback) for exports and COFF symbols.
- **Mach-O metadata:** `MachoSymbolProvider.collectSymbols()` merges exports + symtab;
  `BinaryInfo.getSymbols()` for Mach-O now calls it (still filtered to code areas).
- **Shared import helpers:** new `import_parsers.py` with `parse_pe_imports`,
  `parse_elf_relocation_imports`, `parse_macho_bindings`; PE/ELF/Mach-O providers delegate.
- **xmetadata contract:** documented on `BinaryInfo` and `getSections()` — PE uses active
  `base_addr`, ELF uses absolute LIEF VAs, Mach-O applies slice/base adjustment;
  `symbols` may overlap `exported_functions` when exports also appear in symtab.
- **Tests:** rebased PE xmetadata + `WinApiResolver` parity, Rust PE `base_addr` regression,
  Mach-O `collectSymbols`, xmetadata shape/roundtrip (`testXmetadataNormalization.py`).

## Validation

```bash
make lint
make test
python -m pytest tests/testPeSymbolProvider.py tests/testElfSymbolProvider.py \
  tests/testMachoSymbolProvider.py tests/testRustSymbolProvider.py \
  tests/testXmetadataNormalization.py -q
```

- `make lint` — pass
- `make test` — 293 passed

## Stack

Builds on upstream PR #150, now merged into `master`.
