### PR TITLE
refactor(core): consolidate import-stub helpers and wire has_backend

### DIFF
--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -250,6 +250,8 @@ class Disassembler:
         if self.disassembler:
             self.disassembly = self.disassembler.analyzeBuffer(binary_info, self._callbackAnalysisTimeout)
             return SmdaReport(self.disassembly, config=self.config)
+        if not binary_info.has_backend:
+            raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
     def _createErrorReport(self, start, exception):

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -7,8 +7,6 @@ from capstone import CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN, Cs
 from capstone.arm64 import ARM64_OP_IMM, ARM64_OP_MEM
 
 from smda.common.arch.ArchBackend import ArchBackend
-from smda.utility.ElfFileLoader import ElfFileLoader
-from smda.utility.MachoBinary import get_macho_stub_ranges
 
 from .analyzers import AArch64IndirectCallAnalyzer, AArch64JumpTableAnalyzer, AArch64TfIdf
 from .definitions import (
@@ -241,30 +239,6 @@ class AArch64Backend(ArchBackend):
             if d.disassembly.isAddrWithinMemoryImage(value) and not binary_info.isInCodeAreas(value):
                 emitted.add(value)
                 state.addDataRef(i_address, value)
-
-    @staticmethod
-    def _getPltRanges(binary_info):
-        if not hasattr(binary_info, "_plt_ranges"):
-            binary_info._plt_ranges = ElfFileLoader.getPltRanges(
-                binary_info.raw_data or binary_info.binary,
-                parsed=binary_info.getLiefBinary(),
-            )
-        return binary_info._plt_ranges
-
-    @staticmethod
-    def _getMachoStubRanges(binary_info):
-        if not hasattr(binary_info, "_macho_stub_ranges"):
-            binary_info._macho_stub_ranges = get_macho_stub_ranges(
-                binary_info.getLiefBinary(),
-                base_addr=binary_info.base_addr,
-                bitness=binary_info.bitness,
-                architecture=getattr(binary_info, "architecture", ""),
-            )
-        return binary_info._macho_stub_ranges
-
-    @classmethod
-    def _getImportStubRanges(cls, binary_info):
-        return cls._getPltRanges(binary_info) + cls._getMachoStubRanges(binary_info)
 
     @classmethod
     def _resolvePltGotSlot(cls, d, target):

--- a/src/smda/common/arch/ArchBackend.py
+++ b/src/smda/common/arch/ArchBackend.py
@@ -13,6 +13,9 @@ engine treats all of these abstractly, so new architectures (ARM, MIPS, ...)
 can be added by implementing this interface without touching the engine.
 """
 
+from smda.utility.ElfFileLoader import ElfFileLoader
+from smda.utility.MachoBinary import get_macho_stub_ranges
+
 
 class ArchBackend:
     #: short architecture identifier, written to ``binary_info.architecture``
@@ -67,3 +70,31 @@ class ArchBackend:
         block-ending flag set on ``state``.
         """
         raise NotImplementedError
+
+    # --- shared import-stub range resolution (concrete, not abstract) -----
+    # Every native backend that resolves a direct call/jmp/branch target
+    # against ELF PLT or Mach-O stub ranges needs the same range lookup;
+    # this lives here once instead of being duplicated per backend.
+    @staticmethod
+    def _getPltRanges(binary_info):
+        if not hasattr(binary_info, "_plt_ranges"):
+            binary_info._plt_ranges = ElfFileLoader.getPltRanges(
+                binary_info.raw_data or binary_info.binary,
+                parsed=binary_info.getLiefBinary(),
+            )
+        return binary_info._plt_ranges
+
+    @staticmethod
+    def _getMachoStubRanges(binary_info):
+        if not hasattr(binary_info, "_macho_stub_ranges"):
+            binary_info._macho_stub_ranges = get_macho_stub_ranges(
+                binary_info.getLiefBinary(),
+                base_addr=binary_info.base_addr,
+                bitness=binary_info.bitness,
+                architecture=getattr(binary_info, "architecture", ""),
+            )
+        return binary_info._macho_stub_ranges
+
+    @classmethod
+    def _getImportStubRanges(cls, binary_info):
+        return cls._getPltRanges(binary_info) + cls._getMachoStubRanges(binary_info)

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -6,7 +6,6 @@ from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, Cs
 
 from smda.common.arch.ArchBackend import ArchBackend
 from smda.utility.ElfFileLoader import ElfFileLoader
-from smda.utility.MachoBinary import get_macho_stub_ranges
 
 from .BitnessAnalyzer import BitnessAnalyzer
 from .definitions import (
@@ -107,26 +106,6 @@ class X86Backend(ArchBackend):
         return BitnessAnalyzer().determineBitnessFromDisassembly(disassembly)
 
     @staticmethod
-    def _getPltRanges(binary_info):
-        if not hasattr(binary_info, "_plt_ranges"):
-            binary_info._plt_ranges = ElfFileLoader.getPltRanges(
-                binary_info.raw_data or binary_info.binary,
-                parsed=binary_info.getLiefBinary(),
-            )
-        return binary_info._plt_ranges
-
-    @staticmethod
-    def _getMachoStubRanges(binary_info):
-        if not hasattr(binary_info, "_macho_stub_ranges"):
-            binary_info._macho_stub_ranges = get_macho_stub_ranges(
-                binary_info.getLiefBinary(),
-                base_addr=binary_info.base_addr,
-                bitness=binary_info.bitness,
-                architecture=getattr(binary_info, "architecture", ""),
-            )
-        return binary_info._macho_stub_ranges
-
-    @staticmethod
     def _getElfGotBases(binary_info):
         if not hasattr(binary_info, "_elf_got_bases"):
             binary_info._elf_got_bases = ElfFileLoader.getGotBases(
@@ -134,10 +113,6 @@ class X86Backend(ArchBackend):
                 parsed=binary_info.getLiefBinary(),
             )
         return binary_info._elf_got_bases
-
-    @classmethod
-    def _getImportStubRanges(cls, binary_info):
-        return cls._getPltRanges(binary_info) + cls._getMachoStubRanges(binary_info)
 
     @classmethod
     def _resolveImportSlot(cls, d, target):

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -366,6 +366,7 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
                 # the controlled error report must also serialize cleanly
                 self.assertIsNotNone(report.timestamp)
                 self.assertEqual(report.toDict()["status"], "error")
+                self.assertIn(f"No disassembly backend available for architecture '{architecture}'", report.message)
 
     def test_elf_real_intel_binaries_disassemble(self):
         for fixture_name, (architecture, bitness, has_backend) in self.MIRAI_ELF_FIXTURES.items():

--- a/tests/testMachoFileLoader.py
+++ b/tests/testMachoFileLoader.py
@@ -120,6 +120,7 @@ class TestMachoFileLoader(unittest.TestCase):
                 self.assertEqual(report.num_functions, 0)
                 self.assertEqual(list(report.getFunctions()), [])
                 self.assertEqual(report.toDict()["status"], "error")
+                self.assertIn(f"No disassembly backend available for architecture '{architecture}'", report.message)
 
     def test_fat_universal_system_binary_loads_when_present(self):
         true_path = Path("/usr/bin/true")


### PR DESCRIPTION
## Summary

Follow-up cleanup for #169, addressing items that were flagged during that PR's review and intentionally deferred to keep #169 focused on Mach-O/import-stub parity.

**Note:** this branch stacks on #169 (`fix/macho-intel-stub-parity`). GitHub does not allow a fork-only branch as the base of a cross-repo pull request, so this PR's diff will include #169's commits until #169 merges. The two commits unique to this PR are:

- `refactor(core): hoist shared import-stub range helpers into ArchBackend`
- `fix(core): report the unsupported architecture in no-backend error reports`

## Changes

- **Hoist duplicated helpers.** `_getPltRanges`/`_getMachoStubRanges`/`_getImportStubRanges` were byte-for-byte identical between `X86Backend` and `AArch64Backend`. Moved onto the shared `ArchBackend` base class so both backends inherit one implementation; each backend keeps only its architecture-specific slot-decode logic (`_resolveImportSlot` / `_resolvePltGotSlot`).
- **Consume `has_backend`.** It was exposed by every format loader (#169) but never read anywhere, so a buffer with no disassembly backend fell through to a generic `"Disassembler backend not initialized."` error, indistinguishable from a real internal precondition failure. `Disassembler._disassemble` now checks `has_backend` and raises a message naming the specific unsupported architecture, which flows into the controlled error report.

A third item flagged during #169's review — `RustSymbolProvider`'s Mach-O support living in a "loaders/stub-parity" branch — was reviewed and found to already be adequately isolated (its own commit, with the `_R`/`__R` vs. legacy `_ZN` detection tradeoff documented inline in code). No further change was needed there.

## Tests and validation

- `make lint`
- `python -m ruff format --check .`
- `make test` — 402 passed, 1 skipped
- Extended the existing ELF and Mach-O no-backend controlled-error tests to assert the new architecture-specific message.
