### PR TITLE
fix(common): raise NotImplementedError in getCapstone() for unsupported architectures

### DIFF
--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -190,6 +190,10 @@ class SmdaReport:
 
     def getCapstone(self):
         if self.capstone is None:
+            if self.architecture is not None and self.architecture not in ("intel", "aarch64"):
+                raise NotImplementedError(
+                    f"getCapstone() is only available for Intel and AArch64, not '{self.architecture}'"
+                )
             if self.architecture == "aarch64":
                 self.capstone = Cs(CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN)
             else:

--- a/tests/testSmdaReportBuffer.py
+++ b/tests/testSmdaReportBuffer.py
@@ -89,5 +89,20 @@ class TestSmdaReportBufferPacking(unittest.TestCase):
         self.assertNotIn("buffer", report.toDict())
 
 
+class TestSmdaReportGetCapstone(unittest.TestCase):
+    def test_supported_architectures_return_engine(self):
+        for architecture in ("intel", "aarch64", None):
+            report = _make_minimal_report()
+            report.architecture = architecture
+            self.assertIsNotNone(report.getCapstone())
+
+    def test_unsupported_architectures_raise(self):
+        for architecture in ("cil", "dalvik"):
+            report = _make_minimal_report()
+            report.architecture = architecture
+            with self.assertRaises(NotImplementedError):
+                report.getCapstone()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`SmdaReport.getCapstone()` dispatches on the report architecture but only knows `aarch64` explicitly — every other value silently falls through to an x86 capstone instance. For a `cil` or `dalvik` report this hands the caller a wrong-architecture disassembler instead of a clear error (capstone has no CIL/Dalvik support at all; those backends decode via dncil and SMDA's own Dalvik opcode decoder).

This mirrors the guard that `SmdaInstruction.getDetailed()` already has and raises `NotImplementedError` for architectures other than `intel`/`aarch64` (with `architecture is None` still treated as the legacy intel default). Complements the `getInstructionEscaper()` exposure from v4.2.12: now both public per-architecture accessors on a report either return the correct object or fail loudly.

## Changed behavior

- `getCapstone()` on a `cil`/`dalvik` (or any future unsupported-architecture) report raises `NotImplementedError` instead of returning an x86 `Cs` instance.
- No behavior change for `intel`, `aarch64`, or legacy reports without an architecture field.
- No in-tree caller is affected: `SmdaInstruction.getDetailed()` already guards these architectures before calling, and the AArch64 escaper only calls it for aarch64 reports.

## Validation

- `make lint` — clean.
- `make test` — 454 passed, 1 skipped.
- New regression tests in `tests/testSmdaReportBuffer.py`: supported architectures (`intel`, `aarch64`, `None`) return an engine; `cil`/`dalvik` raise `NotImplementedError`.
