### PR TITLE
refactor(aarch64): dedup shared raw-word GOT/reference decode constants

### DIFF
--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -24,12 +24,16 @@ from .definitions import (
     EXCEPTION_RETURN_INS,
     INDIRECT_JUMP_INS,
     INSTRUCTION_SIZE,
+    LDR_UNSIGNED_64_MASK,
+    LDR_UNSIGNED_64_VALUE,
     NOP,
     RET_INS,
     UNCOND_JUMP_INS,
     adrp_page_value,
     is_bti_landing_pad,
     is_function_prologue,
+    rd_field,
+    rn_field,
 )
 from .FunctionAnalysisState import FunctionAnalysisState
 from .FunctionCandidateManager import FunctionCandidateManager
@@ -38,8 +42,6 @@ LOGGER = logging.getLogger(__name__)
 
 # capstone renders AArch64 immediates as "#0x....": match the hex operands.
 _HEX_OPERAND = re.compile(r"0x[0-9a-fA-F]+")
-_LDR_UNSIGNED_64_MASK = 0xFFC00000
-_LDR_UNSIGNED_64_VALUE = 0xF9400000
 
 
 class AArch64Backend(ArchBackend):
@@ -269,21 +271,21 @@ class AArch64Backend(ArchBackend):
             if word is None:
                 return None
 
-            rd = word & 0x1F
+            rd = rd_field(word)
             if (word & ADRP_MASK) == ADRP_VALUE:
                 registers[rd] = adrp_page_value(word, word_addr)
             elif (word & ADD_IMM64_MASK) == ADD_IMM64_VALUE:
-                rn = (word >> 5) & 0x1F
+                rn = rn_field(word)
                 if rn not in registers:
                     return None
                 registers[rd] = registers[rn] + ((word >> 10) & 0xFFF)
-            elif (word & _LDR_UNSIGNED_64_MASK) == _LDR_UNSIGNED_64_VALUE:
-                rn = (word >> 5) & 0x1F
+            elif (word & LDR_UNSIGNED_64_MASK) == LDR_UNSIGNED_64_VALUE:
+                rn = rn_field(word)
                 if rn not in registers:
                     return None
                 registers[rd] = registers[rn] + (((word >> 10) & 0xFFF) * 8)
             elif (word & BR_MASK) == BR_VALUE:
-                rn = (word >> 5) & 0x1F
+                rn = rn_field(word)
                 return word_addr + INSTRUCTION_SIZE, registers.get(rn)
             else:
                 return None

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -43,6 +43,8 @@ from .definitions import (
     BR_MASK,
     BR_VALUE,
     INSTRUCTION_SIZE,
+    LDR_UNSIGNED_64_MASK,
+    LDR_UNSIGNED_64_VALUE,
     NOP,
     RET_MASK,
     RET_VALUE,
@@ -50,6 +52,8 @@ from .definitions import (
     is_bti_landing_pad,
     is_conditional_branch,
     is_function_prologue,
+    rd_field,
+    rn_field,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -196,7 +200,7 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                     continue
                 word = int.from_bytes(binary[offset : offset + INSTRUCTION_SIZE], "little")
                 if (word & ADRP_MASK) == ADRP_VALUE:
-                    pages[word & 0x1F] = adrp_page_value(word, addr)
+                    pages[rd_field(word)] = adrp_page_value(word, addr)
                 elif (word & ADRP_MASK) == ADR_VALUE:
                     immlo = (word >> 29) & 0x3
                     immhi = (word >> 5) & 0x7FFFF
@@ -204,15 +208,15 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                     if imm & (1 << 20):
                         imm -= 1 << 21
                     seed(addr + imm, addr)
-                    pages.pop(word & 0x1F, None)
+                    pages.pop(rd_field(word), None)
                 elif (word & ADD_IMM64_MASK) == ADD_IMM64_VALUE:
-                    rn = (word >> 5) & 0x1F
+                    rn = rn_field(word)
                     if rn in pages:
                         seed(pages[rn] + ((word >> 10) & 0xFFF), addr)
-                    pages.pop(word & 0x1F, None)
-                elif (word & 0xFFC00000) == 0xF9400000:  # ldr Xt, [Xn, #imm]
-                    rn = (word >> 5) & 0x1F
-                    rd = word & 0x1F
+                    pages.pop(rd_field(word), None)
+                elif (word & LDR_UNSIGNED_64_MASK) == LDR_UNSIGNED_64_VALUE:  # ldr Xt, [Xn, #imm]
+                    rn = rn_field(word)
+                    rd = rd_field(word)
                     if rn in pages:
                         imm = ((word >> 10) & 0xFFF) * 8
                         slot_addr = pages[rn] + imm
@@ -231,7 +235,7 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                 ):
                     pages.clear()  # control-flow edge: register provenance no longer holds
                 else:
-                    pages.pop(word & 0x1F, None)  # any other write invalidates the dest register
+                    pages.pop(rd_field(word), None)  # any other write invalidates the dest register
                 addr += INSTRUCTION_SIZE
 
     def locateReferenceCandidates(self):

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -104,6 +104,10 @@ ADR_VALUE = 0x10000000
 # add Xd, Xn, #imm12 — the lo12 of an adrp+add pair (sh=0 is required by the mask).
 ADD_IMM64_MASK = 0xFFC00000
 ADD_IMM64_VALUE = 0x91000000
+# ldr Xt, [Xn, #imm12] — unsigned-offset 64-bit load, the third leg of an
+# adrp+[add+]ldr GOT/data-pointer materialization.
+LDR_UNSIGNED_64_MASK = 0xFFC00000
+LDR_UNSIGNED_64_VALUE = 0xF9400000
 
 
 def adrp_page_value(word, pc):
@@ -118,6 +122,16 @@ def adrp_page_value(word, pc):
     if imm & (1 << 20):
         imm -= 1 << 21
     return (pc & ~0xFFF) + (imm << 12)
+
+
+def rd_field(word):
+    """Destination register index (bits [4:0]) of a raw AArch64 instruction word."""
+    return word & 0x1F
+
+
+def rn_field(word):
+    """First source register index (bits [9:5]) of a raw AArch64 instruction word."""
+    return (word >> 5) & 0x1F
 
 
 def is_conditional_branch(word):


### PR DESCRIPTION
## Summary

Follow-up to #179's `dataflow.py` extraction. Two AArch64 constant-tracking sites were flagged there as deliberately deferred because they decode raw instruction words directly rather than capstone operands, running in contexts where invoking capstone may be too costly:

- `AArch64Backend._walkGotThunk` / `_resolvePltGotSlot` — probes a single known address for the `adrp;[add;]ldr;br` GOT-thunk shape (PLT/GOT API resolution + whole-function thunk flagging).
- `FunctionCandidateManager.locateAddressRefCandidates` — a whole-image, timeout-guarded word scan seeding weak function candidates from materialized code pointers.

Each had independently re-derived the LDR unsigned-offset-64 mask/value (one as a private module constant, one as an inline literal) and repeated the same `rd`/`rn` register-field bit extraction. This PR extracts only the genuinely shared bit-level primitives into `definitions.py` — it does **not** unify the two loops with each other or with `dataflow.py`.

## Why not unify the loops themselves

The two loops have incompatible semantics, so a single shared abstraction would either weaken correctness or reintroduce the perf risk the original deferral was about:

- `_walkGotThunk` is a bounded (<=6 word) **strict shape-matcher** — it aborts on any unrecognized word, which is required to confirm an *exact* thunk shape.
- `locateAddressRefCandidates` is a whole-image, timeout-guarded **lossy forward tracker** — it invalidates-and-continues on any unrecognized word and clears on control-flow edges.

Forcing `dataflow.py`'s lossy-continue semantics onto `_walkGotThunk` could let a near-miss byte sequence pass as a thunk. Decoding every word of the whole-image sweep via capstone reintroduces the exact perf concern the class was deferred over in the first place.

## Changed behavior

None. This is a pure constant/helper extraction:
- `definitions.py`: adds `LDR_UNSIGNED_64_MASK`/`LDR_UNSIGNED_64_VALUE` (previously `AArch64Backend`'s private `_LDR_UNSIGNED_64_MASK`/`_LDR_UNSIGNED_64_VALUE`, and an inline `0xFFC00000`/`0xF9400000` literal in `FunctionCandidateManager`), plus `rd_field()`/`rn_field()` register-index helpers.
- `AArch64Backend.py` / `FunctionCandidateManager.py`: both raw-word sites now import and use the shared constants/helpers instead of their own copies.

## Validation

- `make lint` — clean.
- Targeted: `pytest tests/testAArch64Disassembler.py tests/testSmdaInstructionDetailAArch64.py tests/testAArch64EscaperCapstoneVerification.py tests/testAArch64MachoCorpus.py -q` — 116 passed, 86 subtests passed.
- Full: `pytest tests/test* -q` — 452 passed, 1 skipped, 491 subtests passed.
- Zero-behavior-change verification: ran a direct before/after comparison of `num_functions`/`num_instructions`/`status` across every sample in the real osx malware corpus (`tests/aarch64_macho_corpus`) — output was byte-identical before and after this change.
