### PR TITLE
fix(intel): skip chained/forwarded function-candidate table entries

### DIFF
--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -53,7 +53,14 @@ class PeSymbolProvider(AbstractLabelProvider):
     def parseExports(self, lief_binary, base_addr=None):
         active_base = self._resolve_base_addr(lief_binary, base_addr)
         function_symbols = {}
-        for function in lief_binary.exported_functions:
+        export = lief_binary.get_export()
+        if export is None:
+            return function_symbols
+        for function in export.entries:
+            if function.is_extern or function.is_forwarded:
+                # forwarder/extern entries redirect to another module's export and have no
+                # local address (LIEF sets .address to 0 for them) - not a local function.
+                continue
             function_name = ""
             with contextlib.suppress(UnicodeDecodeError, AttributeError):
                 # here may occur a LIEF exception that we want to skip ->
@@ -65,25 +72,20 @@ class PeSymbolProvider(AbstractLabelProvider):
 
     def parseSymbols(self, lief_binary, base_addr=None):
         active_base = self._resolve_base_addr(lief_binary, base_addr)
-        # find VA of first code section
         function_symbols = {}
-        code_base_address = None
-        for section in lief_binary.sections:
-            if section.characteristics & 0x20000000:
-                code_base_address = active_base + section.virtual_address
-                break
-        if code_base_address is None:
-            return function_symbols
         for symbol in lief_binary.symbols:
             if hasattr(symbol.complex_type, "name") and symbol.complex_type.name == "FUNCTION":
+                if symbol.section is None:
+                    # section_idx 0/-1/-2 (undefined-external/absolute/debug): not a locally
+                    # defined function, its value is not a usable in-image offset.
+                    continue
                 function_name = ""
                 with contextlib.suppress(UnicodeDecodeError, AttributeError):
                     # here may occur a LIEF exception that we want to skip ->
                     # UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
                     function_name = symbol.name
                 if function_name and all(ord(c) in range(0x20, 0x7F) for c in function_name):
-                    # for some reason, we need to add the section_offset of .text here
-                    function_offset = code_base_address + symbol.value
+                    function_offset = active_base + symbol.section.virtual_address + symbol.value
                     if function_offset not in function_symbols:
                         function_symbols[function_offset] = function_name
         return function_symbols

--- a/src/smda/common/labelprovider/RustSymbolProvider.py
+++ b/src/smda/common/labelprovider/RustSymbolProvider.py
@@ -143,7 +143,12 @@ class RustSymbolProvider(AbstractLabelProvider):
         """Process PE binary symbols for Rust demangling."""
         active_base = resolve_pe_base_addr(lief_binary, base_addr)
         # Parse PE exports
-        for function in lief_binary.exported_functions:
+        export = lief_binary.get_export()
+        for function in export.entries if export is not None else []:
+            if function.is_extern or function.is_forwarded:
+                # forwarder/extern entries redirect to another module's export and have no
+                # local address (LIEF sets .address to 0 for them) - not a local function.
+                continue
             try:
                 try:
                     raw_name = function.name
@@ -158,21 +163,16 @@ class RustSymbolProvider(AbstractLabelProvider):
             except _DEMANGLE_ERRORS as exc:
                 LOGGER.debug("Failed to demangle Rust symbol %s: %s", function.name, exc)
 
-        code_base_address = None
-        for section in lief_binary.sections:
-            if section.characteristics & 0x20000000:
-                code_base_address = active_base + section.virtual_address
-                break
-        if code_base_address is None:
-            return
         # working example: 3969e1a88a063155a6f61b0ca1ac33114c1a39151f3c7dd019084abd30553eab
         # Parse PE symbols (COFF) if available and LIEF extracted them
         # (Similar logic to PeSymbolProvider but focusing on Rust)
         for symbol in lief_binary.symbols:
             # Check if it is a function symbol and has a section
-            if (
-                hasattr(symbol.complex_type, "name") and symbol.complex_type.name == "FUNCTION"
-            ):  # and symbol.has_section:
+            if hasattr(symbol.complex_type, "name") and symbol.complex_type.name == "FUNCTION":
+                if symbol.section is None:
+                    # section_idx 0/-1/-2 (undefined-external/absolute/debug): not a locally
+                    # defined function, its value is not a usable in-image offset.
+                    continue
                 try:
                     try:
                         raw_name = symbol.name
@@ -182,7 +182,7 @@ class RustSymbolProvider(AbstractLabelProvider):
                         demangled = demangle(raw_name)
                         if demangled:
                             demangled = remove_bad_spaces(demangled)
-                            function_offset = code_base_address + symbol.value
+                            function_offset = active_base + symbol.section.virtual_address + symbol.value
                             if function_offset not in self._func_symbols:
                                 self._func_symbols[function_offset] = demangled
                 except _DEMANGLE_ERRORS as exc:

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -744,12 +744,26 @@ class FunctionCandidateManager:
                 if section_name == ".pdata":
                     rva_start = section_va_start - self.disassembly.binary_info.base_addr
                     rva_end = section_va_end - self.disassembly.binary_info.base_addr
-                    # .pdata entries are 12 bytes long (3 DWORDs)
+                    # .pdata entries are 12 bytes long (3 DWORDs): BeginAddress, EndAddress, UnwindInfoAddress
                     for offset in range(rva_start, rva_end - 11, 12):
-                        packed_dword = self.disassembly.binary_info.binary[offset : offset + 4]
-                        if len(packed_dword) < 4:
+                        packed_entry = self.disassembly.getRawBytes(offset, 12)
+                        if len(packed_entry) < 12:
                             break
-                        rva_function_candidate = struct.unpack("I", packed_dword)[0]
+                        rva_function_candidate, _rva_function_end, rva_unwind_info = struct.unpack("<III", packed_entry)
                         if rva_function_candidate == 0:
                             break
+                        if self._isChainedUnwindInfo(rva_unwind_info):
+                            # UNW_FLAG_CHAININFO: this entry is a secondary fragment (e.g. a
+                            # split-off cold/epilogue chunk) chained to another function's
+                            # primary RUNTIME_FUNCTION entry, not an independent function start.
+                            continue
                         self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)
+
+    def _isChainedUnwindInfo(self, rva_unwind_info):
+        # x64 UNWIND_INFO header byte 0 packs Version (bits 0-2) and Flags (bits 3-7);
+        # UNW_FLAG_CHAININFO (0x4) means this RUNTIME_FUNCTION entry chains to another
+        # function's primary entry instead of describing an independent function.
+        header_byte = self.disassembly.getRawBytes(rva_unwind_info, 1)
+        if not header_byte:
+            return False
+        return bool((header_byte[0] >> 3) & 0x4)

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -81,6 +81,34 @@ class PdataExtractionTestSuite(unittest.TestCase):
         self.assertNotIn(BASE_ADDR, candidates)
         self.assertEqual(len(candidates), 1)
 
+    def test_pdata_chained_unwind_info_excluded(self):
+        config = SmdaConfig()
+        fcm = FunctionCandidateManager(config)
+
+        # Entry format: Start RVA, End RVA, Unwind RVA
+        entries = [
+            (0x2000, 0x2040, 0x3000),  # primary entry, unwind info at 0x3000 (Flags=0)
+            (0x2050, 0x2090, 0x3010),  # chained entry, unwind info at 0x3010 (UNW_FLAG_CHAININFO set)
+        ]
+
+        pdata_bytes = b"".join(struct.pack("III", *entry) for entry in entries)
+
+        binary = bytearray(BINARY_SIZE)
+        binary[PDATA_OFFSET : PDATA_OFFSET + len(pdata_bytes)] = pdata_bytes
+        # UNWIND_INFO header byte 0 packs Version (bits 0-2) and Flags (bits 3-7); 0x20 sets
+        # UNW_FLAG_CHAININFO (0x4) with Version 0.
+        binary[0x3010] = 0x20
+
+        disasm = DisassemblyResult()
+        disasm.binary_info = MockBinaryInfo(64, BASE_ADDR, bytes(binary), pdata_size=len(pdata_bytes))
+
+        fcm.init(disasm)
+
+        candidates = fcm.candidates
+        self.assertIn(BASE_ADDR + 0x2000, candidates)
+        self.assertNotIn(BASE_ADDR + 0x2050, candidates)
+        self.assertEqual(len(candidates), 1)
+
     def test_pdata_misaligned_size(self):
         config = SmdaConfig()
         fcm = FunctionCandidateManager(config)

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -36,9 +36,11 @@ class _MockDelayImport:
 
 
 class _MockExport:
-    def __init__(self, name, address):
+    def __init__(self, name, address, *, is_extern=False, is_forwarded=False):
         self.name = name
         self.address = address
+        self.is_extern = is_extern
+        self.is_forwarded = is_forwarded
 
 
 class _MockSection:
@@ -48,10 +50,11 @@ class _MockSection:
 
 
 class _MockSymbol:
-    def __init__(self, name, value):
+    def __init__(self, name, value, *, section=None):
         self.name = name
         self.value = value
         self.complex_type = SimpleNamespace(name="FUNCTION")
+        self.section = section
 
 
 class _MockPeBinary:
@@ -75,6 +78,11 @@ class _MockPeBinary:
         self.delay_imports = delay_imports or []
         self.has_delay_imports = bool(self.delay_imports)
         self.has_imports = bool(self.imports)
+
+    def get_export(self):
+        if not self.exported_functions:
+            return None
+        return SimpleNamespace(entries=self.exported_functions)
 
 
 class TestPeSymbolProviderImports(unittest.TestCase):
@@ -182,7 +190,7 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
         pe_binary = _MockPeBinary(
             exported_functions=[_MockExport("exported_func", 0x1000)],
             sections=[_MockSection(0x20000000, 0x1000)],
-            symbols=[_MockSymbol("local_func", 0x200)],
+            symbols=[_MockSymbol("local_func", 0x200, section=_MockSection(0x20000000, 0x1000))],
             imagebase=0x140000000,
         )
         symbols = provider.collectSymbols(pe_binary, base_addr=0x400000)
@@ -194,7 +202,7 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
         pe_binary = _MockPeBinary(
             exported_functions=[_MockExport("exported_func", 0x1000)],
             sections=[_MockSection(0x20000000, 0x1000)],
-            symbols=[_MockSymbol("local_func", 0x200)],
+            symbols=[_MockSymbol("local_func", 0x200, section=_MockSection(0x20000000, 0x1000))],
             imagebase=0x140000000,
         )
         symbols = provider.collectSymbols(pe_binary, base_addr=0)
@@ -227,7 +235,7 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
             imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("CreateFileW", 0x3000)])],
             exported_functions=[_MockExport("exported_func", 0x1000)],
             sections=[_MockSection(0x20000000, 0x1000)],
-            symbols=[_MockSymbol("local_func", 0x200)],
+            symbols=[_MockSymbol("local_func", 0x200, section=_MockSection(0x20000000, 0x1000))],
             imagebase=0x140000000,
         )
         binary_info = BinaryInfo(b"")
@@ -254,7 +262,7 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
         pe_binary = _MockPeBinary(
             exported_functions=[_MockExport("exported_func", 0x1000)],
             sections=[_MockSection(0x20000000, 0x1000)],
-            symbols=[_MockSymbol("local_func", 0x200)],
+            symbols=[_MockSymbol("local_func", 0x200, section=_MockSection(0x20000000, 0x1000))],
             imagebase=0x140000000,
         )
         binary_info = BinaryInfo(b"")
@@ -266,6 +274,32 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
             symbols = binary_info.getSymbols()
         self.assertEqual(symbols[0x401000], "exported_func")
         self.assertEqual(symbols[0x401200], "local_func")
+
+    def test_parse_exports_skips_forwarded_and_extern_entries(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(
+            exported_functions=[
+                _MockExport("real_func", 0x1000),
+                _MockExport("forwarded_func", 0, is_forwarded=True),
+                _MockExport("extern_func", 0, is_extern=True),
+            ],
+            imagebase=0x140000000,
+        )
+        symbols = provider.parseExports(pe_binary, base_addr=0x400000)
+        self.assertEqual(symbols, {0x401000: "real_func"})
+
+    def test_parse_symbols_skips_entries_with_no_section(self):
+        provider = PeSymbolProvider(None)
+        pe_binary = _MockPeBinary(
+            sections=[_MockSection(0x20000000, 0x1000)],
+            symbols=[
+                _MockSymbol("local_func", 0x200, section=_MockSection(0x20000000, 0x1000)),
+                _MockSymbol("undefined_func", 0, section=None),
+            ],
+            imagebase=0x140000000,
+        )
+        symbols = provider.parseSymbols(pe_binary, base_addr=0x400000)
+        self.assertEqual(symbols, {0x401200: "local_func"})
 
 
 if __name__ == "__main__":

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -18,12 +18,13 @@ from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
 
 
 class MockSymbol:
-    def __init__(self, name, value, is_function=True, demangled_name=None):
+    def __init__(self, name, value, is_function=True, demangled_name=None, section=None):
         self.name = name
         self.value = value
         self.is_function = is_function
         self._demangled_name = demangled_name
         self.complex_type = type("obj", (object,), {"name": "FUNCTION"})
+        self.section = section
 
     @property
     def demangled_name(self):
@@ -44,6 +45,11 @@ class MockLiefBinary:
         self.symbols = symbols
         self.imports = []
 
+    def get_export(self):
+        if not self.exported_functions:
+            return None
+        return type("obj", (object,), {"entries": self.exported_functions})()
+
 
 class MockSection:
     def __init__(self, characteristics, virtual_address):
@@ -52,9 +58,11 @@ class MockSection:
 
 
 class MockExport:
-    def __init__(self, name, address):
+    def __init__(self, name, address, is_extern=False, is_forwarded=False):
         self.name = name
         self.address = address
+        self.is_extern = is_extern
+        self.is_forwarded = is_forwarded
 
 
 class TestRustDemangler(unittest.TestCase):
@@ -240,7 +248,7 @@ class TestRustSymbolProvider(unittest.TestCase):
     def test_pe_rust_symbols_use_base_addr_not_imagebase(self):
         provider = RustSymbolProvider(None)
         mock_binary = MockLiefBinary(
-            [MockSymbol("_ZN3foo3barE", 0x200)],
+            [MockSymbol("_ZN3foo3barE", 0x200, section=MockSection(0x20000000, 0x1000))],
             exported_functions=[MockExport("_RNvC6_123foo3bar", 0x1000)],
         )
         mock_binary.imagebase = 0x140000000
@@ -253,6 +261,29 @@ class TestRustSymbolProvider(unittest.TestCase):
         self.assertEqual(provider.getSymbol(0x401200), "foo::bar")
         self.assertNotIn(0x140001000, provider.getFunctionSymbols())
         self.assertNotIn(0x140001200, provider.getFunctionSymbols())
+
+    def test_pe_rust_symbols_skip_forwarded_exports_and_sectionless_symbols(self):
+        provider = RustSymbolProvider(None)
+        mock_binary = MockLiefBinary(
+            [
+                MockSymbol("_ZN3foo3barE", 0x200, section=MockSection(0x20000000, 0x1000)),
+                MockSymbol("_ZN3foo3bazE", 0, section=None),
+            ],
+            exported_functions=[
+                MockExport("_RNvC6_123foo3bar", 0x1000),
+                MockExport("_RNvC6_123foo3qux", 0, is_forwarded=True),
+            ],
+        )
+        mock_binary.imagebase = 0x140000000
+        mock_binary.sections = [MockSection(0x20000000, 0x1000)]
+
+        with mock.patch("lief.PE.Binary", MockLiefBinary):
+            provider._update_pe(mock_binary, base_addr=0x400000)
+
+        self.assertEqual(provider.getSymbol(0x401000), "123foo::bar")
+        self.assertEqual(provider.getSymbol(0x401200), "foo::bar")
+        self.assertNotIn(0x400000, provider.getFunctionSymbols())
+        self.assertEqual(len(provider.getFunctionSymbols()), 2)
 
     def test_detection_logic(self):
         """Test Rust binary detection based on signatures."""


### PR DESCRIPTION
## Summary

Fixes three sibling instances of the same bug class: a binary-format metadata table row (PE `.pdata`
exception table, PE export table, PE/COFF symbol table) was trusted as an independent local function
start without checking its own "not defined here" flag. Two are bugs (false-positive function starts /
wrong addresses), one is an accuracy improvement (recovers real precision loss from an existing
recall-oriented feature). The accuracy improvement below (PPV/TPR/F1 table) was measured on one
specific evaluation dataset — the **Bao/byteweight `msvc10-64` corpus** (68 PE x64 binaries) — not
across the full accuracy-eval suite; see the caveats in Bug 1 for what was and wasn't affected
elsewhere.

## Bug 1 (improvement): `.pdata` chained unwind-info fragments counted as new functions

**What:** `FunctionCandidateManager.locateExceptionHandlerCandidates()` reads the PE x64 `.pdata`
section (`RUNTIME_FUNCTION` table) and injects every entry's `BeginAddress` as a near-guaranteed
function-start candidate. Some `RUNTIME_FUNCTION` entries are secondary fragments of another
function (e.g. a split-off cold/epilogue chunk) — their `UNWIND_INFO` is marked with
`UNW_FLAG_CHAININFO` specifically so tooling does not mistake them for an independent function. This
was not being checked, so every chained fragment was counted as a brand-new (false-positive)
function.

**How fixed:** read the `UNWIND_INFO` header byte at each entry's `UnwindInfoAddress` and skip the
entry when the `CHAININFO` flag (bit `0x4` of the Flags nibble) is set.

**Measured impact — Bao/byteweight `msvc10-64` dataset only** (68 PE x64 binaries, function-level
macro PPV/TPR/F1; this specific corpus was chosen because it showed the largest PPV regression
against an older SMDA baseline, which is what led to this fix):

| | PPV | TPR | F1 |
|---|---|---|---|
| before | 95.38 | 99.72 | 97.46 |
| after | 98.70 | 99.73 | 99.21 |

TPR is effectively unchanged (99.72 → 99.73) — the fix removes false positives without giving back
any of the feature's genuine recall win. Confirmed no effect on 32-bit configs (feature is 64-bit
only) or raw-memory-dump corpora (no section table present, so `.pdata` is never found).

## Bug 2: PE export forwarders/extern entries treated as local functions

**What:** `PeSymbolProvider.parseExports` and `RustSymbolProvider._update_pe` iterated
`lief_binary.exported_functions` (LIEF's abstract, format-agnostic export view) and trusted every
entry's address. A forwarded or extern export (e.g. an API set forwarder, or a DLL re-exporting
another DLL's function) has no local address — LIEF's PE-specific `ExportEntry` marks these via
`is_extern`/`is_forwarded` and sets `.address` to `0`, but the abstract wrapper does not expose those
flags at all, so every forwarder collapsed onto `base_addr + 0` and was recorded as a function there.

**How fixed:** switched to the PE-specific `lief_binary.get_export().entries`, which exposes
`is_extern`/`is_forwarded`, and skip entries with either flag set.

## Bug 3: COFF symbols with no defining section treated as local functions, wrong section base for the rest

**What:** `PeSymbolProvider.parseSymbols` and `RustSymbolProvider._update_pe` cached the virtual
address of the *first* executable section and added every `FUNCTION`-typed COFF symbol's `.value` to
that single base — regardless of which section the symbol actually belongs to, and without checking
whether the symbol is even defined in this file. A COFF symbol with `section_idx` `0`/`-1`/`-2`
(undefined-external/absolute/debug) is not a locally defined function, and its `.value` is not a
usable in-image offset; symbols legitimately defined in any section other than the first code section
resolved to the wrong address entirely.

**How fixed:** use each symbol's own `.section` (skip when `None`, i.e. not locally defined) and
resolve its address from that section's virtual address instead of a single cached first-code-section
value.

## Systemic pattern

All three are the same root-cause pattern: an unconditionally-trusted binary metadata table entry
that has its own format-native "not an independent local function" signal, unchecked. A tree-wide
sweep covering every symbol/export/exception-table consumer (aarch64, ELF, Mach-O, PDB, Go,
Delphi-KB, CIL/Dalvik label providers) found these are the only real instances; the rest were
confirmed benign for structural reasons specific to those formats (e.g. ELF has no forwarder concept
and already filters by symbol type; Mach-O addresses are gated by a code-area check).

## Validation

```
make lint
make test   # 378 passed, 1 skipped
pytest tests/testPdataExtraction.py -q
pytest tests/testPeSymbolProvider.py tests/testRustSymbolProvider.py -q
pytest tests/testFileFormatParsers.py tests/testPeFileLoader.py -q
```

All targeted and full-suite tests pass. Regression tests added for each of the three fixes.
