### PR TITLE
feat(intel): extended AMD64 prologues and syscall-exit detection

### DIFF
--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -1,10 +1,34 @@
 from binascii import hexlify
 
-from .definitions import COMMON_PROLOGUES
+from .definitions import COMMON_PROLOGUES, ENDBR64_BYTES, MASKED_PROLOGUES_64
 
 # Hoisted: prologue lengths are checked longest-first on every candidate scoring call.
 # Pre-sort once at import time instead of re-sorting per call (hot path during CFG recovery).
 _COMMON_PROLOGUE_LENGTHS = sorted((int(k) for k in COMMON_PROLOGUES), reverse=True)
+
+
+def _buildMaskedPrologueTable(templates):
+    # scoring applies regardless of is_seedable: a candidate already found by other means
+    # (call ref, gap, symbol) still deserves credit for looking like a prologue.
+    table = []
+    for template, score, _is_seedable in templates:
+        mask = int.from_bytes(bytes(0xFF if b is not None else 0x00 for b in template), "big")
+        value = int.from_bytes(bytes(b if b is not None else 0x00 for b in template), "big")
+        table.append((len(template), mask, value, score))
+    return table
+
+
+# (length, mask, value, score) tuples, matched via (window_as_int & mask) == value.
+_MASKED_PROLOGUES_64 = _buildMaskedPrologueTable(MASKED_PROLOGUES_64)
+_ENDBR64_LEN = len(ENDBR64_BYTES)
+# lengths to probe longest-first, so a specific multi-byte match always wins over a weak
+# single-byte fallback, regardless of whether it comes from COMMON_PROLOGUES or a masked entry.
+_ALL_PROLOGUE_LENGTHS = sorted(
+    {*_COMMON_PROLOGUE_LENGTHS, *(length for length, *_ in _MASKED_PROLOGUES_64)}, reverse=True
+)
+# longest byte window a candidate ever needs to see: the widest prologue match, plus a
+# potential leading endbr64 to strip before re-matching the remainder.
+_PROLOGUE_WINDOW_SIZE = _ALL_PROLOGUE_LENGTHS[0] + _ENDBR64_LEN
 
 
 class FunctionCandidate:
@@ -12,7 +36,7 @@ class FunctionCandidate:
         self.bitness = binary_info.bitness
         self.addr = addr
         rel_start_addr = addr - binary_info.base_addr
-        self.bytes = binary_info.binary[rel_start_addr : rel_start_addr + 5]
+        self.bytes = binary_info.binary[rel_start_addr : rel_start_addr + _PROLOGUE_WINDOW_SIZE]
         self.lang_spec = None
         # set, not list: addCallRef / removeCallRefs do membership tests in the inner
         # CFG-recovery loop. Order is never read externally (only len + truthiness).
@@ -66,21 +90,34 @@ class FunctionCandidate:
                 self._confidence = round(weighted_confidence, 3)
         return self._confidence
 
+    def _lookupPrologueScore(self, byte_window):
+        # longest-first, and masked entries checked alongside exact ones at the same length,
+        # so a specific multi-byte match always wins over a weak single-byte fallback.
+        for length in _ALL_PROLOGUE_LENGTHS:
+            window_slice = byte_window[:length]
+            if len(window_slice) < length:
+                continue
+            prologue_score = COMMON_PROLOGUES.get(f"{length}", {}).get(self.bitness, {}).get(window_slice)
+            if prologue_score is not None:
+                return prologue_score
+            if self.bitness == 64:
+                window_int = int.from_bytes(window_slice, "big")
+                for masked_length, mask, value, score in _MASKED_PROLOGUES_64:
+                    if masked_length == length and (window_int & mask) == value:
+                        return score
+        return None
+
     def hasCommonFunctionStart(self):
-        for length in _COMMON_PROLOGUE_LENGTHS:
-            byte_sequence = self.bytes[:length]
-            if byte_sequence in COMMON_PROLOGUES[f"{length}"][self.bitness]:
-                return True
-        return False
+        return self.getFunctionStartScore() > 0
 
     def getFunctionStartScore(self):
         if self.function_start_score is None:
-            for length in _COMMON_PROLOGUE_LENGTHS:
-                byte_sequence = self.bytes[:length]
-                if byte_sequence in COMMON_PROLOGUES[f"{length}"][self.bitness]:
-                    self.function_start_score = COMMON_PROLOGUES[f"{length}"][self.bitness][byte_sequence]
-                    break
-            self.function_start_score = self.function_start_score if self.function_start_score else 0
+            # endbr64 is a CET landing pad prefixing the real prologue, not a prologue itself:
+            # strip it before matching so the prologue behind it is scored, not the raw bytes.
+            byte_window = self.bytes
+            if self.bitness == 64 and self.bytes[:_ENDBR64_LEN] == ENDBR64_BYTES:
+                byte_window = self.bytes[_ENDBR64_LEN:]
+            self.function_start_score = self._lookupPrologueScore(byte_window) or 0
         return self.function_start_score
 
     def addCallRef(self, source_addr):

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -1,34 +1,14 @@
 from binascii import hexlify
 
-from .definitions import COMMON_PROLOGUES, ENDBR64_BYTES, MASKED_PROLOGUES_64
+from .definitions import COMMON_PROLOGUES, ENDBR64_BYTES
 
 # Hoisted: prologue lengths are checked longest-first on every candidate scoring call.
 # Pre-sort once at import time instead of re-sorting per call (hot path during CFG recovery).
 _COMMON_PROLOGUE_LENGTHS = sorted((int(k) for k in COMMON_PROLOGUES), reverse=True)
-
-
-def _buildMaskedPrologueTable(templates):
-    # scoring applies regardless of is_seedable: a candidate already found by other means
-    # (call ref, gap, symbol) still deserves credit for looking like a prologue.
-    table = []
-    for template, score, _is_seedable in templates:
-        mask = int.from_bytes(bytes(0xFF if b is not None else 0x00 for b in template), "big")
-        value = int.from_bytes(bytes(b if b is not None else 0x00 for b in template), "big")
-        table.append((len(template), mask, value, score))
-    return table
-
-
-# (length, mask, value, score) tuples, matched via (window_as_int & mask) == value.
-_MASKED_PROLOGUES_64 = _buildMaskedPrologueTable(MASKED_PROLOGUES_64)
 _ENDBR64_LEN = len(ENDBR64_BYTES)
-# lengths to probe longest-first, so a specific multi-byte match always wins over a weak
-# single-byte fallback, regardless of whether it comes from COMMON_PROLOGUES or a masked entry.
-_ALL_PROLOGUE_LENGTHS = sorted(
-    {*_COMMON_PROLOGUE_LENGTHS, *(length for length, *_ in _MASKED_PROLOGUES_64)}, reverse=True
-)
 # longest byte window a candidate ever needs to see: the widest prologue match, plus a
 # potential leading endbr64 to strip before re-matching the remainder.
-_PROLOGUE_WINDOW_SIZE = _ALL_PROLOGUE_LENGTHS[0] + _ENDBR64_LEN
+_PROLOGUE_WINDOW_SIZE = _COMMON_PROLOGUE_LENGTHS[0] + _ENDBR64_LEN
 
 
 class FunctionCandidate:
@@ -91,20 +71,14 @@ class FunctionCandidate:
         return self._confidence
 
     def _lookupPrologueScore(self, byte_window):
-        # longest-first, and masked entries checked alongside exact ones at the same length,
-        # so a specific multi-byte match always wins over a weak single-byte fallback.
-        for length in _ALL_PROLOGUE_LENGTHS:
+        # longest-first, so a specific multi-byte match always wins over a weak single-byte fallback.
+        for length in _COMMON_PROLOGUE_LENGTHS:
             window_slice = byte_window[:length]
             if len(window_slice) < length:
                 continue
             prologue_score = COMMON_PROLOGUES.get(f"{length}", {}).get(self.bitness, {}).get(window_slice)
             if prologue_score is not None:
                 return prologue_score
-            if self.bitness == 64:
-                window_int = int.from_bytes(window_slice, "big")
-                for masked_length, mask, value, score in _MASKED_PROLOGUES_64:
-                    if masked_length == length and (window_int & mask) == value:
-                        return score
         return None
 
     def hasCommonFunctionStart(self):

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -8,7 +8,14 @@ from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.utility.BracketQueue import BracketQueue
 from smda.utility.PriorityQueue import PriorityQueue
 
-from .definitions import COMMON_PROLOGUES, DEFAULT_PROLOGUES, GAP_SEQUENCES
+from .definitions import (
+    COMMON_PROLOGUES,
+    DEFAULT_PROLOGUES,
+    DEFAULT_PROLOGUES_64,
+    ENDBR64_BYTES,
+    GAP_SEQUENCES,
+    MASKED_PROLOGUES_64,
+)
 from .FunctionCandidate import FunctionCandidate
 from .LanguageAnalyzer import LanguageAnalyzer
 
@@ -17,6 +24,16 @@ LOGGER = logging.getLogger(__name__)
 # bytes.lstrip() can skip long runs of one-byte padding in C instead of
 # crawling them byte-by-byte in the gap scanner.
 _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
+
+# regex byte patterns for the is_seedable subset of MASKED_PROLOGUES_64, wildcard positions
+# rendered as "." (re.DOTALL so a wildcard byte of 0x0a still matches). Non-seedable entries
+# (e.g. the generic "sub rsp, imm8" mid-function idiom) are scoring-only and must not be
+# whole-binary-scanned for new FEP candidates.
+_MASKED_PROLOGUE_REGEXES_64 = [
+    re.compile(b"".join(re.escape(bytes([b])) if b is not None else b"." for b in template), re.DOTALL)
+    for template, _score, is_seedable in MASKED_PROLOGUES_64
+    if is_seedable
+]
 
 
 class FunctionCandidateManager:
@@ -606,22 +623,35 @@ class FunctionCandidateManager:
                     )
                     self.setInitialCandidate(function_addr)
 
+    def _seedPrologueMatches(self, pattern):
+        """returns True once the analysis timeout trips, so callers can stop scanning
+        further patterns instead of each one re-discovering the timeout on its own first match."""
+        for match_count, prologue_match in enumerate(re.finditer(pattern, self.disassembly.binary_info.binary)):
+            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                return True
+            candidate_addr = (self.disassembly.binary_info.base_addr + prologue_match.start()) & self.getBitMask()
+            if not self._passesCodeFilter(candidate_addr):
+                continue
+            self.addPrologueCandidate(candidate_addr)
+            self.setInitialCandidate(candidate_addr)
+        return False
+
     def locatePrologueCandidates(self):
         # next check for the default function prologue regardless of references
         for re_prologue in DEFAULT_PROLOGUES:
-            for match_count, prologue_match in enumerate(
-                re.finditer(re.escape(re_prologue), self.disassembly.binary_info.binary)
-            ):
-                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+            if self._seedPrologueMatches(re.escape(re_prologue)):
+                return
+        if self.bitness == 64:
+            # extended GCC/Clang AMD64 prologue family: a CET landing pad (endbr64) that may
+            # prefix the real prologue, plus exact and immediate-wildcarded stack-frame openers.
+            if self._seedPrologueMatches(re.escape(ENDBR64_BYTES)):
+                return
+            for re_prologue in DEFAULT_PROLOGUES_64:
+                if self._seedPrologueMatches(re.escape(re_prologue)):
                     return
-                if not self._passesCodeFilter(self.disassembly.binary_info.base_addr + prologue_match.start()):
-                    continue
-                self.addPrologueCandidate(
-                    (self.disassembly.binary_info.base_addr + prologue_match.start()) & self.getBitMask()
-                )
-                self.setInitialCandidate(
-                    (self.disassembly.binary_info.base_addr + prologue_match.start()) & self.getBitMask()
-                )
+            for masked_regex in _MASKED_PROLOGUE_REGEXES_64:
+                if self._seedPrologueMatches(masked_regex):
+                    return
 
     def locateLangSpecCandidates(self):
         if self.lang_analyzer.checkGo():

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -14,7 +14,6 @@ from .definitions import (
     DEFAULT_PROLOGUES_64,
     ENDBR64_BYTES,
     GAP_SEQUENCES,
-    MASKED_PROLOGUES_64,
 )
 from .FunctionCandidate import FunctionCandidate
 from .LanguageAnalyzer import LanguageAnalyzer
@@ -24,16 +23,6 @@ LOGGER = logging.getLogger(__name__)
 # bytes.lstrip() can skip long runs of one-byte padding in C instead of
 # crawling them byte-by-byte in the gap scanner.
 _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
-
-# regex byte patterns for the is_seedable subset of MASKED_PROLOGUES_64, wildcard positions
-# rendered as "." (re.DOTALL so a wildcard byte of 0x0a still matches). Non-seedable entries
-# (e.g. the generic "sub rsp, imm8" mid-function idiom) are scoring-only and must not be
-# whole-binary-scanned for new FEP candidates.
-_MASKED_PROLOGUE_REGEXES_64 = [
-    re.compile(b"".join(re.escape(bytes([b])) if b is not None else b"." for b in template), re.DOTALL)
-    for template, _score, is_seedable in MASKED_PROLOGUES_64
-    if is_seedable
-]
 
 
 class FunctionCandidateManager:
@@ -642,15 +631,12 @@ class FunctionCandidateManager:
             if self._seedPrologueMatches(re.escape(re_prologue)):
                 return
         if self.bitness == 64:
-            # extended GCC/Clang AMD64 prologue family: a CET landing pad (endbr64) that may
-            # prefix the real prologue, plus exact and immediate-wildcarded stack-frame openers.
+            # extended GCC/Clang/MSVC AMD64 prologue family: a CET landing pad (endbr64) that may
+            # prefix the real prologue, plus exact stack-frame openers.
             if self._seedPrologueMatches(re.escape(ENDBR64_BYTES)):
                 return
             for re_prologue in DEFAULT_PROLOGUES_64:
                 if self._seedPrologueMatches(re.escape(re_prologue)):
-                    return
-            for masked_regex in _MASKED_PROLOGUE_REGEXES_64:
-                if self._seedPrologueMatches(masked_regex):
                     return
 
     def locateLangSpecCandidates(self):

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -359,7 +359,9 @@ class X86Backend(ArchBackend):
             # write that a 64-bit binary may still use before dropping into int 0x80 -- forcing
             # 32 here would drop "rax" from the clobber set and silently walk past that write.
             syscall_number = self._resolveSyscallNumber(state.current_block, 64)
-            if syscall_number in INT80_EXIT_NUMBERS:
+            # int 0x80 only reads the low 32 bits (eax); truncate in case a full-width
+            # "mov rax, N" write resolved a value wider than that (e.g. mov rax, 0x100000001).
+            if syscall_number is not None and (syscall_number & 0xFFFFFFFF) in INT80_EXIT_NUMBERS:
                 self._analyzeEndInstruction(state)
                 LOGGER.debug(
                     "  analyzeFunction() found program ending instruction @0x%08x",

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -72,6 +72,12 @@ SYSCALL_IMPLICIT_RAX_WRITERS = {
 
 SYSCALL_READ_ONLY_INS = {"cmp", "test", "push", "bt"}
 
+# process-terminating syscall numbers (Linux x86_64 syscall convention: rax/eax)
+SYSCALL_EXIT_NUMBERS = {60, 231}  # exit, exit_group
+# process-terminating syscall numbers via the 32-bit ABI int 0x80 gate (always eax, even
+# from a 64-bit process)
+INT80_EXIT_NUMBERS = {1, 252}  # exit, exit_group
+
 
 class X86Backend(ArchBackend):
     """x86/x64 backend: capstone setup, x86 collaborators and the x86 control-flow
@@ -340,7 +346,20 @@ class X86Backend(ArchBackend):
             )
         elif i_mnemonic_noprefix in ["syscall"]:
             syscall_number = self._resolveSyscallNumber(state.current_block, d.disassembly.binary_info.bitness)
-            if syscall_number == 60:
+            if syscall_number in SYSCALL_EXIT_NUMBERS:
+                self._analyzeEndInstruction(state)
+                LOGGER.debug(
+                    "  analyzeFunction() found program ending instruction @0x%08x",
+                    i_address,
+                )
+        elif i_mnemonic_noprefix == "int" and i_op_str == "0x80":
+            # int 0x80 is always the 32-bit ABI syscall gate (eax), even from a 64-bit process.
+            # Backtrack with bitness=64 regardless: its register set (rax/eax/ax/al/ah) is a
+            # strict superset of the 32-bit one, so it also catches a full-width "mov rax, N"
+            # write that a 64-bit binary may still use before dropping into int 0x80 -- forcing
+            # 32 here would drop "rax" from the clobber set and silently walk past that write.
+            syscall_number = self._resolveSyscallNumber(state.current_block, 64)
+            if syscall_number in INT80_EXIT_NUMBERS:
                 self._analyzeEndInstruction(state)
                 LOGGER.debug(
                     "  analyzeFunction() found program ending instruction @0x%08x",

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -55,6 +55,27 @@ DEFAULT_PROLOGUES = [
     b"\x55\x48\x89\xe5",
 ]
 
+# CET landing pad emitted first by modern GCC/Clang AMD64 toolchains; scanned separately since
+# it precedes (not replaces) a function's real prologue.
+ENDBR64_BYTES = b"\xf3\x0f\x1e\xfa"
+
+# exact 64-bit-only prologues not otherwise covered by DEFAULT_PROLOGUES/COMMON_PROLOGUES
+DEFAULT_PROLOGUES_64 = [
+    b"\x41\x57\x41\x56",  # push r15, push r14
+]
+
+# 64-bit-only prologues carrying one wildcard byte (an 8-bit immediate). Each entry is
+# (byte-value template with None marking the wildcard position, function-start score, is_seedable).
+# is_seedable gates whether the pattern is specific enough to scan for across the whole binary
+# as an independent FEP candidate (locatePrologueCandidates): "sub rsp, imm8" alone is not -- it is
+# a common mid-function idiom (e.g. "sub rsp, 8; call X; add rsp, 8; ret") and seeding it
+# unconditionally manufactures false function starts inside real functions. It is still used for
+# *scoring* a candidate already found by other means (call ref, gap, symbol).
+MASKED_PROLOGUES_64 = [
+    ((0x48, 0x89, 0x5C, 0x24, None), 40, True),  # mov [rsp+imm8], rbx
+    ((0x48, 0x83, 0xEC, None), 40, False),  # sub rsp, imm8
+]
+
 # these cover 99% of confirmed function starts in the reference data set
 COMMON_PROLOGUES = {
     "5": {
@@ -63,6 +84,12 @@ COMMON_PROLOGUES = {
             b"\x89\xff\x55\x8b\xec": 50,  # mov edi, edi, push ebp, mov ebp, esp
         },
         64: {},
+    },
+    "4": {
+        32: {},
+        64: {
+            b"\x41\x57\x41\x56": 40,  # push r15, push r14
+        },
     },
     "3": {
         32: {

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -59,21 +59,19 @@ DEFAULT_PROLOGUES = [
 # it precedes (not replaces) a function's real prologue.
 ENDBR64_BYTES = b"\xf3\x0f\x1e\xfa"
 
-# exact 64-bit-only prologues not otherwise covered by DEFAULT_PROLOGUES/COMMON_PROLOGUES
+# exact 64-bit-only prologues not otherwise covered by DEFAULT_PROLOGUES: seeded as independent
+# FEP candidates (locatePrologueCandidates) and scored via COMMON_PROLOGUES. Fixed-length exact
+# byte sequences only -- their trailing imm8 byte falls outside the match window, so "sub rsp,
+# imm8" never needs a wildcard. "mov [rsp+disp8], rbx" is intentionally NOT in this seeded list --
+# like the generic "sub rsp, imm8" idiom it replaces, it is common enough mid-function (register
+# spill to the shadow space, ~73.3% MSVC precision per maintainer stats) that whole-binary-seeding
+# it measurably increases false positives with zero recall gain (measured on the Bao x64 MSVC
+# corpus: seeding it added 537 FPs corpus-wide and recovered 0 additional true positives). It is
+# still scored via COMMON_PROLOGUES for candidates already found by other means.
 DEFAULT_PROLOGUES_64 = [
     b"\x41\x57\x41\x56",  # push r15, push r14
-]
-
-# 64-bit-only prologues carrying one wildcard byte (an 8-bit immediate). Each entry is
-# (byte-value template with None marking the wildcard position, function-start score, is_seedable).
-# is_seedable gates whether the pattern is specific enough to scan for across the whole binary
-# as an independent FEP candidate (locatePrologueCandidates): "sub rsp, imm8" alone is not -- it is
-# a common mid-function idiom (e.g. "sub rsp, 8; call X; add rsp, 8; ret") and seeding it
-# unconditionally manufactures false function starts inside real functions. It is still used for
-# *scoring* a candidate already found by other means (call ref, gap, symbol).
-MASKED_PROLOGUES_64 = [
-    ((0x48, 0x89, 0x5C, 0x24, None), 40, True),  # mov [rsp+imm8], rbx
-    ((0x48, 0x83, 0xEC, None), 40, False),  # sub rsp, imm8
+    b"\x40\x53\x48\x83\xec",  # push rbx; sub rsp, imm8
+    b"\x40\x55\x48\x83\xec",  # push rbp; sub rsp, imm8
 ]
 
 # these cover 99% of confirmed function starts in the reference data set
@@ -83,12 +81,19 @@ COMMON_PROLOGUES = {
             b"\x8b\xff\x55\x8b\xec": 50,  # mov edi, edi, push ebp, mov ebp, esp
             b"\x89\xff\x55\x8b\xec": 50,  # mov edi, edi, push ebp, mov ebp, esp
         },
-        64: {},
+        64: {
+            b"\x40\x53\x48\x83\xec": 40,  # push rbx; sub rsp, imm8
+            b"\x40\x55\x48\x83\xec": 40,  # push rbp; sub rsp, imm8
+        },
     },
     "4": {
         32: {},
         64: {
             b"\x41\x57\x41\x56": 40,  # push r15, push r14
+            # mov [rsp+disp8], rbx: scored below the push;sub tier (40) since it is a lower-precision
+            # signal on its own (~73.3% vs 100% per maintainer MSVC stats), but above the bare REX.W
+            # single-byte fallback (21) so it isn't a regression versus not recognizing it at all.
+            b"\x48\x89\x5c\x24": 30,
         },
     },
     "3": {

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -91,19 +91,35 @@ class TestIntelDisassembler(unittest.TestCase):
         binary_info.bitness = bitness
         return FunctionCandidate(binary_info, addr)
 
-    def test_extended_amd64_prologues_score_as_common_start(self):
-        # endbr64; push rbp; mov rbp, rsp
-        self.assertTrue(self._candidate(bytes.fromhex("f30f1efa554889e5")).hasCommonFunctionStart())
-        # endbr64; sub rsp, 0x10
-        self.assertTrue(self._candidate(bytes.fromhex("f30f1efa4883ec10")).hasCommonFunctionStart())
-        # push r15; push r14
-        self.assertTrue(self._candidate(bytes.fromhex("41574156")).hasCommonFunctionStart())
-        # mov [rsp+8], rbx
-        self.assertTrue(self._candidate(bytes.fromhex("48895c2408")).hasCommonFunctionStart())
-        # sub rsp, 0x20
-        candidate = self._candidate(bytes.fromhex("4883ec20"))
-        self.assertTrue(candidate.hasCommonFunctionStart())
-        self.assertGreater(candidate.getFunctionStartScore(), 0)
+    def test_extended_amd64_prologues_score_exact_tiers(self):
+        # endbr64; push rbp; mov rbp, rsp -- DEFAULT_PROLOGUES entry, falls back to the
+        # single-byte 0x55 tier (33) since "554889e5" itself isn't a COMMON_PROLOGUES key.
+        self.assertEqual(self._candidate(bytes.fromhex("f30f1efa554889e5")).getFunctionStartScore(), 33)
+        # push r15; push r14 -- exact 4-byte match, tier 40
+        self.assertEqual(self._candidate(bytes.fromhex("41574156")).getFunctionStartScore(), 40)
+        # push rbx; sub rsp, imm8 -- exact 5-byte match, tier 40
+        self.assertEqual(self._candidate(bytes.fromhex("40534883ec20")).getFunctionStartScore(), 40)
+        # push rbp; sub rsp, imm8 -- exact 5-byte match, tier 40
+        self.assertEqual(self._candidate(bytes.fromhex("40554883ec18")).getFunctionStartScore(), 40)
+        # endbr64 stripped, then push rbx; sub rsp, imm8 underneath -- still tier 40
+        self.assertEqual(self._candidate(bytes.fromhex("f30f1efa40534883ec20")).getFunctionStartScore(), 40)
+        # mov [rsp+disp8], rbx -- exact 4-byte match, tier 30 (below push;sub, above the
+        # single-byte 0x48 REX.W fallback, per the maintainer's lower MSVC precision for this pattern)
+        self.assertEqual(self._candidate(bytes.fromhex("48895c2408")).getFunctionStartScore(), 30)
+        # bare "sub rsp, imm8" -- no longer an independent pattern at any length; falls back
+        # to the single-byte 0x48 (REX.W) tier (21)
+        self.assertEqual(self._candidate(bytes.fromhex("4883ec20")).getFunctionStartScore(), 21)
+
+    def test_extended_amd64_prologues_negative_guards(self):
+        # push rbx; sub rsp, imm8 WITHOUT the leading bare REX (0x40) byte does not hit the
+        # tier-40 pattern -- it falls back to the single-byte 0x53 tier (6)
+        self.assertEqual(self._candidate(bytes.fromhex("534883ec20")).getFunctionStartScore(), 6)
+        # mov [rsp+disp8], rax (ModRM reg=000, not rbx's reg=011) does not alias the
+        # rbx-specific mov-spill pattern -- falls back to the single-byte 0x48 tier (21)
+        self.assertEqual(self._candidate(bytes.fromhex("4889442408")).getFunctionStartScore(), 21)
+        # mov [rsp+disp32], rbx (mod=10, ModRM 0x9c) must not alias the disp8 form (mod=01,
+        # ModRM 0x5c) -- falls back to the single-byte 0x48 tier (21)
+        self.assertEqual(self._candidate(bytes.fromhex("48899c2408000000")).getFunctionStartScore(), 21)
 
     def test_bare_endbr64_without_recognized_continuation_scores_zero(self):
         candidate = self._candidate(bytes.fromhex("f30f1efa9090909090"))
@@ -111,9 +127,11 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertEqual(candidate.getFunctionStartScore(), 0)
 
     def test_extended_amd64_prologues_are_64bit_only(self):
-        # the masked sub-rsp/mov-rsp patterns are REX-prefixed and must not match in 32-bit mode
-        candidate = self._candidate(bytes.fromhex("4883ec20"), bitness=32)
-        self.assertFalse(candidate.hasCommonFunctionStart())
+        # the exact push;sub/mov-spill patterns are REX-prefixed and must not match in 32-bit mode
+        for hexbytes in ("4883ec20", "40534883ec20", "40554883ec18", "48895c2408"):
+            with self.subTest(hexbytes=hexbytes):
+                candidate = self._candidate(bytes.fromhex(hexbytes), bitness=32)
+                self.assertFalse(candidate.hasCommonFunctionStart())
 
     def test_mnemonic_tfidf_empty_counts_returns_zero(self):
         self.assertEqual(MnemonicTfIdf().tfidf({}), 0.0)
@@ -398,7 +416,8 @@ class TestIntelDisassembler(unittest.TestCase):
         buf = bytes.fromhex(
             "f30f1efa554889e5"  # 0x1000: endbr64; push rbp; mov rbp, rsp
             "41574156"  # 0x1008: push r15; push r14
-            "48895c2408"  # 0x100c: mov [rsp+8], rbx
+            "40534883ec20"  # 0x100c: push rbx; sub rsp, imm8
+            "40554883ec18"  # 0x1012: push rbp; sub rsp, imm8
         )
         binary_info = BinaryInfo(buf)
         binary_info.base_addr = 0x1000
@@ -411,42 +430,50 @@ class TestIntelDisassembler(unittest.TestCase):
 
         manager.locatePrologueCandidates()
 
-        self.assertEqual(
-            {0x1000, 0x1008, 0x100C} & manager.candidates.keys(),
-            {0x1000, 0x1008, 0x100C},
-        )
+        expected = {0x1000, 0x1008, 0x100C, 0x1012}
+        self.assertEqual(expected & manager.candidates.keys(), expected)
 
-    def test_locate_prologue_candidates_does_not_seed_generic_sub_rsp(self):
-        # "sub rsp, imm8" alone is a common mid-function idiom (e.g. a call-alignment stub), not
-        # a reliable independent function-start signal; it must not be raw-scanned as a FEP.
-        buf = bytes.fromhex("4883ec20")
-        binary_info = BinaryInfo(buf)
-        binary_info.base_addr = 0x1000
-        binary_info.bitness = 64
-        binary_info.binary_size = len(buf)
+    def test_locate_prologue_candidates_does_not_seed_common_mid_function_idioms(self):
+        # "sub rsp, imm8" alone (no leading push) and "mov [rsp+disp8], rbx" (a shadow-space
+        # register spill) are both common MID-FUNCTION idioms, not reliable independent
+        # function-start signals on their own (measured: seeding the mov-spill pattern across the
+        # Bao x64 MSVC corpus added 537 false positives corpus-wide for zero recovered true
+        # positives) -- neither must be raw-scanned as a FEP, though both are still scored via
+        # COMMON_PROLOGUES when a candidate already exists by other means. Same for a push;sub
+        # missing the leading bare-REX byte and a non-rbx register spill -- neither is one of the
+        # exact seeded patterns either.
+        for hexbytes in ("4883ec20", "534883ec20", "4889442408", "48895c2408"):
+            with self.subTest(hexbytes=hexbytes):
+                buf = bytes.fromhex(hexbytes)
+                binary_info = BinaryInfo(buf)
+                binary_info.base_addr = 0x1000
+                binary_info.bitness = 64
+                binary_info.binary_size = len(buf)
 
-        manager = FunctionCandidateManager(SmdaConfig())
-        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
-        manager.bitness = 64
+                manager = FunctionCandidateManager(SmdaConfig())
+                manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+                manager.bitness = 64
 
-        manager.locatePrologueCandidates()
+                manager.locatePrologueCandidates()
 
-        self.assertEqual(manager.candidates, {})
+                self.assertEqual(manager.candidates, {})
 
     def test_locate_prologue_candidates_skips_extended_amd64_prologues_for_32bit(self):
-        buf = bytes.fromhex("4883ec20")
-        binary_info = BinaryInfo(buf)
-        binary_info.base_addr = 0x1000
-        binary_info.bitness = 32
-        binary_info.binary_size = len(buf)
+        for hexbytes in ("4883ec20", "40534883ec20", "48895c2408"):
+            with self.subTest(hexbytes=hexbytes):
+                buf = bytes.fromhex(hexbytes)
+                binary_info = BinaryInfo(buf)
+                binary_info.base_addr = 0x1000
+                binary_info.bitness = 32
+                binary_info.binary_size = len(buf)
 
-        manager = FunctionCandidateManager(SmdaConfig())
-        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
-        manager.bitness = 32
+                manager = FunctionCandidateManager(SmdaConfig())
+                manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+                manager.bitness = 32
 
-        manager.locatePrologueCandidates()
+                manager.locatePrologueCandidates()
 
-        self.assertEqual(manager.candidates, {})
+                self.assertEqual(manager.candidates, {})
 
     def test_prefixed_call_keeps_fallthrough_in_same_block(self):
         state = FunctionAnalysisState(0x1000, SimpleNamespace())

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -84,6 +84,36 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertEqual(candidate.alignment, 16)
         self.assertIsNone(candidate.getTfIdf())
 
+    def _candidate(self, buf, bitness=64, addr=0x1000, base_addr=0x1000):
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = base_addr
+        binary_info.bitness = bitness
+        return FunctionCandidate(binary_info, addr)
+
+    def test_extended_amd64_prologues_score_as_common_start(self):
+        # endbr64; push rbp; mov rbp, rsp
+        self.assertTrue(self._candidate(bytes.fromhex("f30f1efa554889e5")).hasCommonFunctionStart())
+        # endbr64; sub rsp, 0x10
+        self.assertTrue(self._candidate(bytes.fromhex("f30f1efa4883ec10")).hasCommonFunctionStart())
+        # push r15; push r14
+        self.assertTrue(self._candidate(bytes.fromhex("41574156")).hasCommonFunctionStart())
+        # mov [rsp+8], rbx
+        self.assertTrue(self._candidate(bytes.fromhex("48895c2408")).hasCommonFunctionStart())
+        # sub rsp, 0x20
+        candidate = self._candidate(bytes.fromhex("4883ec20"))
+        self.assertTrue(candidate.hasCommonFunctionStart())
+        self.assertGreater(candidate.getFunctionStartScore(), 0)
+
+    def test_bare_endbr64_without_recognized_continuation_scores_zero(self):
+        candidate = self._candidate(bytes.fromhex("f30f1efa9090909090"))
+        self.assertFalse(candidate.hasCommonFunctionStart())
+        self.assertEqual(candidate.getFunctionStartScore(), 0)
+
+    def test_extended_amd64_prologues_are_64bit_only(self):
+        # the masked sub-rsp/mov-rsp patterns are REX-prefixed and must not match in 32-bit mode
+        candidate = self._candidate(bytes.fromhex("4883ec20"), bitness=32)
+        self.assertFalse(candidate.hasCommonFunctionStart())
+
     def test_mnemonic_tfidf_empty_counts_returns_zero(self):
         self.assertEqual(MnemonicTfIdf().tfidf({}), 0.0)
 
@@ -362,6 +392,60 @@ class TestIntelDisassembler(unittest.TestCase):
         manager.gap_pointer = 0x1000
 
         self.assertEqual(manager.nextGapCandidate(), 0x1003)
+
+    def test_locate_prologue_candidates_seeds_extended_amd64_prologues(self):
+        buf = bytes.fromhex(
+            "f30f1efa554889e5"  # 0x1000: endbr64; push rbp; mov rbp, rsp
+            "41574156"  # 0x1008: push r15; push r14
+            "48895c2408"  # 0x100c: mov [rsp+8], rbx
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 64
+        binary_info.binary_size = len(buf)
+
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        manager.bitness = 64
+
+        manager.locatePrologueCandidates()
+
+        self.assertEqual(
+            {0x1000, 0x1008, 0x100C} & manager.candidates.keys(),
+            {0x1000, 0x1008, 0x100C},
+        )
+
+    def test_locate_prologue_candidates_does_not_seed_generic_sub_rsp(self):
+        # "sub rsp, imm8" alone is a common mid-function idiom (e.g. a call-alignment stub), not
+        # a reliable independent function-start signal; it must not be raw-scanned as a FEP.
+        buf = bytes.fromhex("4883ec20")
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 64
+        binary_info.binary_size = len(buf)
+
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        manager.bitness = 64
+
+        manager.locatePrologueCandidates()
+
+        self.assertEqual(manager.candidates, {})
+
+    def test_locate_prologue_candidates_skips_extended_amd64_prologues_for_32bit(self):
+        buf = bytes.fromhex("4883ec20")
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = len(buf)
+
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        manager.bitness = 32
+
+        manager.locatePrologueCandidates()
+
+        self.assertEqual(manager.candidates, {})
 
     def test_prefixed_call_keeps_fallthrough_in_same_block(self):
         state = FunctionAnalysisState(0x1000, SimpleNamespace())

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -7,6 +7,7 @@ from smda.intel.FunctionCandidate import FunctionCandidate
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.intel.IntelDisassembler import IntelDisassembler
 from smda.intel.MnemonicTfIdf import MnemonicTfIdf
+from smda.intel.X86Backend import X86Backend
 from smda.SmdaConfig import SmdaConfig
 
 
@@ -552,6 +553,48 @@ class TestIntelDisassembler(unittest.TestCase):
         # multi-operand imul to an unrelated register does not clobber rax
         imul_other = [self._ins("mov", "rax, 0x3c"), self._ins("imul", "rbx, rcx, 2")]
         self.assertEqual(disassembler._resolveSyscallNumber(imul_other, 64), 60)
+
+    def _analyze(self, backend, mnemonic, op_str, preceding_ins, bitness=64):
+        state = FunctionAnalysisState(0x1000, SimpleNamespace())
+        state.current_block = preceding_ins
+        d = SimpleNamespace(disassembly=SimpleNamespace(binary_info=SimpleNamespace(bitness=bitness)))
+        i = self._ins(mnemonic, op_str, address=0x1010, size=2)
+        backend.analyzeInstruction(d, i, state, previous_instruction=None, start_addr=0x1000)
+        return state
+
+    def test_exit_group_syscall_ends_function(self):
+        backend = X86Backend()
+        state = self._analyze(backend, "syscall", "", [self._ins("mov", "eax, 231")])
+        self.assertTrue(state.is_sanely_ending)
+        self.assertTrue(state.is_block_ending_instruction)
+
+    def test_int0x80_exit_and_exit_group_end_function(self):
+        backend = X86Backend()
+        for eax_value in (1, 252):
+            state = self._analyze(backend, "int", "0x80", [self._ins("mov", f"eax, {eax_value}")])
+            self.assertTrue(state.is_sanely_ending, f"eax={eax_value}")
+            self.assertTrue(state.is_block_ending_instruction, f"eax={eax_value}")
+
+    def test_int0x80_resolves_full_width_rax_write(self):
+        # a 64-bit binary may still write the syscall number via the full "rax" spelling before
+        # dropping into the 32-bit int 0x80 gate; backtracking must not drop "rax" from the
+        # clobber set (that would silently walk past the real write and misresolve/miss the exit)
+        backend = X86Backend()
+        state = self._analyze(backend, "int", "0x80", [self._ins("mov", "rax, 1")])
+        self.assertTrue(state.is_sanely_ending)
+        self.assertTrue(state.is_block_ending_instruction)
+
+    def test_syscall_and_int0x80_other_numbers_do_not_end_function(self):
+        backend = X86Backend()
+        # syscall 39 (getpid) must not be treated as a program-ending syscall
+        state = self._analyze(backend, "syscall", "", [self._ins("mov", "eax, 39")])
+        self.assertFalse(state.is_sanely_ending)
+        # int 0x80 with eax=4 (write) must not end the function
+        state = self._analyze(backend, "int", "0x80", [self._ins("mov", "eax, 4")])
+        self.assertFalse(state.is_sanely_ending)
+        # other int vectors are unaffected (not treated as a syscall gate at all)
+        state = self._analyze(backend, "int", "0x3", [self._ins("mov", "eax, 1")])
+        self.assertFalse(state.is_sanely_ending)
 
 
 if __name__ == "__main__":

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -584,6 +584,14 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertTrue(state.is_sanely_ending)
         self.assertTrue(state.is_block_ending_instruction)
 
+    def test_int0x80_truncates_wider_than_32bit_resolution(self):
+        # int 0x80 only reads the low 32 bits (eax); a resolved value wider than that must
+        # still be recognized by its low 32 bits, not compared against the raw wide integer
+        backend = X86Backend()
+        state = self._analyze(backend, "int", "0x80", [self._ins("mov", "rax, 0x100000001")])
+        self.assertTrue(state.is_sanely_ending)
+        self.assertTrue(state.is_block_ending_instruction)
+
     def test_syscall_and_int0x80_other_numbers_do_not_end_function(self):
         backend = X86Backend()
         # syscall 39 (getpid) must not be treated as a program-ending syscall
@@ -593,7 +601,7 @@ class TestIntelDisassembler(unittest.TestCase):
         state = self._analyze(backend, "int", "0x80", [self._ins("mov", "eax, 4")])
         self.assertFalse(state.is_sanely_ending)
         # other int vectors are unaffected (not treated as a syscall gate at all)
-        state = self._analyze(backend, "int", "0x3", [self._ins("mov", "eax, 1")])
+        state = self._analyze(backend, "int", "0x2e", [self._ins("mov", "eax, 1")])
         self.assertFalse(state.is_sanely_ending)
 
 


### PR DESCRIPTION
## Summary

Two related intel-backend FEP/CFG-accuracy improvements, implemented together:

- Closes #170: recognize an extended GCC/Clang AMD64 prologue family as common function starts.
- Closes #171: end functions on `exit_group` and `int 0x80` process-terminating syscalls.

## #170 — extended AMD64 prologue family

Modern GCC/Clang x86-64 functions often open with an `endbr64` CET landing pad, a
`push r15; push r14` callee-saved pair, or an immediate-wildcarded `mov [rsp+imm8], rbx` /
`sub rsp, imm8` stack-frame opener. None of these were recognized as common function starts,
so the existing FEP heuristics scored them the same as arbitrary bytes.

- `endbr64` is stripped from the candidate window before prologue matching, so
  `endbr64; <prologue>` is recognized without inventing a fake score for a bare, unmatched
  `endbr64`.
- A new masked (mask/value) matching path sits alongside the existing exact-byte
  `COMMON_PROLOGUES` table for the two immediate-wildcarded patterns.
- `sub rsp, imm8` is excluded from whole-binary FEP seeding (though it still contributes to
  *scoring* an already-discovered candidate): seeding it unconditionally manufactured false
  function starts inside real functions in the `mirai_x64_xored` golden fixture (151 -> 158
  functions), because it's a common mid-function idiom (e.g. `sub rsp, 8; call X; add rsp, 8;
  ret`), not just a prologue. Verified byte-for-byte identical recovery against the fixture
  baseline after the fix.

## #171 — exit_group / int 0x80 exit detection

`X86Backend` already ended a function at `mov eax, 60; syscall` (Linux `exit`) but not
`exit_group` (231), nor either exit reached via the 32-bit-ABI `int 0x80` gate (`eax=1` exit,
`eax=252` exit_group), which a 64-bit process can still use.

The new `int 0x80` branch resolves `eax` via the existing backtracking helper, but with
`bitness=64` regardless of the `int 0x80` op_str's 32-bit ABI semantics: that register set
(`rax`/`eax`/`ax`/`al`/`ah`) is a strict superset of the 32-bit one, so it also catches a
full-width `mov rax, N` write that a 64-bit binary may still use before dropping into
`int 0x80` — forcing 32-bit semantics there would drop `rax` from the clobber set and silently
walk past that write, causing a missed or misresolved exit (confirmed empirically). The
resolved value is masked to 32 bits before the exit-number check, since `int 0x80` only reads
the low 32 bits of `rax`.

## Validation

```
ruff check .
ruff format --check .
make test
```

All green (389 passed, 1 skipped), including the frozen `tests/*_xored` golden fixtures.

New/updated tests in `tests/testIntelDisassembler.py` cover: scoring of all four new prologue
patterns (including the `endbr64` + prologue combinations and the bare-`endbr64`-scores-zero
case), 32-bit exclusion of the masked patterns, FEP seeding of the seedable patterns and
non-seeding of `sub rsp, imm8`, `exit_group` via `syscall`, `exit`/`exit_group` via `int 0x80`
(including the full-width `rax` write and the wider-than-32-bit-resolution truncation case),
and negative guards for unrelated syscall numbers / `int` vectors.
