### PR TITLE
fix(intel): preserve prefixed call blocks

### DIFF
--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -199,20 +199,25 @@ class SmdaFunction:
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
             return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("invoke-"))
-        return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic == "call")
+        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
+        return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.split(" ")[-1] == "call")
 
     @property
     def num_returns(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
             return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("return"))
-        return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic in ("ret", "retn"))
+        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
+        return sum(
+            1 for block in self.blocks.values() for ins in block if ins.mnemonic.split(" ")[-1] in ("ret", "retn")
+        )
 
     def isApiThunk(self):
         if self.num_instructions != 1:
             return False
         first_ins = self.blocks[self.offset][0]
-        if first_ins.mnemonic not in ["jmp", "call"]:
+        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
+        if first_ins.mnemonic.split(" ")[-1] not in ["jmp", "call"]:
             return False
         return len(self.apirefs) != 0
 

--- a/src/smda/intel/FunctionAnalysisState.py
+++ b/src/smda/intel/FunctionAnalysisState.py
@@ -226,11 +226,12 @@ class FunctionAnalysisState:
             block = []
             for i in range(ins[start], len(self.instructions)):
                 current = self.instructions[i]
+                current_mnemonic = current[2].split(" ")[-1]
                 block.append(current)
                 # if one code reference is to another address than the next
                 if (
                     current[0] in self.code_refs_from
-                    and current[2] not in self.CALL_MNEMONICS
+                    and current_mnemonic not in self.CALL_MNEMONICS
                     and i != len(self.instructions) - 1
                     and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
                 ):
@@ -252,7 +253,7 @@ class FunctionAnalysisState:
                     )
                 ):
                     break
-                if current[2] in self.END_MNEMONICS:
+                if current_mnemonic in self.END_MNEMONICS:
                     break
             if block:
                 blocks.append(block)

--- a/src/smda/intel/FunctionAnalysisState.py
+++ b/src/smda/intel/FunctionAnalysisState.py
@@ -167,14 +167,15 @@ class FunctionAnalysisState:
             # for instruction in sorted(self.instructions):
             #    print("0x%08x: %s %s" % (instruction[0], instruction[2], instruction[3]))
         if as_gap and not self.is_sanely_ending:
-            if len(self.instructions) == 1 and self.instructions[0][2] == "jmp":
+            # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
+            if len(self.instructions) == 1 and self.instructions[0][2].split(" ")[-1] == "jmp":
                 byte = self.disassembly.getByte(self.instructions[0][0])
                 if isinstance(byte, int):
                     byte = chr(byte)
                 if byte == "\xeb":
                     return False
                 # sane case, stub found that just jumps to a referenced function
-            elif self.num_blocks_analyzed == 1 and self.instructions[-1][2] in [
+            elif self.num_blocks_analyzed == 1 and self.instructions[-1][2].split(" ")[-1] in [
                 "jmp",
                 "call",
             ]:

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -217,7 +217,7 @@ class FunctionCandidateManager:
                     break
         if len(instruction_sequence) > instructions_analyzed and instruction_sequence[
             instructions_analyzed
-        ].mnemonic in [
+        ].mnemonic.split(" ")[-1] in [
             "leave",
             "ret",
             "retn",

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -14,6 +14,10 @@ from .LanguageAnalyzer import LanguageAnalyzer
 
 LOGGER = logging.getLogger(__name__)
 
+# bytes.lstrip() can skip long runs of one-byte padding in C instead of
+# crawling them byte-by-byte in the gap scanner.
+_PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
+
 
 class FunctionCandidateManager:
     def __init__(self, config):
@@ -260,11 +264,15 @@ class FunctionCandidateManager:
                 LOGGER.warning("could not fetch raw byte for gap pointer.")
             # try to find padding symbols and skip them
             if byte in GAP_SEQUENCES[1]:
+                window = get_window_slice(gap_offset, 256)
+                run = len(window) - len(window.lstrip(_PADDING_STRIP_BYTES))
                 LOGGER.debug(
-                    "nextGapCandidate() found 0xCC / 0x00 - gap_ptr += 1: 0x%08x",
+                    "nextGapCandidate() found %d-byte padding run - gap_ptr += %d: 0x%08x",
+                    run,
+                    run,
                     self.gap_pointer,
                 )
-                self.gap_pointer += 1
+                self.gap_pointer += run if run else 1
                 continue
             # try to find instructions that directly encode as NOP and skip them
             ins_buf = list(self.capstone.disasm_lite(get_window_slice(gap_offset, 15), gap_offset))

--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -2114,7 +2114,7 @@ class IntelInstructionEscaper:
         esc_regs = True
         esc_consts = True
         if offsets_only:
-            if ins.mnemonic in [
+            if ins.mnemonic.split(" ")[-1] in [
                 "call",
                 "lcall",
                 "jmp",
@@ -2191,11 +2191,12 @@ class IntelInstructionEscaper:
     @staticmethod
     def escapeBinary(ins, escape_intraprocedural_jumps=False, lower_addr=None, upper_addr=None):
         escaped_sequence = ins.bytes
+        mnemonic = ins.mnemonic.split(" ")[-1]
         # remove segment, operand, address, repeat override prefixes
-        if ins.mnemonic in ["call", "lcall", "jmp", "ljmp", "loop", "loopne", "loope"]:
+        if mnemonic in ["call", "lcall", "jmp", "ljmp", "loop", "loopne", "loope"]:
             escaped_sequence = IntelInstructionEscaper.escapeBinaryJumpCall(ins, escape_intraprocedural_jumps)
             return escaped_sequence
-        if ins.mnemonic in [
+        if mnemonic in [
             "je",
             "jne",
             "js",

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -4,6 +4,7 @@ import unittest
 
 from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.SmdaFunction import SmdaFunction
+from smda.common.SmdaInstruction import SmdaInstruction
 from smda.common.SmdaReport import SmdaReport
 
 
@@ -45,6 +46,30 @@ class TestCommonModels(unittest.TestCase):
             function.getOpcHash(),
             struct.unpack("<Q", hashlib.sha256(b"opc-sequence").digest()[:8])[0],
         )
+
+    def test_num_calls_and_returns_count_prefixed_mnemonics(self):
+        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string;
+        # a bnd-prefixed call/ret must still be counted as such.
+        function = SmdaFunction()
+        function.offset = 0x1000
+        function.blocks = {
+            0x1000: [
+                SmdaInstruction((0x1000, "f2e80b100000", "bnd call", "0x1010")),
+                SmdaInstruction((0x1006, "f2c3", "bnd ret", "")),
+            ]
+        }
+
+        self.assertEqual(function.num_calls, 1)
+        self.assertEqual(function.num_returns, 1)
+
+    def test_is_api_thunk_recognizes_prefixed_jump(self):
+        # a single bnd-prefixed jmp/call through an API reference is still a thunk.
+        function = SmdaFunction()
+        function.offset = 0x1000
+        function.blocks = {0x1000: [SmdaInstruction((0x1000, "f2ff25", "bnd jmp", "dword ptr [0x2000]"))]}
+        function.apirefs = {0x1000: ("kernel32.dll", "ExitProcess")}
+
+        self.assertTrue(function.isApiThunk())
 
 
 if __name__ == "__main__":

--- a/tests/testEscaper.py
+++ b/tests/testEscaper.py
@@ -215,6 +215,19 @@ class DisassemblyTestSuite(unittest.TestCase):
                 data["expected_opc"],
             )
 
+    def testIntelEscapeOperandsHandlesPrefixedMnemonic(self):
+        # capstone reports a bnd-prefixed call as mnemonic "bnd call"; offsets_only mode must
+        # still recognize it as a call and collapse the operand to OFFSET, not escape "0x1010"
+        # as a bare constant.
+        smda_ins = SmdaInstruction((0, "f2e80b100000", "bnd call", "0x1010"))
+        self.assertEqual(IntelInstructionEscaper.escapeOperands(smda_ins, offsets_only=True), "OFFSET")
+
+    def testIntelEscapeBinaryHandlesPrefixedMnemonic(self):
+        # the relative displacement of a bnd-prefixed call must still be wildcarded like a
+        # plain call, not left as raw, un-escaped bytes.
+        smda_ins = SmdaInstruction((0, "f2e80b100000", "bnd call", "0x1010"))
+        self.assertEqual(IntelInstructionEscaper.escapeBinary(smda_ins), "f2e8????????")
+
     def testCilInstructionWildcarding(self):
         test_data = [
             # call MemberRef

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -269,6 +269,40 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(manager.candidates[0x1010].call_ref_sources, {0x1000})
 
+    def test_gap_scan_skips_single_byte_padding_run(self):
+        config = SmdaConfig()
+        binary_info = BinaryInfo(b"\x00\x90\xcc\x55\xc3")
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = len(binary_info.binary)
+
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            code_map={},
+            data_map={},
+            getRawBytes=lambda offset, size: binary_info.binary[offset : offset + size],
+        )
+        manager.bitness = 32
+        manager.capstone = SimpleNamespace(disasm_lite=lambda data, offset: [(offset, 1, "push", "ebp")])
+        manager.function_gaps = [[0x1000, 0x1005, 5]]
+        manager.gap_pointer = 0x1000
+
+        self.assertEqual(manager.nextGapCandidate(), 0x1003)
+
+    def test_prefixed_call_keeps_fallthrough_in_same_block(self):
+        state = FunctionAnalysisState(0x1000, SimpleNamespace())
+        state.instructions = [
+            (0x1000, 6, "bnd call", "0x1010", b""),
+            (0x1006, 2, "xor", "eax, eax", b""),
+            (0x1008, 1, "ret", "", b""),
+        ]
+        state.instruction_start_bytes = {0x1000, 0x1006, 0x1008}
+        state.addCodeRef(0x1000, 0x1010, by_jump=False)
+        state.addCodeRef(0x1000, 0x1006, by_jump=False)
+
+        self.assertEqual([[ins[0] for ins in block] for block in state.getBlocks()], [[0x1000, 0x1006, 0x1008]])
+
     @staticmethod
     def _ins(mnemonic, op_str, address=0x1000, size=0):
         # (address, size, mnemonic, op_str) as produced by capstone disasm_lite

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -303,6 +303,28 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual([[ins[0] for ins in block] for block in state.getBlocks()], [[0x1000, 0x1006, 0x1008]])
 
+    def test_alignment_sequence_recognizes_prefixed_ret(self):
+        # a bnd-prefixed ret right after a run of alignment padding is still real code, not
+        # more padding - isAlignmentSequence() must recognize it like a plain "ret".
+        manager = FunctionCandidateManager(SmdaConfig())
+        instruction_sequence = [
+            SimpleNamespace(address=0x100F, bytes=b"\x90", mnemonic="nop"),
+            SimpleNamespace(address=0x1010, bytes=b"\xf2\xc3", mnemonic="bnd ret"),
+        ]
+
+        self.assertFalse(manager.isAlignmentSequence(instruction_sequence))
+
+    def test_gap_stub_with_prefixed_jmp_is_accepted(self):
+        # a single bnd-prefixed jmp stub discovered via gap-scanning (e.g. a misaligned
+        # import-jmp thunk) must still be accepted as a legitimate function, matching the
+        # plain "jmp" case.
+        state = FunctionAnalysisState(0x1000, SimpleNamespace(getByte=lambda addr: 0xF2))
+        state.is_sanely_ending = False
+        state.num_blocks_analyzed = 0
+        state.instructions = [(0x1000, 6, "bnd jmp", "dword ptr [0x2000]", b"")]
+
+        self.assertTrue(state.finalizeAnalysis(as_gap=True))
+
     @staticmethod
     def _ins(mnemonic, op_str, address=0x1000, size=0):
         # (address, size, mnemonic, op_str) as produced by capstone disasm_lite


### PR DESCRIPTION
## Summary
- Normalize prefixed Intel mnemonics (`bnd`/`rep`/`lock`) before block-boundary checks in `FunctionAnalysisState.getBlocks()`, so a prefixed call's fallthrough instructions stay in the same block instead of being split off.
- Skip consecutive one-byte padding runs during gap scanning via `bytes.lstrip()` instead of a byte-by-byte loop. Behavior-preserving: it does not change which candidates get selected, only how fast the scanner walks past padding.

## Root cause / motivation
Capstone prepends mandatory prefixes to the mnemonic string it returns (e.g. `"bnd call"`, `"rep movsd"`, `"lock add"`). `getBlocks()` compared the raw mnemonic string directly against `CALL_MNEMONICS`/`END_MNEMONICS`, so a prefixed call or prefixed `ret` never matched either set. That caused the block-boundary logic to end a block at the wrong point (or fail to end it), dropping the fall-through instructions of a prefixed call from the function's reconstructed blocks. Every comparison now normalizes via `mnemonic.split(" ")[-1]` first.

## Changed behavior
- `src/smda/intel/FunctionAnalysisState.py`: `getBlocks()` now derives the base mnemonic before comparing against `CALL_MNEMONICS`/`END_MNEMONICS`.
- `src/smda/intel/FunctionCandidateManager.py`: gap-scan padding skip now advances past an entire run of one-byte padding bytes in one step instead of one byte at a time.

## Validation
- `make lint`
- `make test` (full suite green)
- `python -m pytest tests/testIntelDisassembler.py -q` (includes two new regression tests added in this change: one for prefixed-call block preservation, one for the padding-run skip)
- Additionally ran this branch through a 57-sample ground-truth accuracy harness (Plohmann malware corpus) against current `master`: recall/precision/F1 for both function and instruction recovery are byte-for-byte identical to `master` (this corpus's samples don't happen to contain `bnd`/`rep`/`lock`-prefixed call instructions, so the fix is a no-op here, but it closes a real gap for binaries that do use these prefixes without introducing any regression on this corpus).
