### PR TITLE
fix(intel): gap-scan head/tail of raw memory dumps

### DIFF
--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -147,7 +147,18 @@ class FunctionCandidateManager:
         prev_ins = 0
         min_code = min(self.disassembly.code_map) if self.disassembly.code_map else self.getBitMask()
         max_code = max(self.disassembly.code_map) if self.disassembly.code_map else 0
-        for code_area in self._code_areas:
+        # Raw memory dumps are loaded without section info, so self._code_areas is empty; fall back to
+        # the full mapped image so the head (before the first instruction) and tail (after the last
+        # instruction) still get gap-scanned. Without this, functions that lie entirely before the
+        # first or after the last already-discovered instruction (e.g. trailing jmp/thunk tables) are
+        # never reached by the gap pass.
+        code_areas = self._code_areas or [
+            [
+                self.disassembly.binary_info.base_addr,
+                self.disassembly.binary_info.base_addr + self.disassembly.binary_info.binary_size,
+            ]
+        ]
+        for code_area in code_areas:
             if code_area[0] < min_code < code_area[1] and min_code != code_area[0]:
                 gaps.append([code_area[0], min_code, min_code - code_area[0]])
             if code_area[0] < max_code < code_area[1] and max_code != code_area[1]:

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -152,6 +152,7 @@ class FunctionCandidateManager:
         # instruction) still get gap-scanned. Without this, functions that lie entirely before the
         # first or after the last already-discovered instruction (e.g. trailing jmp/thunk tables) are
         # never reached by the gap pass.
+        using_synthetic_area = not self._code_areas
         code_areas = self._code_areas or [
             [
                 self.disassembly.binary_info.base_addr,
@@ -162,7 +163,15 @@ class FunctionCandidateManager:
             if code_area[0] < min_code < code_area[1] and min_code != code_area[0]:
                 gaps.append([code_area[0], min_code, min_code - code_area[0]])
             if code_area[0] < max_code < code_area[1] and max_code != code_area[1]:
-                gaps.append([max_code, code_area[1], code_area[1] - max_code])
+                # For the synthetic full-image fallback (raw memory dumps with no section info),
+                # the tail gap must start AFTER the last instruction's address, mirroring the
+                # interior-hole branch's prev_ins + 1 below. max_code is itself in code_map, so a
+                # gap starting at max_code leaves the gap-pointer on a code_map address;
+                # getNextGap()'s strict "gap[0] > gap_pointer" test then finds no further gap,
+                # returns the bitmask sentinel, and the scan terminates -- abandoning the whole tail
+                # region unscanned. Section-derived code areas keep the legacy start (behavior-neutral).
+                tail_start = max_code + 1 if using_synthetic_area else max_code
+                gaps.append([tail_start, code_area[1], code_area[1] - tail_start])
         for ins in sorted(self.disassembly.code_map.keys()):
             if prev_ins != 0 and ins - prev_ins > 1:
                 gaps.append([prev_ins + 1, ins, ins - prev_ins])

--- a/tests/testIntegration.py
+++ b/tests/testIntegration.py
@@ -62,7 +62,9 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         cls.cutwail_unmapped_disassembly = disasm.disassembleUnmappedBuffer(cls.cutwail_binary)
 
     def testAsproxDisassemblyCoverage(self):
-        assert len(list(self.asprox_disassembly.getFunctions())) == 105
+        # 106 (was 105): scanning the tail of the mapped image (past the last already-discovered
+        # instruction) recovers one additional gap-candidate function.
+        assert len(list(self.asprox_disassembly.getFunctions())) == 106
 
     def testOep(self):
         # PE header from buffers are not parsed, so we don't get header infos
@@ -108,7 +110,7 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         report_as_dict = self.asprox_disassembly.toDict()
         assert report_as_dict["status"] == "ok"
         assert report_as_dict["base_addr"] == 0x8D0000
-        assert report_as_dict["statistics"]["num_instructions"] == 15706
+        assert report_as_dict["statistics"]["num_instructions"] == 15714
         assert report_as_dict["sha256"] == "db8a133fed1b706608a4492079b702ded6b70369a980d2b5ae355a6adc78ef00"
         SmdaReport.fromDict(report_as_dict)
 

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -269,6 +269,26 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(manager.candidates[0x1010].call_ref_sources, {0x1000})
 
+    def test_function_gaps_cover_head_and_tail_without_code_areas(self):
+        # Raw memory dumps are loaded without section info (_code_areas is empty). The gap scan
+        # must still cover the head (before the first instruction) and tail (after the last
+        # instruction) of the mapped image, otherwise functions that lie entirely before the first
+        # or after the last already-discovered instruction (e.g. trailing jmp/thunk tables) are
+        # never reached by the gap pass.
+        manager = FunctionCandidateManager(SmdaConfig())
+        binary_info = BinaryInfo(b"\x00" * 0x100)
+        binary_info.base_addr = 0x1000
+        binary_info.binary_size = 0x100
+        manager._code_areas = []
+        # only one already-discovered instruction, in the middle of the image
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={0x1080: 1})
+
+        manager.updateFunctionGaps()
+
+        # a head gap [base_addr, first_instruction) and a tail gap [last_instruction, image_end)
+        self.assertIn([0x1000, 0x1080, 0x80], manager.function_gaps)
+        self.assertIn([0x1080, 0x1100, 0x80], manager.function_gaps)
+
     @staticmethod
     def _ins(mnemonic, op_str, address=0x1000, size=0):
         # (address, size, mnemonic, op_str) as produced by capstone disasm_lite

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -285,9 +285,12 @@ class TestIntelDisassembler(unittest.TestCase):
 
         manager.updateFunctionGaps()
 
-        # a head gap [base_addr, first_instruction) and a tail gap [last_instruction, image_end)
+        # a head gap [base_addr, first_instruction) and a tail gap that starts AFTER the last
+        # instruction's address (max_code + 1, mirroring the interior-hole branch). Starting the
+        # tail gap at max_code itself would leave the gap-pointer on a code_map address, which
+        # getNextGap() cannot advance past -- the tail would never be scanned.
         self.assertIn([0x1000, 0x1080, 0x80], manager.function_gaps)
-        self.assertIn([0x1080, 0x1100, 0x80], manager.function_gaps)
+        self.assertIn([0x1081, 0x1100, 0x7F], manager.function_gaps)
 
     @staticmethod
     def _ins(mnemonic, op_str, address=0x1000, size=0):


### PR DESCRIPTION
## Summary

Gap-scan the head and tail of raw memory dumps so functions lying entirely before the first or after the last already-discovered instruction are recovered. Two related commits fixing the same "tail-gap coverage" class:

1. **Create the head/tail gaps** for raw dumps (empty `_code_areas`).
2. **Scan the tail past the last instruction** — fix an off-by-one that made the gap walk abandon the entire tail region.

## Root cause

`FunctionCandidateManager.updateFunctionGaps()` only generated the head gap (before the first instruction) and tail gap (after the last instruction) by iterating `self._code_areas`. Raw memory dumps load from a buffer without section info, so `_code_areas` is empty and those regions were never turned into gaps — a function lying entirely before the first or after the last already-discovered instruction (e.g. a trailing `jmp`/thunk table) was unreachable by the gap pass.

Adding the synthetic full-image fallback exposed a second, pre-existing off-by-one: the tail gap was built as `[max_code, image_end)`, but `max_code` is the last instruction's address — itself in `code_map`. When the gap walk reaches `gap_pointer == max_code`, `nextGapCandidate()` sees it "already inside code map" and calls `getNextGap()`, whose strict `gap[0] > gap_pointer` test finds no further gap (the tail gap starts *at* `max_code`), returns the bitmask sentinel, and the scan terminates — abandoning the entire tail unscanned. The tail gap must start at `max_code + 1`, mirroring the interior-hole branch's `prev_ins + 1`.

## Changed behavior

- Fall back to the full mapped image `[base_addr, base_addr + binary_size)` as one synthetic code area when `_code_areas` is empty.
- Start that synthetic tail gap at `max_code + 1` so the gap-pointer lands past the last instruction and the tail is scanned. **Section-derived code areas (PE/ELF/Mach-O loads) keep the legacy behavior and are byte-for-byte unchanged** — the fix is scoped to the raw-dump fallback.
- AArch64 subclasses this manager and overrides only `nextGapCandidate`, so it inherits the fix; Dalvik/CIL have no gap-scanning candidate manager.

## Validation

Measured on the 57-sample malware memory-dump corpus (all loaded via `disassembleBuffer`, i.e. empty `_code_areas`), micro-averaged:

| metric | before | after |
|---|---|---|
| function recall | 98.061% | **98.814%** |
| function precision | 89.539% | 89.321% |
| function F1 | 93.606% | **93.828%** |
| missed functions | 425 | 260 |
| instruction recall | 98.898% | **99.033%** |
| instruction F1 | 94.572% | 94.571% |

Net **+165 functions recovered** (e.g. contopee's trailing import-thunk table, mewsei +44, kins +30, x64-prikorma +6). Function F1 up, instruction F1 flat. The additional "extra" functions are dominated by coherent compiler functions the IDA-snapshot ground truth did not label (verified iceix/feodo/rockloader/zlader — real prologues, calls, branches, `ret`), not garbage decode. Newly-surfaced tiny artifacts are < 10 instructions and ignored by MCRIT, consistent with the existing gap-scan "extract when in doubt" design.

Commands:
- `make lint` — clean
- `python -m pytest tests/testIntelDisassembler.py` — passes (regression test `test_function_gaps_cover_head_and_tail_without_code_areas` covers both gaps and the `max_code + 1` tail start)
- `make test` — 359 passed, 1 skipped (updated the asprox coverage/marshalling golden values to match the tail-scan recovery; the komplex Mach-O and mirai ELF loader fixtures are unchanged, confirming the section-derived path is untouched)
