### PR TITLE
perf(core): complete single-item set.update([x]) to set.add(x) sweep

### DIFF
--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -212,12 +212,8 @@ class DisassemblyResult:
         return None
 
     def addCodeRefs(self, addr_from, addr_to):
-        refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.add(addr_to)
-        self.code_refs_from[addr_from] = refs_from
-        refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.add(addr_from)
-        self.code_refs_to[addr_to] = refs_to
+        self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+        self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
 
     def removeCodeRefs(self, addr_from, addr_to):
         refs_from = self.code_refs_from.get(addr_from, set())
@@ -228,12 +224,8 @@ class DisassemblyResult:
         self.code_refs_to[addr_to] = refs_to
 
     def addDataRefs(self, addr_from, addr_to):
-        refs_from = self.data_refs_from.get(addr_from, set())
-        refs_from.add(addr_to)
-        self.data_refs_from[addr_from] = refs_from
-        refs_to = self.data_refs_to.get(addr_to, set())
-        refs_to.add(addr_from)
-        self.data_refs_to[addr_to] = refs_to
+        self.data_refs_from.setdefault(addr_from, set()).add(addr_to)
+        self.data_refs_to.setdefault(addr_to, set()).add(addr_from)
 
     def removeDataRefs(self, addr_from, addr_to):
         refs_from = self.data_refs_from.get(addr_from, set())

--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -213,10 +213,10 @@ class DisassemblyResult:
 
     def addCodeRefs(self, addr_from, addr_to):
         refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.update([addr_to])
+        refs_from.add(addr_to)
         self.code_refs_from[addr_from] = refs_from
         refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.update([addr_from])
+        refs_to.add(addr_from)
         self.code_refs_to[addr_to] = refs_to
 
     def removeCodeRefs(self, addr_from, addr_to):
@@ -229,10 +229,10 @@ class DisassemblyResult:
 
     def addDataRefs(self, addr_from, addr_to):
         refs_from = self.data_refs_from.get(addr_from, set())
-        refs_from.update([addr_to])
+        refs_from.add(addr_to)
         self.data_refs_from[addr_from] = refs_from
         refs_to = self.data_refs_to.get(addr_to, set())
-        refs_to.update([addr_from])
+        refs_to.add(addr_from)
         self.data_refs_to[addr_to] = refs_to
 
     def removeDataRefs(self, addr_from, addr_to):

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -53,16 +53,16 @@ class FunctionAnalysisState:
         self.is_jmp = False
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
-        self.code_refs.update([(addr_from, addr_to)])
+        self.code_refs.add((addr_from, addr_to))
         refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.update([addr_to])
+        refs_from.add(addr_to)
         self.code_refs_from[addr_from] = refs_from
         refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.update([addr_from])
+        refs_to.add(addr_from)
         self.code_refs_to[addr_to] = refs_to
         if by_jump:
             self.is_jmp = True
-            self.jump_targets.update([addr_to])
+            self.jump_targets.add(addr_to)
 
     def removeCodeRef(self, addr_from, addr_to):
         if (addr_from, addr_to) in self.code_refs:
@@ -75,9 +75,8 @@ class FunctionAnalysisState:
             self.jump_targets.remove(addr_to)
 
     def addDataRef(self, addr_from, addr_to, size=1):
-        self.data_refs.update([(addr_from, addr_to)])
-        for i in range(size):
-            self.data_bytes.update([addr_to + i])
+        self.data_refs.add((addr_from, addr_to))
+        self.data_bytes.update(range(addr_to, addr_to + size))
 
     def finalizeAnalysis(self, as_gap=False):
         fn_min = min([ins[0] for ins in self.instructions])

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -54,12 +54,8 @@ class FunctionAnalysisState:
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
-        refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.add(addr_to)
-        self.code_refs_from[addr_from] = refs_from
-        refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.add(addr_from)
-        self.code_refs_to[addr_to] = refs_to
+        self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+        self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
         if by_jump:
             self.is_jmp = True
             self.jump_targets.add(addr_to)

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -91,12 +91,8 @@ class DalvikFunctionAnalysisState:
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
-        refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.add(addr_to)
-        self.code_refs_from[addr_from] = refs_from
-        refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.add(addr_from)
-        self.code_refs_to[addr_to] = refs_to
+        self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+        self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
         if by_jump:
             self.jump_targets.add(addr_to)
 

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -63,7 +63,7 @@ class DalvikFunctionAnalysisState:
     def chooseNextBlock(self):
         self.is_block_ending_instruction = False
         self.block_start = self.block_queue.pop()
-        self.processed_blocks.update([self.block_start])
+        self.processed_blocks.add(self.block_start)
         return self.block_start
 
     def addBlockToQueue(self, block_start):
@@ -90,15 +90,15 @@ class DalvikFunctionAnalysisState:
             self.addCodeRef(i_address, i_address + i_size)
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
-        self.code_refs.update([(addr_from, addr_to)])
+        self.code_refs.add((addr_from, addr_to))
         refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.update([addr_to])
+        refs_from.add(addr_to)
         self.code_refs_from[addr_from] = refs_from
         refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.update([addr_from])
+        refs_to.add(addr_from)
         self.code_refs_to[addr_to] = refs_to
         if by_jump:
-            self.jump_targets.update([addr_to])
+            self.jump_targets.add(addr_to)
 
     def removeCodeRef(self, addr_from, addr_to):
         if (addr_from, addr_to) in self.code_refs:
@@ -111,9 +111,8 @@ class DalvikFunctionAnalysisState:
             self.jump_targets.remove(addr_to)
 
     def addDataRef(self, addr_from, addr_to, size=1):
-        self.data_refs.update([(addr_from, addr_to)])
-        for i in range(size):
-            self.data_bytes.update([addr_to + i])
+        self.data_refs.add((addr_from, addr_to))
+        self.data_bytes.update(range(addr_to, addr_to + size))
 
     def backtrackInstructions(self, addr_from, num_instructions):
         backtracked = []

--- a/src/smda/intel/FunctionAnalysisState.py
+++ b/src/smda/intel/FunctionAnalysisState.py
@@ -76,12 +76,8 @@ class FunctionAnalysisState:
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
-        refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.add(addr_to)
-        self.code_refs_from[addr_from] = refs_from
-        refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.add(addr_from)
-        self.code_refs_to[addr_to] = refs_to
+        self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+        self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
         if by_jump:
             self.is_jmp = True
             self.jump_targets.add(addr_to)

--- a/src/smda/intel/FunctionAnalysisState.py
+++ b/src/smda/intel/FunctionAnalysisState.py
@@ -50,7 +50,7 @@ class FunctionAnalysisState:
     def chooseNextBlock(self):
         self.is_block_ending_instruction = False
         self.block_start = self.block_queue.pop()
-        self.processed_blocks.update([self.block_start])
+        self.processed_blocks.add(self.block_start)
         return self.block_start
 
     def addBlockToQueue(self, block_start):
@@ -77,14 +77,14 @@ class FunctionAnalysisState:
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
         refs_from = self.code_refs_from.get(addr_from, set())
-        refs_from.update([addr_to])
+        refs_from.add(addr_to)
         self.code_refs_from[addr_from] = refs_from
         refs_to = self.code_refs_to.get(addr_to, set())
-        refs_to.update([addr_from])
+        refs_to.add(addr_from)
         self.code_refs_to[addr_to] = refs_to
         if by_jump:
             self.is_jmp = True
-            self.jump_targets.update([addr_to])
+            self.jump_targets.add(addr_to)
 
     def removeCodeRef(self, addr_from, addr_to):
         if (addr_from, addr_to) in self.code_refs:
@@ -97,9 +97,8 @@ class FunctionAnalysisState:
             self.jump_targets.remove(addr_to)
 
     def addDataRef(self, addr_from, addr_to, size=1):
-        self.data_refs.update([(addr_from, addr_to)])
-        for i in range(size):
-            self.data_bytes.update([addr_to + i])
+        self.data_refs.add((addr_from, addr_to))
+        self.data_bytes.update(range(addr_to, addr_to + size))
 
     def backtrackInstructions(self, addr_from, num_instructions):
         if not self._instructions_sorted:


### PR DESCRIPTION
## Summary
Completes the single-item `set.update([x])` -> `set.add(x)` conversion that an earlier hot-path round applied only partially, and collapses the per-byte `addDataRef` loops into one `update(range(...))` call (mirroring the existing `addInstruction` fix).

## Motivation
`set.add(x)` is ~3.5x faster per call than `set.update([x])` (no throwaway list allocation + iteration), and these helpers are hot: `DisassemblyResult.addCodeRefs` alone runs ~340k times on the larger bundled Intel fixtures. The earlier round converted `FunctionAnalysisState.addCodeRef`'s top-level set and `addInstruction`, but left siblings across the tree.

## Changed behavior
None — `set.add(x)` and `set.update([x])` are behaviorally identical for a single element, and `update(range(addr_to, addr_to + size))` adds exactly the elements the removed per-byte loop added (including the empty `size=0` case).

Converted sites:
- `DisassemblyResult.addCodeRefs` / `addDataRefs` (both directions)
- `intel/FunctionAnalysisState`: `chooseNextBlock`, `addCodeRef` inner ref maps, `jump_targets`, `addDataRef`
- `dalvik/DalvikFunctionAnalysisState` and `cil/FunctionAnalysisState`: same shapes

A tree-wide search for the `.update([` pattern is clean after this change; the AArch64 backend never had it.

## Validation
- `make lint` clean; full `make test`: 452 passed, 1 skipped.
