### PR TITLE
fix(aarch64): report-metric accuracy, PLT-thunk attribution, and candidate-scan timeouts

### DIFF
--- a/.github/workflows/scripts/run_perf_check.py
+++ b/.github/workflows/scripts/run_perf_check.py
@@ -45,6 +45,7 @@ def run_benchmark(iterations, output_file):
         {"name": "komplex", "filename": "komplex_xored", "base_addr": 0, "backend": "intel"},
         {"name": "njrat", "filename": "njrat_xored", "base_addr": 0, "backend": "cil"},
         {"name": "pe_export", "filename": "pe_export_label_test_xored", "base_addr": 0, "backend": "intel"},
+        {"name": "aarch64_static", "filename": "aarch64_static_xored", "base_addr": 0, "backend": "aarch64"},
     ]
 
     results = {}

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -129,7 +129,6 @@ class AArch64Backend(ArchBackend):
     @classmethod
     def _callFallthroughFunctionStart(cls, d, addr):
         if addr in d.fc_manager.getFunctionStartCandidates():
-            print(f"found candidate at call fallthrough 0x{addr:08x}")
             return addr
 
         cursor = addr
@@ -138,12 +137,10 @@ class AArch64Backend(ArchBackend):
             skipped_nop = True
             cursor += INSTRUCTION_SIZE
         if skipped_nop and cursor in d.fc_manager.getFunctionStartCandidates():
-            print(f"skipped NOPs, found candidate at 0x{cursor:08x}")
             return cursor
         if skipped_nop and cursor % 16 == 0:
             word = cls._wordAt(d, cursor)
             if word not in (None, 0, NOP):
-                print(f"skipped NOPs, found non-NOP at 0x{cursor:08x}: 0x{word:08x}")
                 return cursor
         return None
 
@@ -356,12 +353,18 @@ class AArch64Backend(ArchBackend):
                 thunk_walk = self._walkGotThunk(d, state.start_addr)
                 if thunk_walk is not None and thunk_walk[0] == i_address + i_size:
                     state.setThunkCall(True)
-            # br and the PAC indirect jumps (braa/brab/braaz/brabz): indirect branch
-            jumptable_targets = d.jumptable_analyzer.getJumpTargets(instruction, state)
-            for target in jumptable_targets:
-                if d.disassembly.isAddrWithinMemoryImage(target):
-                    state.addBlockToQueue(target)
-                    state.addCodeRef(i_address, target, by_jump=True)
+            # br / bra*: import stubs (PLT/Mach-O) are multi-insn adrp+ldr+br sequences
+            # whose entry is in a stub range — resolve the GOT slot and attribute the API
+            # to this branch (mirrors x86 jmp [iat] thunk analysis).
+            got_slot = self._resolvePltGotSlot(d, state.start_addr)
+            if got_slot is not None and d._handleApiTarget(i_address, got_slot, got_slot):
+                state.setSanelyEnding(True)
+            else:
+                jumptable_targets = d.jumptable_analyzer.getJumpTargets(instruction, state)
+                for target in jumptable_targets:
+                    if d.disassembly.isAddrWithinMemoryImage(target):
+                        state.addBlockToQueue(target)
+                        state.addCodeRef(i_address, target, by_jump=True)
             state.setNextInstructionReachable(False)
             state.setBlockEndingInstruction(True)
         # else: SEQUENTIAL — engine books it and continues to the next instruction.

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -71,10 +71,20 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         # The x86-only PLT/stub-chain and PE .pdata passes do not apply and are
         # omitted; the NOP-based gap scan is disabled (see nextGapCandidate).
         self.locateSymbolCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locateReferenceCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locateAddressRefCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locateDataPointerCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locatePrologueCandidates()
+        if self._candidateTimeoutTripped():
+            return
         self.locateLangSpecCandidates()
         self.identified_alignment = self._identifyAlignment()
 
@@ -128,7 +138,9 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             # naturally aligned, so an unaligned section start would otherwise
             # stride past every aligned pointer in the section.
             scan_start = (section_start + (pointer_size - 1)) & ~(pointer_size - 1)
-            for pointer_va in range(scan_start, section_end - (pointer_size - 1), pointer_size):
+            for match_count, pointer_va in enumerate(range(scan_start, section_end - (pointer_size - 1), pointer_size)):
+                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                    return
                 raw = self.disassembly.getBytes(pointer_va, pointer_size)
                 if raw is None or len(raw) != pointer_size:
                     continue
@@ -173,7 +185,11 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         for low, high in exec_ranges:
             pages = {}  # Xd -> adrp page base currently held in that register
             addr = low
+            match_count = 0
             while addr + INSTRUCTION_SIZE <= high:
+                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                    return
+                match_count += 1
                 offset = addr - base
                 if offset < 0 or offset + INSTRUCTION_SIZE > len(binary):
                     addr += INSTRUCTION_SIZE
@@ -224,7 +240,9 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         # call-reference candidate — the AArch64 analogue of the base 0xE8 scan.
         binary = self.disassembly.binary_info.binary
         base = self.disassembly.binary_info.base_addr
-        for offset in range(0, len(binary) - (INSTRUCTION_SIZE - 1), INSTRUCTION_SIZE):
+        for match_count, offset in enumerate(range(0, len(binary) - (INSTRUCTION_SIZE - 1), INSTRUCTION_SIZE)):
+            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                return
             word = int.from_bytes(binary[offset : offset + INSTRUCTION_SIZE], "little")
             if (word & BL_MASK) != BL_VALUE:
                 continue
@@ -246,7 +264,9 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         # see definitions.is_function_prologue for the exact encodings.
         binary = self.disassembly.binary_info.binary
         base = self.disassembly.binary_info.base_addr
-        for offset in range(0, len(binary) - (INSTRUCTION_SIZE - 1), INSTRUCTION_SIZE):
+        for match_count, offset in enumerate(range(0, len(binary) - (INSTRUCTION_SIZE - 1), INSTRUCTION_SIZE)):
+            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                return
             word = int.from_bytes(binary[offset : offset + INSTRUCTION_SIZE], "little")
             if not is_function_prologue(word):
                 continue

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -257,7 +257,10 @@ class SmdaFunction:
             return self._isAArch64ApiThunk()
         if self.num_instructions != 1:
             return False
-        first_ins = self.blocks[self.offset][0]
+        block = self.blocks.get(self.offset)
+        if not block:
+            return False
+        first_ins = block[0]
         if architecture == "dalvik":
             return first_ins.mnemonic.startswith("invoke-")
         mnemonic = self._baseMnemonic(first_ins.mnemonic)

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -7,6 +7,11 @@ import struct
 from typing import Iterator, List
 
 from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper
+from smda.aarch64.definitions import CALL_INS as AARCH64_CALL_INS
+from smda.aarch64.definitions import EXCEPTION_RETURN_INS as AARCH64_EXCEPTION_RETURN_INS
+from smda.aarch64.definitions import INDIRECT_JUMP_INS as AARCH64_INDIRECT_JUMP_INS
+from smda.aarch64.definitions import RET_INS as AARCH64_RET_INS
+from smda.aarch64.definitions import UNCOND_JUMP_INS as AARCH64_UNCOND_JUMP_INS
 from smda.common.CodeXref import CodeXref
 from smda.common.DominatorTree import build_dominator_tree, get_nesting_depth
 from smda.common.ExceptionHandling import reraise_non_operational_exception
@@ -194,32 +199,87 @@ class SmdaFunction:
     def num_instructions(self):
         return sum(len(block) for block in self.blocks.values())
 
+    @staticmethod
+    def _baseMnemonic(mnemonic):
+        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
+        return mnemonic.split(" ")[-1]
+
     @property
     def num_calls(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
             return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("invoke-"))
-        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
-        return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.split(" ")[-1] == "call")
+        if architecture == "aarch64":
+            call_mnemonics = AARCH64_CALL_INS
+        elif architecture == "cil":
+            call_mnemonics = {"call", "calli", "callvirt"}
+        else:
+            call_mnemonics = {"call"}
+        return sum(
+            1 for block in self.blocks.values() for ins in block if self._baseMnemonic(ins.mnemonic) in call_mnemonics
+        )
 
     @property
     def num_returns(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
             return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("return"))
-        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
+        if architecture == "aarch64":
+            return_mnemonics = AARCH64_RET_INS | AARCH64_EXCEPTION_RETURN_INS
+        else:
+            return_mnemonics = {"ret", "retn"}
         return sum(
-            1 for block in self.blocks.values() for ins in block if ins.mnemonic.split(" ")[-1] in ("ret", "retn")
+            1 for block in self.blocks.values() for ins in block if self._baseMnemonic(ins.mnemonic) in return_mnemonics
         )
 
+    # AArch64 PLT/Mach-O import stubs: optional bti/nop, then adrp + add/ldr + br.
+    # Kept intentionally tight so ordinary short functions with an API call are not
+    # misclassified as thunks.
+    _AARCH64_API_THUNK_BODY = frozenset(
+        {
+            "adrp",
+            "adr",
+            "add",
+            "ldr",
+            "ldp",
+            "nop",
+            "mov",
+            "movz",
+            "movk",
+            "movn",
+            "bti",
+            "autia1716",
+            "autib1716",
+        }
+    )
+    _AARCH64_API_THUNK_MAX_INSNS = 8
+
     def isApiThunk(self):
+        if not self.apirefs:
+            return False
+        architecture = self.smda_report.architecture if self.smda_report else ""
+        if architecture == "aarch64":
+            return self._isAArch64ApiThunk()
         if self.num_instructions != 1:
             return False
         first_ins = self.blocks[self.offset][0]
-        # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string
-        if first_ins.mnemonic.split(" ")[-1] not in ["jmp", "call"]:
+        return self._baseMnemonic(first_ins.mnemonic) in ("jmp", "call")
+
+    def _isAArch64ApiThunk(self):
+        # Import stubs are a single straight-line block ending in a transfer that
+        # carries the API ref (single b/br, or multi-insn adrp+ldr+br PLT shape).
+        if self.num_blocks != 1 or self.num_instructions > self._AARCH64_API_THUNK_MAX_INSNS:
             return False
-        return len(self.apirefs) != 0
+        block = self.blocks.get(self.offset)
+        if not block:
+            return False
+        transfer = AARCH64_CALL_INS | AARCH64_UNCOND_JUMP_INS | AARCH64_INDIRECT_JUMP_INS
+        last = block[-1]
+        if self._baseMnemonic(last.mnemonic) not in transfer:
+            return False
+        if not any(ins.offset in self.apirefs and self._baseMnemonic(ins.mnemonic) in transfer for ins in block):
+            return False
+        return all(self._baseMnemonic(ins.mnemonic) in self._AARCH64_API_THUNK_BODY for ins in block[:-1])
 
     def isExported(self):
         return self.is_exported

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -241,12 +241,7 @@ class SmdaFunction:
             "adr",
             "add",
             "ldr",
-            "ldp",
             "nop",
-            "mov",
-            "movz",
-            "movk",
-            "movn",
             "bti",
             "autia1716",
             "autib1716",
@@ -263,7 +258,12 @@ class SmdaFunction:
         if self.num_instructions != 1:
             return False
         first_ins = self.blocks[self.offset][0]
-        return self._baseMnemonic(first_ins.mnemonic) in ("jmp", "call")
+        if architecture == "dalvik":
+            return first_ins.mnemonic.startswith("invoke-")
+        mnemonic = self._baseMnemonic(first_ins.mnemonic)
+        if architecture == "cil":
+            return mnemonic in ("call", "calli", "callvirt", "jmp")
+        return mnemonic in ("jmp", "call")
 
     def _isAArch64ApiThunk(self):
         # Import stubs are a single straight-line block ending in a transfer that

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -622,6 +622,47 @@ class TestAArch64PltResolution(unittest.TestCase):
         self.assertEqual(fake_disassembler.call_targets, [])
         self.assertEqual(state.code_refs, [(call_addr, plt, False)])
 
+    def test_analyzing_plt_stub_as_function_records_api_on_br(self):
+        # When the PLT entry itself is recovered as a function, the terminal br
+        # must attribute the GOT import (so isApiThunk can see the apiref).
+        fake_disassembler, plt, got_slot = self._build_disassembler()
+        br_addr = plt + 12  # adrp; ldr; add; br
+
+        class FakeState:
+            def __init__(self, start_addr):
+                self.start_addr = start_addr
+                self.sanely_ending = False
+                self.next_reachable = True
+                self.block_ending = False
+                self.queue = []
+                self.code_refs = []
+
+            def setSanelyEnding(self, value=True):
+                self.sanely_ending = value
+
+            def setNextInstructionReachable(self, value):
+                self.next_reachable = value
+
+            def setBlockEndingInstruction(self, value=True):
+                self.block_ending = value
+
+            def addBlockToQueue(self, addr):
+                self.queue.append(addr)
+
+            def addCodeRef(self, from_addr, to_addr, by_jump=False):
+                self.code_refs.append((from_addr, to_addr, by_jump))
+
+        state = FakeState(plt)
+        backend = AArch64Backend()
+        backend.analyzeInstruction(fake_disassembler, (br_addr, 4, "br", "x17"), state, None, plt)
+
+        self.assertEqual(fake_disassembler.api_targets, [(br_addr, got_slot, got_slot)])
+        self.assertTrue(state.sanely_ending)
+        self.assertFalse(state.next_reachable)
+        self.assertTrue(state.block_ending)
+        self.assertEqual(state.queue, [])
+        self.assertEqual(state.code_refs, [])
+
     def test_uncond_branch_tailcall_to_plt_stub_records_api_reference(self):
         # A thin wrapper that tail-calls an import via a bare unconditional branch
         # (instead of "bl") must resolve through the same PLT/Mach-O-stub decode as

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -634,6 +634,7 @@ class TestAArch64PltResolution(unittest.TestCase):
                 self.sanely_ending = False
                 self.next_reachable = True
                 self.block_ending = False
+                self.thunk_call = False
                 self.queue = []
                 self.code_refs = []
 
@@ -645,6 +646,9 @@ class TestAArch64PltResolution(unittest.TestCase):
 
             def setBlockEndingInstruction(self, value=True):
                 self.block_ending = value
+
+            def setThunkCall(self, value=True):
+                self.thunk_call = value
 
             def addBlockToQueue(self, addr):
                 self.queue.append(addr)
@@ -660,6 +664,9 @@ class TestAArch64PltResolution(unittest.TestCase):
         self.assertTrue(state.sanely_ending)
         self.assertFalse(state.next_reachable)
         self.assertTrue(state.block_ending)
+        # the whole function body is exactly the adrp/ldr/add/br thunk shape, so
+        # the merged upstream thunk_functions classification must also fire here.
+        self.assertTrue(state.thunk_call)
         self.assertEqual(state.queue, [])
         self.assertEqual(state.code_refs, [])
 

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -4,6 +4,7 @@ import logging
 import types
 import unittest
 
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager as AArch64FunctionCandidateManager
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
 
@@ -16,6 +17,22 @@ def _make_manager(config, binary=b"\x55\x8b\xec" * 1024, base_addr=0x1000, bitne
     binary_info = types.SimpleNamespace(bitness=bitness, base_addr=base_addr, binary=binary)
     manager.disassembly = types.SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
     manager.bitness = bitness
+    return manager
+
+
+def _make_aarch64_manager(config, binary, base_addr=0x1000):
+    manager = AArch64FunctionCandidateManager(config)
+    binary_info = types.SimpleNamespace(bitness=64, base_addr=base_addr, binary=binary)
+    manager.disassembly = types.SimpleNamespace(
+        binary_info=binary_info,
+        analysis_timeout=False,
+        isAddrWithinMemoryImage=lambda addr: base_addr <= addr < base_addr + len(binary),
+        getBytes=lambda addr, size: (
+            binary[addr - base_addr : addr - base_addr + size] if 0 <= addr - base_addr < len(binary) else None
+        ),
+    )
+    manager.bitness = 64
+    manager._code_areas = []
     return manager
 
 
@@ -75,6 +92,36 @@ class CandidateSafeguardsTestSuite(unittest.TestCase):
         config = SmdaConfig()
         self.assertEqual(config.MAX_FUNCTION_CANDIDATES, 200000)
         self.assertEqual(config.MAX_CALL_REFS_PER_CANDIDATE, 2000)
+
+    def test_aarch64_reference_scan_honors_analysis_timeout(self):
+        # BL imm26=1 targets base+4; without timeout this seeds a reference candidate.
+        bl_to_next = (0x94000000 | 1).to_bytes(4, "little")
+        ret = (0xD65F03C0).to_bytes(4, "little")
+        binary = bl_to_next + ret + b"\x00" * 0x100
+        config = SmdaConfig()
+        config.MAX_FUNCTION_CANDIDATES = 0
+        manager = _make_aarch64_manager(config, binary)
+        manager.locateReferenceCandidates()
+        self.assertIn(0x1004, manager.candidates)
+
+        manager_timeout = _make_aarch64_manager(config, binary)
+        manager_timeout.disassembly.analysis_timeout = True
+        manager_timeout.locateReferenceCandidates()
+        self.assertEqual(manager_timeout.candidates, {})
+
+    def test_aarch64_locate_candidates_aborts_between_passes(self):
+        # stp x29, x30, [sp, #-16]! is a recognized prologue; timeout after symbols
+        # must skip the prologue pass entirely.
+        stp_fp_lr = (0xA9BF7BFD).to_bytes(4, "little")
+        ret = (0xD65F03C0).to_bytes(4, "little")
+        binary = stp_fp_lr + ret
+        config = SmdaConfig()
+        config.MAX_FUNCTION_CANDIDATES = 0
+        manager = _make_aarch64_manager(config, binary)
+        manager.symbol_addresses = []
+        manager.disassembly.analysis_timeout = True
+        manager.locateCandidates()
+        self.assertEqual(manager.candidates, {})
 
 
 if __name__ == "__main__":

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -71,6 +71,98 @@ class TestCommonModels(unittest.TestCase):
 
         self.assertTrue(function.isApiThunk())
 
+    def test_aarch64_num_calls_and_returns(self):
+        report = SmdaReport()
+        report.architecture = "aarch64"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {
+            0x1000: [
+                SmdaInstruction((0x1000, "94000001", "bl", "#0x1004")),
+                SmdaInstruction((0x1004, "d63f0000", "blr", "x0")),
+                SmdaInstruction((0x1008, "d65f0bff", "retaa", "")),
+            ]
+        }
+
+        self.assertEqual(function.num_calls, 2)
+        self.assertEqual(function.num_returns, 1)
+
+    def test_aarch64_num_returns_counts_pac_and_exception_returns(self):
+        report = SmdaReport()
+        report.architecture = "aarch64"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {
+            0x1000: [
+                SmdaInstruction((0x1000, "d65f0fff", "retab", "")),
+            ],
+            0x1004: [
+                SmdaInstruction((0x1004, "d69f0bff", "eretaa", "")),
+            ],
+        }
+
+        self.assertEqual(function.num_returns, 2)
+
+    def test_aarch64_is_api_thunk_recognizes_branch(self):
+        report = SmdaReport()
+        report.architecture = "aarch64"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {0x1000: [SmdaInstruction((0x1000, "d61f0200", "br", "x16"))]}
+        function.apirefs = {0x1000: ("libc.so", "printf")}
+
+        self.assertTrue(function.isApiThunk())
+
+        function.blocks = {0x1000: [SmdaInstruction((0x1000, "14000000", "b", "#0x1000"))]}
+        self.assertTrue(function.isApiThunk())
+
+    def test_aarch64_is_api_thunk_recognizes_multi_insn_plt(self):
+        # ELF/Mach-O import stubs are adrp+ldr(+add)+br, optionally prefixed with bti/nop.
+        report = SmdaReport()
+        report.architecture = "aarch64"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x402000
+        function.blocks = {
+            0x402000: [
+                SmdaInstruction((0x402000, "d503245f", "bti", "c")),
+                SmdaInstruction((0x402004, "b0000010", "adrp", "x16, #0x403000")),
+                SmdaInstruction((0x402008, "f9400e11", "ldr", "x17, [x16, #0x18]")),
+                SmdaInstruction((0x40200C, "91006210", "add", "x16, x16, #0x18")),
+                SmdaInstruction((0x402010, "d61f0220", "br", "x17")),
+            ]
+        }
+        function.apirefs = {0x402010: ("libc.so", "puts")}
+
+        self.assertTrue(function.isApiThunk())
+
+        # A real function body (stp frame + bl) with an API ref is not a thunk.
+        function.blocks = {
+            0x402000: [
+                SmdaInstruction((0x402000, "a9bf7bfd", "stp", "x29, x30, [sp, #-0x10]!")),
+                SmdaInstruction((0x402004, "94000001", "bl", "#0x402008")),
+                SmdaInstruction((0x402008, "d65f03c0", "ret", "")),
+            ]
+        }
+        function.apirefs = {0x402004: ("libc.so", "puts")}
+        self.assertFalse(function.isApiThunk())
+
+    def test_cil_num_calls_counts_callvirt_and_calli(self):
+        report = SmdaReport()
+        report.architecture = "cil"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {
+            0x1000: [
+                SmdaInstruction((0x1000, "28", "call", "0x06000001")),
+                SmdaInstruction((0x1005, "6f", "callvirt", "0x0a000002")),
+                SmdaInstruction((0x100A, "29", "calli", "0x11000003")),
+                SmdaInstruction((0x100F, "2a", "ret", "")),
+            ]
+        }
+
+        self.assertEqual(function.num_calls, 3)
+        self.assertEqual(function.num_returns, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -146,6 +146,24 @@ class TestCommonModels(unittest.TestCase):
         function.apirefs = {0x402004: ("libc.so", "puts")}
         self.assertFalse(function.isApiThunk())
 
+    def test_aarch64_is_api_thunk_rejects_argument_setting_wrapper(self):
+        # A wrapper that sets up an argument before tail-branching to an import
+        # is a real function, not an import stub - mov/movz/movk/movn/ldp never
+        # appear in a genuine ELF/Mach-O import-stub body.
+        report = SmdaReport()
+        report.architecture = "aarch64"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {
+            0x1000: [
+                SmdaInstruction((0x1000, "52800020", "mov", "w0, #1")),
+                SmdaInstruction((0x1004, "14000000", "b", "#0x1004")),
+            ]
+        }
+        function.apirefs = {0x1004: ("libc.so", "exit")}
+
+        self.assertFalse(function.isApiThunk())
+
     def test_cil_num_calls_counts_callvirt_and_calli(self):
         report = SmdaReport()
         report.architecture = "cil"
@@ -162,6 +180,26 @@ class TestCommonModels(unittest.TestCase):
 
         self.assertEqual(function.num_calls, 3)
         self.assertEqual(function.num_returns, 1)
+
+    def test_cil_is_api_thunk_recognizes_callvirt(self):
+        report = SmdaReport()
+        report.architecture = "cil"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {0x1000: [SmdaInstruction((0x1000, "6f", "callvirt", "0x0a000002"))]}
+        function.apirefs = {0x1000: ("mscorlib.dll", "WriteLine")}
+
+        self.assertTrue(function.isApiThunk())
+
+    def test_dalvik_is_api_thunk_recognizes_invoke(self):
+        report = SmdaReport()
+        report.architecture = "dalvik"
+        function = SmdaFunction(smda_report=report)
+        function.offset = 0x1000
+        function.blocks = {0x1000: [SmdaInstruction((0x1000, "6e10", "invoke-virtual", "{v0}, Ljava/io/PrintStream;"))]}
+        function.apirefs = {0x1000: ("Ljava/io/PrintStream;", "println")}
+
+        self.assertTrue(function.isApiThunk())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three AArch64 accuracy/robustness fixes plus a CI addition, each its own commit:

1. **Report-metric accuracy** — `num_calls`, `num_returns`, and `isApiThunk()` were x86-hardcoded (only counted `call`/`ret`/`retn`, only recognized single-instruction `jmp`/`call` thunks). Now architecture-aware for aarch64 (bl/blr calls, ret/retaa/retab/eret*/drps returns, multi-instruction adrp+ldr+br thunks) and cil (call/calli/callvirt).
2. **AArch64 indirect-jump API attribution** — a `br`/`bra*` landing in a resolved PLT/GOT stub now records an apiref via the existing `_resolvePltGotSlot`/`_handleApiTarget` helpers, falling back to the jumptable analyzer otherwise. Removed 3 leftover debug `print()`s.
3. **AArch64 candidate-scan timeouts** — the five candidate-discovery passes (symbol/reference/address-ref/data-pointer/prologue) now honor the same `_candidateTimeoutTripped()` guard the x86 candidate manager already uses, so a pathological binary can't hang candidate discovery.
4. **CI** — added the existing `aarch64_static` fixture to the perf/correctness-gate benchmark matrix.

## Details

### 1. Report metrics (`src/smda/common/SmdaFunction.py`)

- `num_calls`/`num_returns` branch on `smda_report.architecture` and pull the right mnemonic set per backend (aarch64 sets from `src/smda/aarch64/definitions.py`; cil adds `calli`/`callvirt`).
- `isApiThunk()` gained `_isAArch64ApiThunk()`, recognizing the multi-instruction `adrp+ldr(+add)+br` PLT/Mach-O-stub shape (optionally `bti`/`nop`-prefixed), bounded to 8 instructions and a fixed allowed-mnemonic body set.
- Follow-up fix in the same PR (caught by a sibling sweep before shipping): the body-mnemonic set originally included `mov`/`movz`/`movk`/`movn`/`ldp`, none of which appear in a real import-stub shape — this let an argument-setting tailcall wrapper (`mov w0, #1; b api@plt`) misclassify as a thunk. Trimmed to the mnemonics that actually appear in ELF/Mach-O stubs. The non-aarch64 fallback also still hardcoded `jmp`/`call` for every architecture; fixed so cil (`calli`/`callvirt`/`jmp`) and dalvik (`invoke-*`) single-instruction thunks are recognized too, matching what `num_calls` already knows for those backends.

### 2. Indirect-jump PLT/GOT resolution (`src/smda/aarch64/AArch64Backend.py`)

- Import stubs are sometimes recovered as their own function (rather than inlined at a call site); previously the `br` terminating such a stub only fed the jumptable analyzer, so no apiref was ever recorded for GOT slots reached via a bare indirect `br`. This mirrors the existing direct-call/tailcall PLT resolution (already wired for `bl` and unconditional `b`), extending it to the `INDIRECT_JUMP_INS` (`br`/`braa`/`brab`/`braaz`/`brabz`) path.
- Falls back to the pre-existing jumptable-target logic whenever `_resolvePltGotSlot` returns `None` or the target doesn't resolve to an API — byte-identical to prior behavior for all non-stub indirect jumps.

### 3. Candidate-scan timeout guards (`src/smda/aarch64/FunctionCandidateManager.py`)

- Extends the timeout-guard pattern already used by `intel/FunctionCandidateManager.py` to AArch64's five candidate-scan passes, checked every 4096 iterations in the byte-scanning loops (and once per pass in `locateCandidates()`), so scanning a large or adversarial binary can't hang without bound.

## Validation

```
make lint
python -m pytest tests/test*
```

Full suite green: 417 passed, 1 skipped, 480 subtests. `ruff check`/`ruff format --check` clean on the whole tree.

New/updated regression tests in `tests/testAArch64Disassembler.py`, `tests/testCandidateSafeguards.py`, and `tests/testCommonModels.py`, including a test proving the argument-setting-wrapper misclassification is fixed (`test_aarch64_is_api_thunk_rejects_argument_setting_wrapper`) and new cil/dalvik `isApiThunk()` coverage.

## Review notes

- Commit 1 (report metrics) has no dependency on commits 2/3; all three are stacked here for convenience.
- Two known, intentionally-deferred gaps surfaced while reviewing this change (not fixed here, noted for a future follow-up):
  - A conditional tail-branch (`cbz`/`cbnz`/`tbz`/`tbnz`/`b.<cond>`) straight into a PLT/GOT stub is not yet resolved to an API reference — same rarity/severity class as the existing x86 conditional-tailcall gap.
  - PAC-hardened import stubs (`adrp, add, ldr, autia1716, br`) and arm64e `braa`-terminated stubs aren't resolved by `_resolvePltGotSlot`'s current 4-instruction/plain-`br` decode window.
