### PR TITLE
fix(intel): recover MSVC hotpatch stubs mislocated by the gap scanner

### DIFF
--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -8,7 +8,7 @@ from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.utility.BracketQueue import BracketQueue
 from smda.utility.PriorityQueue import PriorityQueue
 
-from .definitions import DEFAULT_PROLOGUES, GAP_SEQUENCES
+from .definitions import COMMON_PROLOGUES, DEFAULT_PROLOGUES, GAP_SEQUENCES
 from .FunctionCandidate import FunctionCandidate
 from .LanguageAnalyzer import LanguageAnalyzer
 
@@ -197,6 +197,13 @@ class FunctionCandidateManager:
     def isEffectiveNop(self, byte_sequence):
         return byte_sequence in GAP_SEQUENCES[len(byte_sequence)]
 
+    def isHotpatchPrologue(self, byte_window):
+        # An MSVC hotpatch stub (`mov edi, edi; push ebp; mov ebp, esp`) opens with a
+        # `mov edi, edi` that is byte-identical to a 2-byte effective NOP, yet it IS the
+        # function's true entry. Recognizing the 5-byte prologue lets callers avoid
+        # skipping/rounding past that leading NOP and mislocating the start two bytes late.
+        return byte_window in COMMON_PROLOGUES["5"].get(self.bitness, {})
+
     def isAlignmentSequence(self, instruction_sequence):
         is_alignment_sequence = False
         instructions_analyzed = 0
@@ -285,6 +292,11 @@ class FunctionCandidateManager:
             found_multi_byte_nop = False
             for gap_length in range(max(GAP_SEQUENCES.keys()), 1, -1):
                 if get_window_slice(gap_offset, gap_length) in GAP_SEQUENCES[gap_length]:
+                    # Do not skip a `mov edi, edi` effective NOP when it is the landing pad of
+                    # a hotpatch stub: that byte pair is the function's true start, and skipping
+                    # it would mislocate the function two bytes late (at the `push ebp`).
+                    if self.isHotpatchPrologue(get_window_slice(gap_offset, 5)):
+                        break
                     LOGGER.debug(
                         "nextGapCandidate() found %d byte effective nop - gap_ptr += %d: 0x%08x",
                         gap_length,

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -367,12 +367,19 @@ class X86Backend(ArchBackend):
                     state.endBlock()
                     state.setSanelyEnding(True)
                     if d.fc_manager.isAlignmentSequence(instruction_sequence):
-                        next_aligned_address = previous_address + (16 - previous_address % 16)
+                        # A hotpatch stub right after a call can look like alignment padding
+                        # (its leading `mov edi, edi` is an effective NOP), but that byte pair
+                        # is the next function's true entry. Seed it directly rather than the
+                        # 16-byte-rounded address, which would land two bytes late.
+                        if d.fc_manager.isHotpatchPrologue(d._getDisasmWindowBuffer(i_address)[:5]):
+                            next_candidate_address = i_address
+                        else:
+                            next_candidate_address = previous_address + (16 - previous_address % 16)
                         LOGGER.debug(
                             "  Adding: 0x%x as candidate.",
-                            next_aligned_address,
+                            next_candidate_address,
                         )
-                        d.fc_manager.addCandidate(next_aligned_address, is_gap=True)
+                        d.fc_manager.addCandidate(next_candidate_address, is_gap=True)
                     return True
                 else:
                     LOGGER.debug(

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -269,6 +269,56 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(manager.candidates[0x1010].call_ref_sources, {0x1000})
 
+    def _first_gap_candidate(self, stub, base=0x1000, stub_off=0x10):
+        # Build a buffer with a gap (between two mapped instructions at base and base+0x100),
+        # int3-padded up to `stub` at base+stub_off, then drive the gap scanner once.
+        from capstone import CS_ARCH_X86, CS_MODE_32, Cs
+
+        buf = bytearray(b"\x90")  # base+0x00: a mapped instruction bounding the gap
+        buf += b"\xcc" * (stub_off - len(buf))  # int3 padding leading into the gap
+        buf += stub  # base+stub_off: the candidate bytes under test
+        buf += b"\xcc" * (0x200 - len(buf))  # trailing fill
+
+        binary_info = BinaryInfo(bytes(buf))
+        binary_info.base_addr = base
+        binary_info.binary_size = len(buf)
+        binary_info.bitness = 32
+        disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            code_map={base: 1, base + 0x100: 1},
+            data_map={},
+            getRawBytes=lambda offset, n: bytes(buf)[offset : offset + n],
+        )
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = disassembly
+        manager.bitness = 32
+        manager.capstone = Cs(CS_ARCH_X86, CS_MODE_32)
+        return manager.nextGapCandidate()
+
+    def test_hotpatch_prologue_not_skipped_as_effective_nop(self):
+        # `mov edi, edi; push ebp; mov ebp, esp` is an MSVC hotpatch stub whose leading
+        # `mov edi, edi` (0x8bff) is an effective NOP but IS the true function start. The
+        # gap scanner must return the stub start, not skip it to the `push ebp` two bytes
+        # later (which would mislocate the function and drop its true entry).
+        self.assertEqual(self._first_gap_candidate(b"\x8b\xff\x55\x8b\xec"), 0x1010)
+        # control: a bare `mov edi, edi` not followed by a real prologue is still treated
+        # as an effective NOP and skipped, so it is never returned as the candidate start.
+        self.assertNotEqual(self._first_gap_candidate(b"\x8b\xff\x90\x90\x90"), 0x1010)
+
+    def test_is_hotpatch_prologue_predicate(self):
+        # The shared predicate backs both the gap scanner and the post-call alignment-cut
+        # path, so lock its contract directly: both `mov edi, edi` encodings of the MSVC
+        # hotpatch stub match in 32-bit, non-hotpatch windows do not, and 64-bit never
+        # matches (the stub is a 32-bit convention; COMMON_PROLOGUES["5"][64] is empty).
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 32
+        self.assertTrue(manager.isHotpatchPrologue(b"\x8b\xff\x55\x8b\xec"))
+        self.assertTrue(manager.isHotpatchPrologue(b"\x89\xff\x55\x8b\xec"))
+        self.assertFalse(manager.isHotpatchPrologue(b"\x8b\xff\x90\x90\x90"))
+        self.assertFalse(manager.isHotpatchPrologue(b"\x55\x8b\xec\x83\xec"))  # bare prologue, no NOP
+        manager.bitness = 64
+        self.assertFalse(manager.isHotpatchPrologue(b"\x8b\xff\x55\x8b\xec"))
+
     @staticmethod
     def _ins(mnemonic, op_str, address=0x1000, size=0):
         # (address, size, mnemonic, op_str) as produced by capstone disasm_lite


### PR DESCRIPTION
## Summary

Fixes a function-start mislocation bug where MSVC hotpatch stubs (`mov edi, edi; push ebp; mov ebp, esp`) had their true entry skipped as an effective NOP, anchoring the function two bytes late at the `push ebp`.

## Root cause

An MSVC hotpatch stub opens with `mov edi, edi` (`8b ff`), which is byte-identical to a 2-byte effective NOP in `GAP_SEQUENCES`. Two code paths treated this landing pad as inter-function padding:

1. **Gap scanner** (`FunctionCandidateManager.nextGapCandidate`): skipped the `8b ff` as a multi-byte NOP, advancing `gap_pointer` past the true entry to the `push ebp` two bytes later.
2. **Post-call alignment-cut** (`X86Backend.analyzeInstruction`): seeded the next candidate at the 16-byte-rounded address after a call, which lands two bytes past the hotpatch stub's true entry.

## Changed behavior

Added a shared `isHotpatchPrologue` predicate (`FunctionCandidateManager`) that checks a 5-byte window against `COMMON_PROLOGUES["5"]` (the `mov edi, edi; push ebp; mov ebp, esp` encodings).

- **Gap scanner**: before skipping a multi-byte effective NOP, if the 5-byte window is a hotpatch prologue, stop skipping and return the current address as the candidate start.
- **Post-call alignment-cut**: when cutting at an alignment sequence after a call, if the current address is a hotpatch prologue, seed the candidate at the true entry (`i_address`) instead of the 16-byte-rounded address.

The predicate is 32-bit only — `COMMON_PROLOGUES["5"][64]` is empty because the MSVC hotpatch stub is a 32-bit convention.

## Validation

```
make lint
make test
```

- ruff check: all checks passed
- ruff format: 135 files already formatted
- pytest: 360 passed, 1 skipped, 474 subtests passed

Corpus impact (Plohmann malpedia/itw ground truth, 57 samples, paired same-machine runs of master vs this branch), function-level:

| | master | this PR |
|---|---|---|
| missed functions | 423 | **421** |
| extra functions | 2512 | **2510** |
| PPV (macro, per-sample mean) | 93.032 | **93.043** |
| TPR (macro, per-sample mean) | 97.787 | **97.798** |
| F1 (macro, per-sample mean) | 94.980 | **94.992** |
| F1 (micro, corpus-wide) | 93.611 | **93.620** |

The corpus-wide diff isolates to exactly the fixed pattern: two hotpatch stubs recovered at their true starts (nabucur `0xf4d922`, `0xf4dc5d`) and their two `+2`-mislocated counterparts removed from the extras — no other sample changes. Precision, recall, and F1 all improve simultaneously; zero new false positives.

## Tests

Two new regression tests in `tests/testIntelDisassembler.py`:

- `test_hotpatch_prologue_not_skipped_as_effective_nop`: drives the gap scanner with a hotpatch stub and verifies the candidate start is the true entry, not two bytes late. Includes a control case where a bare `mov edi, edi` without a following prologue is still skipped.
- `test_is_hotpatch_prologue_predicate`: locks the predicate contract directly — both `mov edi, edi` encodings match in 32-bit, non-hotpatch windows do not, and 64-bit never matches.
