### PR TITLE
feat(aarch64): FEAT_HBC/drps coverage, API-thunk detection, stack-string recovery

### DIFF
--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -87,21 +87,36 @@ class Disassembler:
         finally:
             smda_report.buffer = previous_buffer
 
+    #: backends that record non-buffer-backed strings via disassembly.addStringRef
+    #: (the string only exists as a runtime/decode-time side effect, e.g. CIL's
+    #: ldstr token or an AArch64 stack-built string — there are no corresponding
+    #: bytes anywhere in the file for the generic StringExtractor to find).
+    _ANALYZER_STRINGREF_TYPES = {"dalvik": "dex", "cil": "cil", "aarch64": "stack"}
+
     def _extractStrings(self, smda_report, mode=None):
+        architecture = smda_report.architecture
+        analyzer_type = self._ANALYZER_STRINGREF_TYPES.get(architecture, "analyzer")
         for smda_function in smda_report.getFunctions():
-            if smda_report.architecture == "dalvik":
-                if smda_function.stringrefs and isinstance(smda_function.stringrefs, dict):
-                    smda_function.stringrefs = [
-                        {
-                            "string": string_value,
-                            "ins_addr": referencing_addr,
-                            "data_addr": None,
-                            "type": "dex",
-                        }
-                        for referencing_addr, string_value in sorted(smda_function.stringrefs.items())
-                    ]
+            # SmdaFunction.__init__ sets stringrefs to the raw addStringRef dict
+            # (ref_addr -> string) for every architecture when WITH_STRINGS is set;
+            # normalize it into the same shape the generic extractor below produces.
+            analyzer_provided = []
+            if isinstance(smda_function.stringrefs, dict):
+                analyzer_provided = [
+                    {
+                        "string": string_value,
+                        "ins_addr": referencing_addr,
+                        "data_addr": None,
+                        "type": analyzer_type,
+                    }
+                    for referencing_addr, string_value in sorted(smda_function.stringrefs.items())
+                ]
+            if architecture == "dalvik":
+                # DEX strings are part of the parsed file structure, not the raw
+                # buffer bytes: the generic StringExtractor cannot see them either.
+                smda_function.stringrefs = analyzer_provided
                 continue
-            function_strings = []
+            function_strings = analyzer_provided
             for string_result in extract_strings(smda_function, mode=mode):
                 string, referencing_addr, string_addr, string_type = string_result
                 function_strings.append(

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -21,6 +21,7 @@ from .definitions import (
     BR_VALUE,
     CALL_INS,
     COND_BRANCH_INS,
+    COND_BRANCH_PREFIXES,
     END_INS,
     EXCEPTION_RETURN_INS,
     INDIRECT_JUMP_INS,
@@ -219,7 +220,11 @@ class AArch64Backend(ArchBackend):
             return
         if i_mnemonic in END_INS or i_mnemonic in ALWAYS_BRANCH_INS or i_mnemonic in UNCOND_JUMP_INS:
             return
-        if i_mnemonic.startswith("b.") or i_mnemonic in COND_BRANCH_INS or i_mnemonic in INDIRECT_JUMP_INS:
+        if (
+            i_mnemonic.startswith(COND_BRANCH_PREFIXES)
+            or i_mnemonic in COND_BRANCH_INS
+            or i_mnemonic in INDIRECT_JUMP_INS
+        ):
             return
 
         ins_bytes = d.disassembly.getBytes(i_address, i_size)
@@ -349,10 +354,11 @@ class AArch64Backend(ArchBackend):
             self._endFunction(state)
             LOGGER.debug("  analyzeFunction() found trap terminator @0x%08x", i_address)
         elif i_mnemonic in ALWAYS_BRANCH_INS:
-            # b.al / b.nv are spelled b.<cond> but always branch (no fall-through),
-            # so they are unconditional. Must precede the generic "b." test below.
+            # b.al/b.nv and FEAT_HBC's bc.al/bc.nv are spelled b.<cond>/bc.<cond> but
+            # always branch (no fall-through), so they are unconditional. Must precede
+            # the generic "b."/"bc." test below.
             self._analyzeUncondBranch(d, instruction, state)
-        elif i_mnemonic.startswith("b.") or i_mnemonic in COND_BRANCH_INS:
+        elif i_mnemonic.startswith(COND_BRANCH_PREFIXES) or i_mnemonic in COND_BRANCH_INS:
             self._analyzeCondBranch(d, instruction, state)
         elif i_mnemonic in UNCOND_JUMP_INS:
             self._analyzeUncondBranch(d, instruction, state)

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -272,12 +272,16 @@ class AArch64Backend(ArchBackend):
         return cls._getPltRanges(binary_info) + cls._getMachoStubRanges(binary_info)
 
     @classmethod
-    def _resolvePltGotSlot(cls, d, target):
-        binary_info = d.disassembly.binary_info
-        if not any(start <= target < end for start, end in cls._getImportStubRanges(binary_info)):
-            return None
+    def _walkGotThunk(cls, d, addr):
+        """Walk an optional nop/bti prefix, then adrp; [add;] ldr; br from addr.
 
-        cursor = target
+        Returns (end_addr, target_register_value) if the raw words starting at
+        addr decode to EXACTLY that shape (nothing interleaved) before hitting an
+        unrecognized word, else None. end_addr is the address right after the
+        terminating br — callers compare it against a specific instruction's end
+        to confirm nothing else follows (used by both PLT/GOT slot resolution and
+        API-thunk-body detection, which share this decode)."""
+        cursor = addr
         for _ in range(2):
             prefix = cls._wordAt(d, cursor)
             if prefix is None:
@@ -289,14 +293,14 @@ class AArch64Backend(ArchBackend):
 
         registers = {}
         for index in range(4):
-            addr = cursor + index * INSTRUCTION_SIZE
-            word = cls._wordAt(d, addr)
+            word_addr = cursor + index * INSTRUCTION_SIZE
+            word = cls._wordAt(d, word_addr)
             if word is None:
                 return None
 
             rd = word & 0x1F
             if (word & ADRP_MASK) == ADRP_VALUE:
-                registers[rd] = adrp_page_value(word, addr)
+                registers[rd] = adrp_page_value(word, word_addr)
             elif (word & ADD_IMM64_MASK) == ADD_IMM64_VALUE:
                 rn = (word >> 5) & 0x1F
                 if rn not in registers:
@@ -309,16 +313,24 @@ class AArch64Backend(ArchBackend):
                 registers[rd] = registers[rn] + (((word >> 10) & 0xFFF) * 8)
             elif (word & BR_MASK) == BR_VALUE:
                 rn = (word >> 5) & 0x1F
-                return registers.get(rn)
+                return word_addr + INSTRUCTION_SIZE, registers.get(rn)
             else:
                 return None
         return None
+
+    @classmethod
+    def _resolvePltGotSlot(cls, d, target):
+        binary_info = d.disassembly.binary_info
+        if not any(start <= target < end for start, end in cls._getImportStubRanges(binary_info)):
+            return None
+        walk = cls._walkGotThunk(d, target)
+        return walk[1] if walk is not None else None
 
     # --- engine entry point ----------------------------------------------
     def analyzeInstruction(self, disassembler, instruction, state, previous_instruction, start_addr):
         del start_addr
         d = disassembler
-        i_address, _i_size, i_mnemonic, i_op_str = instruction
+        i_address, i_size, i_mnemonic, i_op_str = instruction
         # capstone arm64 mnemonics carry no prefixes, so the mnemonic is used as-is.
 
         self._recordDataRefs(d, instruction, state)
@@ -363,6 +375,13 @@ class AArch64Backend(ArchBackend):
         elif i_mnemonic in UNCOND_JUMP_INS:
             self._analyzeUncondBranch(d, instruction, state)
         elif i_mnemonic in INDIRECT_JUMP_INS:
+            if i_mnemonic == "br":
+                # a function whose ENTIRE body is the canonical GOT/API-import thunk
+                # (optional nop/bti landing pad, then adrp; [add;] ldr; br) is a thunk,
+                # not a real routine — same decode _resolvePltGotSlot uses for callers.
+                thunk_walk = self._walkGotThunk(d, state.start_addr)
+                if thunk_walk is not None and thunk_walk[0] == i_address + i_size:
+                    state.setThunkCall(True)
             # br and the PAC indirect jumps (braa/brab/braaz/brabz): indirect branch
             jumptable_targets = d.jumptable_analyzer.getJumpTargets(instruction, state)
             for target in jumptable_targets:

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -27,6 +27,7 @@ from smda.aarch64.definitions import (
     ALWAYS_BRANCH_INS,
     CALL_INS,
     COND_BRANCH_INS,
+    COND_BRANCH_PREFIXES,
     END_INS,
     EXCEPTION_RETURN_INS,
     INDIRECT_JUMP_INS,
@@ -158,7 +159,7 @@ def operands_use_vector_layout(operands: str) -> bool:
 def is_control_flow_mnemonic(mnemonic: str) -> bool:
     if mnemonic in _TRAP_MNEMONICS:
         return False
-    if mnemonic.startswith("b."):
+    if mnemonic.startswith(COND_BRANCH_PREFIXES):
         return True
     return mnemonic in _CONTROL_FLOW_MNEMONICS
 

--- a/src/smda/aarch64/AArch64InstructionEscaper.py
+++ b/src/smda/aarch64/AArch64InstructionEscaper.py
@@ -624,10 +624,13 @@ class AArch64InstructionEscaper:
         "mov": 0xC1,
     }
 
-    # Mnemonic prefix -> keep-mask for conditional variants. Currently just
-    # b.cond; other conditional mnemonics use their base entry.
+    # Mnemonic prefix -> keep-mask for conditional variants: b.cond and FEAT_HBC's
+    # hinted bc.cond share the same imm19 branch-offset layout (differing only in
+    # bit 4), so both get the same keep-mask. Other conditional mnemonics use their
+    # base entry.
     _AARCH64_CONDITIONAL_KEEP_MASKS = {
         "b.": 0xC1,
+        "bc.": 0xC1,
     }
 
     @staticmethod

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -322,6 +322,7 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             0xD69F03E0,  # eret
             0xD69F0BFF,  # eretaa
             0xD69F0FFF,  # eretab
+            0xD6BF03E0,  # drps (Debug Restore PState: transfers control to ELR_ELx, same class)
         }
         return not (
             (prev_word & RET_MASK) == RET_VALUE

--- a/src/smda/aarch64/analyzers.py
+++ b/src/smda/aarch64/analyzers.py
@@ -7,7 +7,18 @@ resolution, and jump table analysis for AArch64.
 import logging
 import struct
 
+from capstone.arm64 import ARM64_SFT_LSL
+
 from .definitions import adrp_page_value
+
+
+def _movImmediateValue(op):
+    """The value an IMM operand of mov/movz/movk contributes, with its lsl
+    shift applied — capstone leaves op.imm as the raw unshifted 16-bit field
+    (e.g. `movk w8, #0x6c6c, lsl #16` reports imm=0x6c6c, not 0x6c6c0000)."""
+    shift = op.shift.value if op.shift.type == ARM64_SFT_LSL else 0
+    return op.imm << shift, shift
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +31,183 @@ def norm_reg(name):
     if name.startswith(("w", "x")):
         return "x" + name[1:]
     return name
+
+
+def _updateConstantTracking(d, cap_ins, constants):
+    """Extend `constants` (normalized register name -> tracked immediate value)
+    from a single decoded instruction, in place. Shared by indirect-call target
+    resolution (_resolveRegister) and stack-string recovery (recoverStackStrings) —
+    both need the identical adrp/adr/add/mov/movz/movk/ldr/ldur dataflow."""
+    if not cap_ins.operands:
+        return
+    mnemonic = cap_ins.mnemonic.lower()
+    dest_op = cap_ins.operands[0]
+    if dest_op.type != 1:  # REG
+        return
+    dest_reg = norm_reg(cap_ins.reg_name(dest_op.reg))
+
+    if mnemonic == "adrp" and len(cap_ins.operands) >= 2:
+        word = int.from_bytes(cap_ins.bytes, "little")
+        constants[dest_reg] = adrp_page_value(word, cap_ins.address)
+    elif mnemonic == "adr" and len(cap_ins.operands) >= 2:
+        if cap_ins.operands[1].type == 2:  # IMM
+            constants[dest_reg] = cap_ins.operands[1].imm
+    elif mnemonic == "add" and len(cap_ins.operands) >= 3:
+        op1 = cap_ins.operands[1]
+        op2 = cap_ins.operands[2]
+        if op1.type == 1 and op2.type == 2:  # REG + IMM
+            src_reg = norm_reg(cap_ins.reg_name(op1.reg))
+            if src_reg in constants:
+                constants[dest_reg] = constants[src_reg] + op2.imm
+            else:
+                constants.pop(dest_reg, None)
+        elif op1.type == 1 and op2.type == 1:  # REG + REG
+            reg1 = norm_reg(cap_ins.reg_name(op1.reg))
+            reg2 = norm_reg(cap_ins.reg_name(op2.reg))
+            if reg1 in constants and reg2 in constants:
+                constants[dest_reg] = constants[reg1] + constants[reg2]
+            else:
+                constants.pop(dest_reg, None)
+    elif mnemonic in ("mov", "movz", "movk") and len(cap_ins.operands) >= 2:
+        op1 = cap_ins.operands[1]
+        if op1.type == 2:  # IMM
+            imm_value, shift = _movImmediateValue(op1)
+            if mnemonic == "movk" and dest_reg in constants:
+                # movk only replaces a 16-bit slice, leaving the rest of the
+                # register's previously-tracked bits intact (unlike movz, which
+                # zero-fills everything else).
+                constants[dest_reg] = (constants[dest_reg] & ~(0xFFFF << shift)) | imm_value
+            elif mnemonic == "movk":
+                constants.pop(dest_reg, None)
+            else:
+                constants[dest_reg] = imm_value
+        elif op1.type == 1:  # REG
+            src_reg = norm_reg(cap_ins.reg_name(op1.reg))
+            if src_reg in constants:
+                constants[dest_reg] = constants[src_reg]
+            else:
+                constants.pop(dest_reg, None)
+    elif mnemonic in ("ldr", "ldur") and len(cap_ins.operands) >= 2:
+        op1 = cap_ins.operands[1]
+        resolved = False
+        if op1.type == 3:  # MEM
+            base_reg = norm_reg(cap_ins.reg_name(op1.mem.base))
+            if base_reg in constants and op1.mem.index == 0:
+                slot_addr = constants[base_reg] + op1.mem.disp
+                if d.disassembly.isAddrWithinMemoryImage(slot_addr):
+                    raw_val = d.disassembly.getBytes(slot_addr, 8)
+                    if raw_val and len(raw_val) == 8:
+                        val = struct.unpack("<Q", raw_val)[0]
+                        constants[dest_reg] = val
+                        resolved = True
+        if not resolved:
+            constants.pop(dest_reg, None)
+
+
+def _registerValue(reg_name, constants):
+    """Look up a register's tracked constant, treating wzr/xzr as literal 0."""
+    normalized = norm_reg(reg_name)
+    if normalized == "xzr":
+        return 0
+    return constants.get(normalized)
+
+
+def _isSpWriteback(op_str):
+    """Whether op_str shows an sp-based pre/post-index writeback (mutates sp).
+
+    Capstone's python binding exposes no `.writeback` flag on this build, so this
+    matches its op_str syntax directly: pre-index ends the operand string with a
+    trailing `!` (e.g. "x29, x30, [sp, #-16]!"); post-index appends an immediate
+    after the closing bracket (e.g. "x29, x30, [sp], #16").
+    """
+    if "[sp" not in op_str:
+        return False
+    return op_str.rstrip().endswith("!") or "], #" in op_str or "],#" in op_str
+
+
+def _mutatesStackPointer(cap_ins):
+    """Whether this instruction changes sp's value: explicit dest-is-sp arithmetic
+    (sub/add/mov) or an sp-based pre/post-index writeback. Any earlier tracked
+    stack-relative offsets become meaningless once sp moves."""
+    if cap_ins.operands and cap_ins.operands[0].type == 1 and cap_ins.reg_name(cap_ins.operands[0].reg) == "sp":
+        return True
+    return _isSpWriteback(cap_ins.op_str)
+
+
+_SINGLE_STORE_WIDTH = {"strb": 1, "sturb": 1, "strh": 2, "sturh": 2}
+_SINGLE_STORE_MNEMONICS = frozenset({"str", "stur", "strb", "sturb", "strh", "sturh"})
+#: minimum/maximum length of a reconstructed stack string (avoid single-byte
+#: noise and pathological runs from misclassified constants)
+_MIN_STACK_STRING_LEN = 4
+_MAX_STACK_STRING_LEN = 128
+
+
+def _recordStackStore(cap_ins, mnemonic, constants, stack_bytes):
+    """Record the byte(s) an sp-relative store writes into `stack_bytes`
+    (offset -> (byte_value, instruction_addr)), if the stored value is a
+    currently-tracked constant. Handles single-register str/strb/strh/stur*
+    and the two-register stp (frame-adjacent stack-string writes)."""
+    operands = cap_ins.operands
+    if mnemonic in _SINGLE_STORE_MNEMONICS and len(operands) == 2:
+        src_op, mem_op = operands
+        if src_op.type != 1 or mem_op.type != 3:  # REG, MEM
+            return
+        if not mem_op.mem.base or cap_ins.reg_name(mem_op.mem.base) != "sp" or mem_op.mem.index != 0:
+            return
+        src_name = cap_ins.reg_name(src_op.reg)
+        value = _registerValue(src_name, constants)
+        if value is None:
+            return
+        width = _SINGLE_STORE_WIDTH.get(mnemonic, 4 if src_name.lower().startswith("w") else 8)
+        offset = mem_op.mem.disp
+        for b in range(width):
+            stack_bytes[offset + b] = ((value >> (8 * b)) & 0xFF, cap_ins.address)
+    elif mnemonic == "stp" and len(operands) == 3:
+        reg1_op, reg2_op, mem_op = operands
+        if reg1_op.type != 1 or reg2_op.type != 1 or mem_op.type != 3:
+            return
+        if not mem_op.mem.base or cap_ins.reg_name(mem_op.mem.base) != "sp" or mem_op.mem.index != 0:
+            return
+        reg1_name = cap_ins.reg_name(reg1_op.reg)
+        reg2_name = cap_ins.reg_name(reg2_op.reg)
+        width = 4 if reg1_name.lower().startswith("w") else 8
+        offset = mem_op.mem.disp
+        for reg_name, base_offset in ((reg1_name, offset), (reg2_name, offset + width)):
+            value = _registerValue(reg_name, constants)
+            if value is None:
+                continue
+            for b in range(width):
+                stack_bytes[base_offset + b] = ((value >> (8 * b)) & 0xFF, cap_ins.address)
+
+
+def _emitStackStrings(d, analysis_state, stack_bytes):
+    """Reconstruct contiguous printable-ASCII runs from `stack_bytes` and record
+    each as a stringref anchored at the store that wrote the run's first byte."""
+    if not stack_bytes:
+        return
+
+    def flush(run):
+        if len(run) < _MIN_STACK_STRING_LEN:
+            return
+        run = run[:_MAX_STACK_STRING_LEN]
+        first_addr = run[0][1]
+        string = "".join(chr(byte_val) for byte_val, _addr in run)
+        d.disassembly.addStringRef(analysis_state.start_addr, first_addr, string)
+
+    run = []
+    prev_offset = None
+    for offset in sorted(stack_bytes):
+        byte_val, addr = stack_bytes[offset]
+        is_printable = 0x20 <= byte_val <= 0x7E
+        if not is_printable or (prev_offset is not None and offset != prev_offset + 1):
+            flush(run)
+            run = []
+        if is_printable:
+            run.append((byte_val, addr))
+            prev_offset = offset
+        else:
+            prev_offset = None
+    flush(run)
 
 
 class AArch64TfIdf:
@@ -66,66 +254,54 @@ class AArch64IndirectCallAnalyzer:
             if not bytes_ins:
                 continue
             cap_ins = next(d.capstone.disasm(bytes_ins, ins[0]), None)
-            if not cap_ins or not cap_ins.operands:
+            if not cap_ins:
                 continue
-            mnemonic = cap_ins.mnemonic.lower()
-            dest_op = cap_ins.operands[0]
-            if dest_op.type != 1:  # REG
-                continue
-            dest_reg = norm_reg(cap_ins.reg_name(dest_op.reg))
-
-            if mnemonic == "adrp" and len(cap_ins.operands) >= 2:
-                word = int.from_bytes(cap_ins.bytes, "little")
-                constants[dest_reg] = adrp_page_value(word, cap_ins.address)
-            elif mnemonic == "adr" and len(cap_ins.operands) >= 2:
-                if cap_ins.operands[1].type == 2:  # IMM
-                    constants[dest_reg] = cap_ins.operands[1].imm
-            elif mnemonic == "add" and len(cap_ins.operands) >= 3:
-                op1 = cap_ins.operands[1]
-                op2 = cap_ins.operands[2]
-                if op1.type == 1 and op2.type == 2:  # REG + IMM
-                    src_reg = norm_reg(cap_ins.reg_name(op1.reg))
-                    if src_reg in constants:
-                        constants[dest_reg] = constants[src_reg] + op2.imm
-                    else:
-                        constants.pop(dest_reg, None)
-                elif op1.type == 1 and op2.type == 1:  # REG + REG
-                    reg1 = norm_reg(cap_ins.reg_name(op1.reg))
-                    reg2 = norm_reg(cap_ins.reg_name(op2.reg))
-                    if reg1 in constants and reg2 in constants:
-                        constants[dest_reg] = constants[reg1] + constants[reg2]
-                    else:
-                        constants.pop(dest_reg, None)
-            elif mnemonic in ("mov", "movz", "movk") and len(cap_ins.operands) >= 2:
-                op1 = cap_ins.operands[1]
-                if op1.type == 2:  # IMM
-                    constants[dest_reg] = op1.imm
-                elif op1.type == 1:  # REG
-                    src_reg = norm_reg(cap_ins.reg_name(op1.reg))
-                    if src_reg in constants:
-                        constants[dest_reg] = constants[src_reg]
-                    else:
-                        constants.pop(dest_reg, None)
-            elif mnemonic in ("ldr", "ldur") and len(cap_ins.operands) >= 2:
-                op1 = cap_ins.operands[1]
-                resolved = False
-                if op1.type == 3:  # MEM
-                    base_reg = norm_reg(cap_ins.reg_name(op1.mem.base))
-                    if base_reg in constants and op1.mem.index == 0:
-                        slot_addr = constants[base_reg] + op1.mem.disp
-                        if d.disassembly.isAddrWithinMemoryImage(slot_addr):
-                            raw_val = d.disassembly.getBytes(slot_addr, 8)
-                            if raw_val and len(raw_val) == 8:
-                                val = struct.unpack("<Q", raw_val)[0]
-                                constants[dest_reg] = val
-                                resolved = True
-                if not resolved:
-                    constants.pop(dest_reg, None)
+            _updateConstantTracking(d, cap_ins, constants)
 
         return constants.get(norm_reg(reg_name))
 
+    def recoverStackStrings(self, analysis_state):
+        """danielplohmann/smda#173: reconstruct strings built byte-by-byte on the
+        stack (mov <reg>, #imm; strb <reg>, [sp, #off]; ... or stp with tracked
+        register values) into disassembly.stringrefs, mirroring what dalvik/cil
+        already do for their single-instruction string literals. Runs once per
+        finalized function block, after the whole function's instructions and
+        block structure are known (unlike analyzeInstruction's streaming pass,
+        this needs no speculative-candidate rollback).
+
+        Known limitation (v1): only tracks str/strb/strh/stur*/stp with an sp
+        base; a SIMD-register stack-string materialization (e.g. `ldr q0, <lit>;
+        str q0, [sp]`) is not decomposed into constant bytes and is silently
+        skipped, same as any other value this backend's constant tracker can't
+        resolve.
+        """
+        d = self.disassembler
+        if not d.config.WITH_STRINGS:
+            return
+        for block in analysis_state.getBlocks():
+            constants = {}
+            stack_bytes = {}
+            for ins in block:
+                bytes_ins = d.disassembly.getBytes(ins[0], ins[1])
+                if not bytes_ins:
+                    continue
+                cap_ins = next(d.capstone.disasm(bytes_ins, ins[0]), None)
+                if not cap_ins:
+                    continue
+                mnemonic = cap_ins.mnemonic.lower()
+
+                if _mutatesStackPointer(cap_ins):
+                    _emitStackStrings(d, analysis_state, stack_bytes)
+                    stack_bytes = {}
+                else:
+                    _recordStackStore(cap_ins, mnemonic, constants, stack_bytes)
+
+                _updateConstantTracking(d, cap_ins, constants)
+            _emitStackStrings(d, analysis_state, stack_bytes)
+
     def resolveRegisterCalls(self, analysis_state, block_depth=3):
         del block_depth
+        self.recoverStackStrings(analysis_state)
         if not analysis_state.call_register_ins:
             return
 
@@ -236,7 +412,13 @@ class AArch64JumpTableAnalyzer:
             elif mnemonic in ("mov", "movz", "movk") and len(ins.operands) >= 2:
                 op1 = ins.operands[1]
                 if op1.type == 2:  # IMM
-                    constants[dest_reg] = op1.imm
+                    imm_value, shift = _movImmediateValue(op1)
+                    if mnemonic == "movk" and dest_reg in constants:
+                        constants[dest_reg] = (constants[dest_reg] & ~(0xFFFF << shift)) | imm_value
+                    elif mnemonic == "movk":
+                        constants.pop(dest_reg, None)
+                    else:
+                        constants[dest_reg] = imm_value
                 elif op1.type == 1:  # REG
                     src_reg = norm_reg(ins.reg_name(op1.reg))
                     if src_reg in constants:

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -23,6 +23,15 @@ do not "simplify" away):
   they are classified as unconditional and checked before the generic ``b.`` test.
 - ``eret``/``eretaa``/``eretab`` return from an exception level with *no* capstone
   groups at all, so they too must be matched by mnemonic (kernel/firmware code).
+- ``drps`` (Debug Restore PState, Debug-state only) also carries *no* capstone groups
+  and 0 operands; it transfers control to ``ELR_ELx`` like an exception return, so it
+  is folded into ``EXCEPTION_RETURN_INS`` rather than falling through as sequential.
+- FEAT_HBC's hinted conditional branch ``bc.<cond>`` (ARMv8.8/9.3, e.g. LLVM ``+hbc``)
+  shares the b.<cond> encoding with bit 4 set and, like the trap/return instructions
+  above, carries *no* capstone groups either. It is a distinct mnemonic prefix
+  (``bc.`` not ``b.``), so every ``b.``-prefix test in this backend must also test
+  ``bc.`` or it silently drops the taken-branch edge; ``bc.al``/``bc.nv`` are its
+  always-taken aliases, mirroring ``b.al``/``b.nv``.
 """
 
 # fixed AArch64 instruction width (bytes); also the recursion stride
@@ -32,16 +41,22 @@ NOP = 0xD503201F
 # --- control-flow mnemonic classes (capstone arm64) ----------------------
 #: function-return terminators, incl. pointer-auth variants (retaa/retab)
 RET_INS = {"ret", "retaa", "retab"}
-#: exception-level returns, incl. pointer-auth variants (kernel/firmware code)
-EXCEPTION_RETURN_INS = {"eret", "eretaa", "eretab"}
+#: exception-level returns, incl. pointer-auth variants (kernel/firmware code),
+#: and drps (Debug Restore PState: transfers control to ELR_ELx, no operands)
+EXCEPTION_RETURN_INS = {"eret", "eretaa", "eretab", "drps"}
 #: direct (bl) and indirect (blr + pointer-auth blra*) calls — none terminate a block
 CALL_INS = {"bl", "blr", "blraa", "blrab", "blraaz", "blrabz"}
 #: trap / undefined-instruction terminators (verified: empty capstone groups)
 END_INS = {"brk", "hlt", "udf"}
 #: compare-and-branch / test-and-branch conditionals (fall-through + target)
 COND_BRANCH_INS = {"cbz", "cbnz", "tbz", "tbnz"}
-#: always-true conditional branches (b.al/b.nv): single successor, no fall-through
-ALWAYS_BRANCH_INS = {"b.al", "b.nv"}
+#: always-true conditional branches (b.al/b.nv and FEAT_HBC's bc.al/bc.nv):
+#: single successor, no fall-through
+ALWAYS_BRANCH_INS = {"b.al", "b.nv", "bc.al", "bc.nv"}
+#: mnemonic prefixes covering every plain and FEAT_HBC-hinted conditional branch
+#: (b.eq/b.ne/... and bc.eq/bc.ne/...); ALWAYS_BRANCH_INS above must be checked
+#: first since b.al/b.nv/bc.al/bc.nv also match these prefixes but never fall through
+COND_BRANCH_PREFIXES = ("b.", "bc.")
 #: unconditional direct branch (single successor; may be a tailcall)
 UNCOND_JUMP_INS = {"b"}
 #: indirect branch through a register, incl. pointer-auth variants (bra*)
@@ -75,8 +90,11 @@ CBZ_CBNZ_MASK = 0x7E000000
 CBZ_CBNZ_VALUE = 0x34000000
 TBZ_TBNZ_MASK = 0x7E000000
 TBZ_TBNZ_VALUE = 0x36000000
-BCOND_MASK = 0xFF000010
-BCOND_VALUE = 0x54000000  # b.<cond> (also matches the always-branches b.al/b.nv)
+BCOND_MASK = 0xFF000000
+BCOND_VALUE = 0x54000000  # b.<cond> and FEAT_HBC's hinted bc.<cond> (bit 4 = o1,
+# unset for b.<cond>, set for bc.<cond>) share this encoding; also matches the
+# always-branches b.al/b.nv/bc.al/bc.nv. Bit 4 is deliberately left unmasked so
+# both hinted and unhinted forms match.
 
 # --- PC-relative address materialization (reference recovery) -------------
 # adrp Xd, #page and adr Xd, #imm share the mask; bit 31 selects adrp vs adr.
@@ -103,11 +121,13 @@ def adrp_page_value(word, pc):
 
 
 def is_conditional_branch(word):
-    """True for cbz/cbnz, tbz/tbnz and b.<cond> (compare/test/condition branches).
+    """True for cbz/cbnz, tbz/tbnz, b.<cond> and FEAT_HBC's bc.<cond>
+    (compare/test/condition branches, hinted or not).
 
     A function never opens with one of these, so the gap scan treats a leading
-    conditional branch as a stray block tail (not an entry) and skips it. b.al/b.nv
-    also match the b.<cond> mask; they are never valid entries, so skipping is benign.
+    conditional branch as a stray block tail (not an entry) and skips it. b.al/b.nv/
+    bc.al/bc.nv also match the b.<cond>/bc.<cond> mask; they are never valid entries,
+    so skipping is benign.
     """
     return (
         (word & CBZ_CBNZ_MASK) == CBZ_CBNZ_VALUE

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -26,7 +26,9 @@ from types import SimpleNamespace
 import lief
 
 from smda.aarch64.AArch64Backend import AArch64Backend
-from smda.aarch64.definitions import adrp_page_value
+from smda.aarch64.AArch64CapstoneVerification import is_control_flow_mnemonic
+from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper
+from smda.aarch64.definitions import EXCEPTION_RETURN_INS, adrp_page_value, is_conditional_branch
 from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaReport import SmdaReport
@@ -369,6 +371,148 @@ class TestAArch64PacAndAlwaysBranches(unittest.TestCase):
         self.assertEqual(
             [ins.mnemonic for ins in report.getFunction(BASE).getInstructions()],
             ["paciasp", "mov", "eret"],
+        )
+
+
+class TestAArch64HintedConditionalBranch(unittest.TestCase):
+    """FEAT_HBC's hinted conditional branch bc.<cond> (ARMv8.8/9.3).
+
+    Capstone decodes bc.eq/bc.ne/... distinctly from b.eq/b.ne/... (mnemonic
+    prefix "bc." instead of "b."), with the encoding differing only in bit 4
+    (o1/hint bit). Every "is this a conditional branch" check in the AArch64
+    backend must recognize both prefixes, and the raw-encoding gap-scan mask
+    must match bit 4 set or unset. Verified live against capstone 5.0.7:
+    bytes 10 00 00 54 decode to mnemonic 'bc.eq', op_str '#0x401000', groups [].
+    """
+
+    @staticmethod
+    def _encode_bc_cond(source, target, cond, hint=1):
+        imm19 = ((target - source) // 4) & 0x7FFFF
+        return 0x54000000 | (imm19 << 5) | (hint << 4) | cond
+
+    def _disassemble_words(self, words, oep=None):
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        code = b"".join(w.to_bytes(4, "little") for w in words)
+        return Disassembler(config, backend="aarch64").disassembleBuffer(
+            code,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + len(code)]],
+            oep=oep,
+            architecture="aarch64",
+        )
+
+    def test_is_control_flow_mnemonic_recognizes_bc_cond_forms(self):
+        for mnemonic in ("bc.eq", "bc.ne", "bc.al", "bc.nv", "bc.gt"):
+            self.assertTrue(is_control_flow_mnemonic(mnemonic), mnemonic)
+
+    def test_is_conditional_branch_matches_hinted_encoding(self):
+        # bc.eq: bit 4 (hint/o1) is set, distinguishing it from plain b.eq.
+        word = self._encode_bc_cond(BASE, BASE + 0xC, cond=0x0, hint=1)
+        self.assertEqual(word, 0x54000070)
+        self.assertTrue(is_conditional_branch(word))
+        # This is exactly the bit-4-set case the pre-fix BCOND_MASK (0xFF000010,
+        # which required bit 4 clear) excluded: confirm the bit really is set,
+        # i.e. the old mask would have missed this word.
+        self.assertNotEqual(word & 0xFF000010, 0x54000000)
+        self.assertEqual(word & 0x10, 0x10)
+
+    def test_conditional_branch_has_two_successors(self):
+        # mirrors TestAArch64Disassembler.test_conditional_branch_has_two_successors,
+        # substituting bc.eq (hinted) for cbz.
+        target = BASE + 0xC
+        report = self._disassemble_words(
+            [
+                self._encode_bc_cond(BASE, target, cond=0x0),  # bc.eq 0x40100c
+                0xD2800020,  # 0x401004 mov x0, #1
+                0xD65F03C0,  # 0x401008 ret
+                0xD65F03C0,  # 0x40100c ret
+            ],
+            oep=0,
+        )
+        self.assertEqual(report.status, "ok")
+        function = report.getFunction(BASE)
+        self.assertEqual(function.num_blocks, 3)
+        blocks = {b.offset: b for b in function.getBlocks()}
+        self.assertEqual(set(blocks), {BASE, BASE + 0x4, target})
+        # bc.eq #0x40100c -> taken (target) + fall-through (BASE + 0x4)
+        self.assertEqual(set(blocks[BASE].getSuccessors()), {BASE + 0x4, target})
+
+    def test_bc_always_branch_has_no_fallthrough(self):
+        # bc.al always branches (like b.al): the skipped-over fall-through
+        # instruction must NOT be booked into the function.
+        report = self._disassemble_words(
+            [
+                0xD503233F,  # 0x401000 paciasp
+                self._encode_bc_cond(BASE + 0x4, BASE + 0xC, cond=0xE),  # 0x401004 bc.al 0x40100c
+                0xD2800060,  # 0x401008 mov x0, #3  (unreachable fall-through)
+                0xD65F03C0,  # 0x40100c ret
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        instruction_offsets = [ins.offset for ins in report.getFunction(BASE).getInstructions()]
+        self.assertEqual(instruction_offsets, [BASE, BASE + 0x4, BASE + 0xC])
+        self.assertNotIn(BASE + 0x8, instruction_offsets)
+
+    def test_escaper_classifies_bc_cond_as_control_flow(self):
+        target = BASE + 0xC
+        report = self._disassemble_words(
+            [
+                self._encode_bc_cond(BASE, target, cond=0x0),  # bc.eq 0x40100c
+                0xD2800020,  # mov x0, #1
+                0xD65F03C0,  # ret
+                0xD65F03C0,  # ret
+            ],
+            oep=0,
+        )
+        self.assertEqual(report.status, "ok")
+        instruction = next(iter(report.getFunction(BASE).getInstructions()))
+        self.assertEqual(instruction.mnemonic, "bc.eq")
+        self.assertEqual(AArch64InstructionEscaper.escapeMnemonicForInstruction(instruction), "C")
+
+
+class TestAArch64DrpsExceptionReturn(unittest.TestCase):
+    """drps (Debug Restore PState) carries no capstone groups and 0 operands,
+    same class as eret/brk/hlt/udf: it must be special-cased by mnemonic since
+    capstone gives no group signal, and it transfers control to ELR_ELx."""
+
+    def _disassemble_words(self, words):
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        code = b"".join(w.to_bytes(4, "little") for w in words)
+        return Disassembler(config, backend="aarch64").disassembleBuffer(
+            code,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + len(code)]],
+            architecture="aarch64",
+        )
+
+    def test_drps_in_exception_return_ins(self):
+        self.assertIn("drps", EXCEPTION_RETURN_INS)
+
+    def test_is_control_flow_mnemonic_recognizes_drps(self):
+        self.assertTrue(is_control_flow_mnemonic("drps"))
+
+    def test_drps_terminates_block(self):
+        # mirrors TestAArch64PacAndAlwaysBranches.test_exception_return_terminates_block,
+        # substituting drps for eret.
+        report = self._disassemble_words(
+            [
+                0xD503233F,  # paciasp
+                0xD2800020,  # mov x0, #1
+                0xD6BF03E0,  # drps
+                0xD503233F,  # paciasp
+                0xD2800040,  # mov x0, #2
+                0xD65F03C0,  # ret
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertEqual({f.offset for f in report.getFunctions()}, {BASE, BASE + 0xC})
+        self.assertEqual(
+            [ins.mnemonic for ins in report.getFunction(BASE).getInstructions()],
+            ["paciasp", "mov", "drps"],
         )
 
 
@@ -916,6 +1060,24 @@ class TestAArch64GapScan(unittest.TestCase):
             word.to_bytes(4, "little")
             for word in [
                 0xD65F0BFF,  # retaa
+                0xD503245F,  # bti c
+            ]
+        )
+        binary_info = BinaryInfo(binary)
+        binary_info.base_addr = BASE
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={})
+        manager._candidate_offsets = set()
+
+        self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4))
+
+    def test_bti_after_drps_is_not_suppressed_as_interior(self):
+        # drps (Debug Restore PState) transfers control to ELR_ELx like eret*, so a BTI
+        # right after it is a legitimate landing pad, not fragmentation of straight-line code.
+        binary = b"".join(
+            word.to_bytes(4, "little")
+            for word in [
+                0xD6BF03E0,  # drps
                 0xD503245F,  # bti c
             ]
         )

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -1073,6 +1073,119 @@ class TestAArch64StringExtraction(unittest.TestCase):
         )
 
 
+class TestAArch64StackStringRecovery(unittest.TestCase):
+    """danielplohmann/smda#173: strings built byte-by-byte on the stack via
+    tracked-register stores (str/strb/strh/stur* and stp) are reconstructed and
+    recorded into disassembly.stringrefs / SmdaFunction.stringrefs, same as
+    dalvik/cil's own addStringRef-backed (non-buffer) strings."""
+
+    def _disassemble_words(self, words, with_strings=True):
+        config = SmdaConfig()
+        config.WITH_STRINGS = with_strings
+        code = b"".join(w.to_bytes(4, "little") for w in words)
+        return Disassembler(config, backend="aarch64").disassembleBuffer(
+            code,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + len(code)]],
+            oep=0,
+            architecture="aarch64",
+        )
+
+    def test_string_built_byte_by_byte_via_strb_is_recovered(self):
+        report = self._disassemble_words(
+            [
+                0x52800908,  # mov w8, #0x48 ('H')
+                0x390003E8,  # strb w8, [sp]
+                0x52800CA8,  # mov w8, #0x65 ('e')
+                0x390007E8,  # strb w8, [sp, #1]
+                0x52800D88,  # mov w8, #0x6c ('l')
+                0x39000BE8,  # strb w8, [sp, #2]
+                0x52800D88,  # mov w8, #0x6c ('l')
+                0x39000FE8,  # strb w8, [sp, #3]
+                0x52800DE8,  # mov w8, #0x6f ('o')
+                0x390013E8,  # strb w8, [sp, #4]
+                0xD65F03C0,  # ret
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertIn(
+            {"string": "Hello", "ins_addr": BASE + 4, "data_addr": None, "type": "stack"},
+            report.getFunction(BASE).stringrefs,
+        )
+
+    def test_string_built_via_stp_register_pair_is_recovered(self):
+        report = self._disassemble_words(
+            [
+                0x528CA908,  # mov w8, #0x6548
+                0x72AD8D88,  # movk w8, #0x6c6c, lsl #16   (w8 = 0x6C6C6548 = "Hell", little-endian)
+                0x52842DE9,  # mov w9, #0x216f
+                0x72A00009,  # movk w9, #0, lsl #16        (w9 = 0x0000216F = "o!\0\0", little-endian)
+                0x290027E8,  # stp w8, w9, [sp]
+                0xD65F03C0,  # ret
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertIn(
+            {"string": "Hello!", "ins_addr": BASE + 0x10, "data_addr": None, "type": "stack"},
+            report.getFunction(BASE).stringrefs,
+        )
+
+    def test_gated_by_with_strings_config(self):
+        report = self._disassemble_words(
+            [
+                0x52800908,  # mov w8, #0x48 ('H')
+                0x390003E8,  # strb w8, [sp]
+                0x52800CA8,  # mov w8, #0x65 ('e')
+                0x390007E8,  # strb w8, [sp, #1]
+                0x52800D88,  # mov w8, #0x6c ('l')
+                0x39000BE8,  # strb w8, [sp, #2]
+                0x52800D88,  # mov w8, #0x6c ('l')
+                0x39000FE8,  # strb w8, [sp, #3]
+                0x52800DE8,  # mov w8, #0x6f ('o')
+                0x390013E8,  # strb w8, [sp, #4]
+                0xD65F03C0,  # ret
+            ],
+            with_strings=False,
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertFalse(report.getFunction(BASE).stringrefs)
+
+    def test_stack_pointer_mutation_resets_stale_offsets(self):
+        # "Test" is written at offsets 0-3 relative to the ORIGINAL sp; "sub sp,
+        # sp, #16" then moves sp, so "Data" at offsets 0-3 afterwards is a
+        # PHYSICALLY DIFFERENT stack slot even though the numeric offsets repeat.
+        # Without resetting tracked offsets on the sp mutation, "Data"'s writes
+        # would silently overwrite the same dict keys "Test" used, losing "Test"
+        # entirely (never flushed) instead of producing two separate strings.
+        report = self._disassemble_words(
+            [
+                0x52800A88,  # mov w8, #0x54 ('T')
+                0x390003E8,  # strb w8, [sp]
+                0x52800CA8,  # mov w8, #0x65 ('e')
+                0x390007E8,  # strb w8, [sp, #1]
+                0x52800E68,  # mov w8, #0x73 ('s')
+                0x39000BE8,  # strb w8, [sp, #2]
+                0x52800E88,  # mov w8, #0x74 ('t')
+                0x39000FE8,  # strb w8, [sp, #3]
+                0xD10043FF,  # sub sp, sp, #0x10
+                0x52800888,  # mov w8, #0x44 ('D')
+                0x390003E8,  # strb w8, [sp]
+                0x52800C28,  # mov w8, #0x61 ('a')
+                0x390007E8,  # strb w8, [sp, #1]
+                0x52800E88,  # mov w8, #0x74 ('t')
+                0x39000BE8,  # strb w8, [sp, #2]
+                0x52800C28,  # mov w8, #0x61 ('a')
+                0x39000FE8,  # strb w8, [sp, #3]
+                0xD65F03C0,  # ret
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        stringrefs = report.getFunction(BASE).stringrefs
+        self.assertIn({"string": "Test", "ins_addr": BASE + 4, "data_addr": None, "type": "stack"}, stringrefs)
+        self.assertIn({"string": "Data", "ins_addr": BASE + 0x28, "data_addr": None, "type": "stack"}, stringrefs)
+
+
 class TestAArch64AddressMaterialization(unittest.TestCase):
     """adrp page resolution used by the address-reference recovery pass."""
 
@@ -1369,6 +1482,7 @@ class TestAArch64Analyzers(unittest.TestCase):
             def __init__(self, disassembly_result, capstone):
                 self.disassembly = disassembly_result
                 self.capstone = capstone
+                self.config = SimpleNamespace(WITH_STRINGS=False)
 
             def resolveApi(self, to_addr, api_addr):
                 if to_addr == 0x401020:
@@ -1448,6 +1562,7 @@ class TestAArch64Analyzers(unittest.TestCase):
             def __init__(self, disassembly_result, capstone):
                 self.disassembly = disassembly_result
                 self.capstone = capstone
+                self.config = SimpleNamespace(WITH_STRINGS=False)
 
             def resolveApi(self, to_addr, api_addr):
                 if to_addr == 0x401020:

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -659,6 +659,93 @@ class TestAArch64PltResolution(unittest.TestCase):
         self.assertEqual(state.code_refs, [(branch_addr, plt, True)])
 
 
+class TestAArch64ApiThunkDetection(unittest.TestCase):
+    """danielplohmann/smda#172: a function whose entire body is the canonical
+    adrp; [add;] ldr; br GOT/API-import thunk (optionally nop/bti-prefixed) is
+    flagged via state.setThunkCall(True), landing in disassembly.thunk_functions."""
+
+    def _disassemble_words(self, words, oep=0):
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        code = b"".join(w.to_bytes(4, "little") for w in words)
+        disassembler = Disassembler(config, backend="aarch64")
+        report = disassembler.disassembleBuffer(
+            code,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + len(code)]],
+            oep=oep,
+            architecture="aarch64",
+        )
+        return report, disassembler.disassembly
+
+    def test_walk_got_thunk_three_instructions(self):
+        words = [
+            0x90000010,  # adrp x16, #0
+            0xF9400210,  # ldr x16, [x16]
+            0xD61F0200,  # br x16
+        ]
+        code = b"".join(w.to_bytes(4, "little") for w in words)
+        binary_info = BinaryInfo(code)
+        binary_info.base_addr = BASE
+        fake_disassembler = SimpleNamespace(disassembly=SimpleNamespace(binary_info=binary_info))
+        fake_disassembler.disassembly.isAddrWithinMemoryImage = lambda addr: BASE <= addr < BASE + len(code)
+
+        result = AArch64Backend._walkGotThunk(fake_disassembler, BASE)
+
+        self.assertIsNotNone(result)
+        end_addr, _target = result
+        self.assertEqual(end_addr, BASE + len(words) * 4)
+
+    def test_three_instruction_thunk_is_flagged(self):
+        report, disassembly = self._disassemble_words(
+            [
+                0x90000010,  # adrp x16, #0
+                0xF9400210,  # ldr x16, [x16]
+                0xD61F0200,  # br x16
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertIn(BASE, disassembly.thunk_functions)
+
+    def test_four_instruction_thunk_with_add_is_flagged(self):
+        report, disassembly = self._disassemble_words(
+            [
+                0x90000010,  # adrp x16, #0
+                0x91000210,  # add x16, x16, #0
+                0xF9400210,  # ldr x16, [x16]
+                0xD61F0200,  # br x16
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertIn(BASE, disassembly.thunk_functions)
+
+    def test_bti_prefixed_thunk_is_flagged(self):
+        report, disassembly = self._disassemble_words(
+            [
+                0xD503245F,  # bti c
+                0x90000010,  # adrp x16, #0
+                0xF9400210,  # ldr x16, [x16]
+                0xD61F0200,  # br x16
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertIn(BASE, disassembly.thunk_functions)
+
+    def test_normal_function_with_more_than_thunk_body_is_not_flagged(self):
+        # a real prologue precedes the adrp/ldr/br shape: not a thunk.
+        report, disassembly = self._disassemble_words(
+            [
+                0xA9BF7BFD,  # stp x29, x30, [sp, #-16]!
+                0x90000010,  # adrp x16, #0
+                0xF9400210,  # ldr x16, [x16]
+                0xD61F0200,  # br x16
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertNotIn(BASE, disassembly.thunk_functions)
+
+
 class TestAArch64PrologueDiscovery(unittest.TestCase):
     """Frame-less prologues are discovered with no inbound call reference.
 


### PR DESCRIPTION
## Summary

Three AArch64 backend improvements, each its own commit:

1. **Recognize FEAT_HBC's `bc.<cond>` hinted conditional branch and `drps`** — both decode correctly under capstone but carry *no* instruction groups (verified live against capstone 5.0.7: `bc.eq` groups `[]` vs `b.eq` groups `['jump', 'branch_relative']`), so both were silently falling through as sequential/never-return instructions instead of being classified as a conditional branch / exception return respectively.
2. **Detect AArch64 API/GOT-thunk functions** (closes #172) — a function whose entire body is the canonical `adrp; [add;] ldr; br` thunk shape (optionally `nop`/`bti`-prefixed) is now flagged via `state.setThunkCall(True)`, landing in `disassembly.thunk_functions`.
3. **Recover stack-built strings into `function.stringrefs`** (closes #173) — strings AArch64 code constructs byte-by-byte on the stack (`mov w8, #0x48; strb w8, [sp]; ...`) are now reconstructed and recorded, mirroring what dalvik/cil already do for their own non-buffer-backed strings.

## Details

### 1. `bc.<cond>` / `drps` (commit `fix(aarch64): recognize FEAT_HBC bc.<cond> branches and drps exception returns`)

- `bc.<cond>` (ARMv8.8/9.3 hinted conditional branch) shares `b.<cond>`'s imm19 encoding, differing only in bit 4. Every `b.`-prefix mnemonic check in the backend, escaper and gap-scan mask now also matches `bc.`.
- `drps` (Debug Restore PState) transfers control to `ELR_ELx` like `eret*`, with zero operands and no capstone groups — folded into the same exception-return handling.
- Includes a sibling fix the initial pass on this class would have missed: `FunctionCandidateManager._isLikelyInteriorBtiCandidate`'s own hardcoded terminator-encoding set (used to decide whether a BTI landing pad right after it is a real function entry) was missing `drps`'s raw encoding.

### 2. API/GOT-thunk detection (commit `feat(aarch64): detect adrp+ldr+br API thunks`)

- Extracts the raw-encoding walk out of the existing `_resolvePltGotSlot` into a shared `_walkGotThunk` helper: PLT/GOT slot resolution gates on the target being inside a known PLT/stub range, while thunk-body detection instead checks that the walk's end address lines up exactly with the current `br`, proving nothing else is in the function body.
- Covers the 3-instruction (`adrp; ldr; br`) and 4-instruction (`adrp; add; ldr; br`) forms, with an optional leading `nop`/`bti`.

### 3. Stack-string recovery (commit `feat(aarch64): recover stack-built strings into function.stringrefs`)

- `AArch64IndirectCallAnalyzer.recoverStackStrings` runs once per finalized function block (from the existing `resolveRegisterCalls` hook, so block structure is already settled), tracking `str`/`strb`/`strh`/`stur*` and `stp` writes to `[sp, #imm]` whose source register holds a value already tracked by the existing adrp/add/mov/movz/movk/ldr constant tracker. Wide/pair stores are decomposed into individual bytes; contiguous printable-ASCII runs are reconstructed into strings.
- Any stack-pointer mutation (`sub`/`add`/`mov` with `sp` as destination, or a pre/post-index writeback such as `stp x29, x30, [sp, #-16]!`) flushes and resets tracking, since offsets from before and after no longer refer to the same physical stack slots.
- Surfaced two bugs while building this, both fixed in the same commit since the feature doesn't work correctly without them:
  - **`movk`'s capstone IMM operand is the raw, unshifted 16-bit field** (e.g. `movk w8, #0x6c6c, lsl #16` reports `imm=0x6c6c`, not `0x6c6c0000`). The existing constant tracker — shared by indirect-call-target resolution and jump-table analysis — was silently computing the wrong register value for any `movk` with a non-zero shift. Fixed in both occurrences of the tracking logic.
  - **`Disassembler._extractStrings` unconditionally overwrote `smda_function.stringrefs`** with only buffer-derived strings for every non-`dalvik` architecture, discarding any `addStringRef`-based entries. This was already silently affecting CIL's own `ldstr`-derived strings (no existing test exercises CIL with `WITH_STRINGS=True` end-to-end, so it was a latent, untested gap rather than a regression). Generalized the `dalvik` special-case into an architecture-keyed one so analyzer-provided strings are normalized and merged in for every backend that uses `addStringRef`.

## Validation

```
make lint
python -m pytest tests/test*
```

Full suite green: 424 passed, 1 skipped, 480 subtests passed. `ruff check`/`ruff format --check` clean on the whole tree.

New/updated regression tests: `TestAArch64HintedConditionalBranch`, `TestAArch64DrpsExceptionReturn`, `TestAArch64ApiThunkDetection`, `TestAArch64StackStringRecovery` in `tests/testAArch64Disassembler.py`, each verified to fail against the pre-fix code and pass against the fix.

## Review notes for the maintainer

- Commit 1 has no dependency on commits 2/3 (they can be reviewed/merged independently if preferred, though all three are stacked in this PR for convenience).
- Commit 3's fix to `Disassembler._extractStrings` (`src/smda/Disassembler.py`) is the only change outside `src/smda/aarch64/**` — it's necessary for stack-string recovery to actually surface in `SmdaFunction.stringrefs` (a naive `addStringRef`-only approach would otherwise be silently discarded by the existing buffer-string extraction pass), and it incidentally fixes the same class of bug for CIL.
- `_MIN_STACK_STRING_LEN`/`_MAX_STACK_STRING_LEN` (4/128) in `analyzers.py` are conservative defaults to avoid single-byte noise and pathological runs — happy to tune if you'd prefer different thresholds.
- Known v1 limitation, documented inline: a SIMD-register stack-string materialization (e.g. `ldr q0, <literal>; str q0, [sp]`) is not decomposed into bytes and is silently skipped, same as any other value the existing constant tracker can't resolve.
