### PR TITLE
perf(common): skip redundant aarch64 report-time data-ref re-derivation

### DIFF
--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -63,7 +63,18 @@ class SmdaInstruction:
                     if value is not None and value not in emitted and smda_report.isAddrWithinMemoryImage(value):
                         emitted.add(value)
                         data_refs.append(value)
-        elif smda_report.architecture == "aarch64" and self.operands and "0x" in self.operands:
+        elif (
+            smda_report.architecture == "aarch64"
+            and not smda_report.data_refs_from
+            and self.operands
+            and "0x" in self.operands
+        ):
+            # AArch64 CFG recovery derives per-instruction data refs with this same
+            # IMM/MEM(base==0)/in-image/not-in-code-area filter (AArch64Backend._recordDataRefs)
+            # and stores them in the report as data_refs_from, so re-deriving them here via a
+            # capstone re-decode is redundant whenever the report carries recorded refs. Only
+            # fall back for reports without any (e.g. serialized by versions predating
+            # xdata_refs_from).
             if self.getMnemonicGroup(AArch64InstructionEscaper) == "C":
                 self._data_refs = data_refs
                 yield from self._data_refs


### PR DESCRIPTION
## Summary
For AArch64 reports, `SmdaInstruction.getDataRefs()` re-decoded every non-control-flow instruction through capstone at report/consumer time to re-derive data refs that the backend already computed during CFG recovery. This gates that capstone fallback on the report carrying no recorded data refs, eliminating a duplicate whole-report capstone decode pass.

## Motivation
`AArch64Backend._recordDataRefs` walks every applicable instruction's detailed operands during CFG recovery with the exact filter `getDataRefs` re-applies later (`ARM64_OP_IMM` / `ARM64_OP_MEM` with `base==0`, in-image, not in code areas) and stores the results, which reach the report as `data_refs_from`. The report-time second pass (`bytes.fromhex` + `capstone.disasm` + operand walk per instruction) therefore re-derives values the first pass already yielded — measured at ~13-16% of total analysis wall time on the larger bundled AArch64 corpus fixtures.

## Changed behavior
- When an AArch64 report has a non-empty `data_refs_from` map (all natively analyzed reports, and deserialized reports produced by versions that emit `xdata_refs_from`), `getDataRefs()` now returns the recorded refs without the capstone re-derivation.
- The fallback still runs for AArch64 reports without recorded refs, e.g. reports serialized by versions predating `xdata_refs_from`, or IDA-exported reports (the IDA exporter does not populate `data_refs_from`), so those paths are unchanged.
- Intel is untouched: its report-time capstone pass is the primary source of data refs (only jump-table refs are recorded at CFG time), so it cannot take this shortcut.

## Validation
- Equivalence proof: a per-instruction diff of fallback-present vs fallback-absent results across all 13 bundled AArch64 fixtures (Mach-O corpus + the static ELF fixture) found **0 instructions out of 306,992** where the fallback contributed any ref not already recorded.
- Wall time (median of 3, full analysis with string extraction): Turtle 5935 ms -> 4931 ms (-16.9%), osx.gimmick 1473 ms -> 1310 ms (-11.1%).
- `make lint` clean; full `make test`: 452 passed, 1 skipped. The AArch64 corpus tests assert per-fixture data-ref counts and act as the regression net for this gate.
