### PR TITLE
feat(aarch64): platform candidate boosts - PE exception directory, ELF .eh_frame, Mach-O metadata pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 # SMDA
 
 SMDA is a minimalist recursive disassembler library that is optimized for accurate Control Flow Graph (CFG) recovery from memory dumps.
-It is based on [Capstone](http://www.capstone-engine.org/) and currently supports x86/x64 Intel machine code, experimental CIL (.NET) disassembly, and Dalvik bytecode from raw DEX files.
-As input, arbitrary memory dumps (ideally with known base address) can be processed, and raw DEX files can be analyzed directly.
+It is based on [Capstone](http://www.capstone-engine.org/) and currently provides native backends for x86/x64 Intel and AArch64 (ARM64) machine code, experimental CIL (.NET) disassembly, and Dalvik bytecode from raw DEX files.
+As input, PE, ELF, and Mach-O files (including fat/universal binaries), arbitrary memory dumps (ideally with known base address), and raw DEX files can be processed.
 The output is a collection of functions, basic blocks, and instructions with their respective edges between blocks and functions (in/out).
 Optionally, references to the Windows API can be inferred by using the ApiScout method.
 
@@ -50,7 +50,7 @@ There is also a demo script:
 
 For Dalvik, the current scope is raw single-DEX inputs. APK, multi-dex container handling, and ODEX/VDEX/CDEX runtime-artifact analysis are not yet first-class workflows in SMDA.
 
-The code should be fully compatible with Python 3.8+.
+The code should be fully compatible with Python 3.10+.
 Further explanation on the innerworkings follow in separate publications but will be referenced here.
 
 To take full advantage of SMDA's capabilities, make sure to (optionally) install:

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -31,6 +31,9 @@ class SmdaConfig:
     # improve disassembly by resolving references through data flows
     USE_ALIGNMENT = True
     USE_SYMBOLS_AS_CANDIDATES = True
+    # seed AArch64 function candidates from the PE ARM64 exception directory (classic 0xAA64
+    # images only); off until validated against real ARM64 PE samples with independent labels
+    USE_PE_ARM64_PDATA_CANDIDATES = False
     RESOLVE_REGISTER_CALLS = True
     # limit this to avoid blowing up analysis time for weird samples
     MAX_INDIRECT_CALLS_PER_BASIC_BLOCK = 50

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -34,6 +34,9 @@ class SmdaConfig:
     # seed AArch64 function candidates from the PE ARM64 exception directory (classic 0xAA64
     # images only); off until validated against real ARM64 PE samples with independent labels
     USE_PE_ARM64_PDATA_CANDIDATES = False
+    # promote unclaimed ELF .eh_frame FDE starts as late AArch64 candidates (after the primary
+    # pass, before gap analysis); off until validated against ground-truth function boundaries
+    USE_ELF_EH_FRAME_CANDIDATES = False
     RESOLVE_REGISTER_CALLS = True
     # limit this to avoid blowing up analysis time for weird samples
     MAX_INDIRECT_CALLS_PER_BASIC_BLOCK = 50

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -37,6 +37,10 @@ class SmdaConfig:
     # promote unclaimed ELF .eh_frame FDE starts as late AArch64 candidates (after the primary
     # pass, before gap analysis); off until validated against ground-truth function boundaries
     USE_ELF_EH_FRAME_CANDIDATES = False
+    # extend the AArch64 adr/adrp address-materialization scan to Mach-O instruction sections,
+    # recording targets as weak address evidence; off until validated with exact-address ground
+    # truth for the Mach-O corpus
+    USE_MACHO_ADDRESS_REF_CANDIDATES = False
     RESOLVE_REGISTER_CALLS = True
     # limit this to avoid blowing up analysis time for weird samples
     MAX_INDIRECT_CALLS_PER_BASIC_BLOCK = 50

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -64,15 +64,16 @@ LOGGER = logging.getLogger(__name__)
 
 class FunctionCandidateManager(_IntelFunctionCandidateManager):
     def init(self, disassembly, cbAnalysisTimeout=None):
+        # Reset the memoized executable-section ranges and Mach-O fixup state
+        # BEFORE base initialization: super().init() runs candidate discovery,
+        # so a reused manager instance would otherwise consume the previous
+        # binary's cached data during the scans.
+        self._exec_ranges = None
+        self._macho_fixup_state = None
         super().init(disassembly, cbAnalysisTimeout)
         # The base init() builds an x86 capstone purely for its NOP-based gap scan,
         # which this backend disables (see nextGapCandidate); drop the stale handle.
         self.capstone = None
-        # Drop the memoized executable-section ranges and Mach-O fixup state so a
-        # reused manager instance recomputes them for the new binary instead of
-        # leaking stale data.
-        self._exec_ranges = None
-        self._macho_fixup_state = None
 
     def locateCandidates(self):
         # AArch64 candidate discovery: symbols, PE ARM64 exception-directory entries
@@ -235,7 +236,10 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             if self.disassembly.isCode(fde_start):
                 continue
             self.ensureCandidate(fde_start)
-            accepted.append(fde_start)
+            # MAX_FUNCTION_CANDIDATES can reject the registration; never analyze
+            # a start that was not actually recorded
+            if fde_start in self.candidates:
+                accepted.append(fde_start)
         # register ALL accepted starts as known function starts before analyzing
         # any of them: the branch classifier consults getFunctionStartCandidates()
         # during analysis, so an earlier deferred function could otherwise absorb

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -16,8 +16,13 @@ x86 byte-level scans with AArch64-aware ones:
   unanalyzed executable bytes, recovering unreferenced / indirect-only functions
   that none of the above reaches.
 
-x86-only passes (PLT/stub chains, PE ``.pdata`` exception tables) do not apply and
-remain future iterate-steps; for a statically linked ELF there is no PLT to recover.
+* PE ARM64 exception-directory discovery (opt-in via
+  ``USE_PE_ARM64_PDATA_CANDIDATES``) seeds guaranteed function starts from the
+  image's ``.pdata`` RUNTIME_FUNCTION records, in place of the x86-shaped
+  12-byte-record pass.
+
+The x86-only PLT/stub-chain pass does not apply and remains a future
+iterate-step; for a statically linked ELF there is no PLT to recover.
 """
 
 import contextlib
@@ -66,11 +71,15 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         self._exec_ranges = None
 
     def locateCandidates(self):
-        # AArch64 candidate discovery: symbols, BL call references, stored function
-        # pointers (.init_array/.fini_array + data tables), then entry prologues.
-        # The x86-only PLT/stub-chain and PE .pdata passes do not apply and are
-        # omitted; the NOP-based gap scan is disabled (see nextGapCandidate).
+        # AArch64 candidate discovery: symbols, PE ARM64 exception-directory entries
+        # (opt-in), BL call references, stored function pointers (.init_array/
+        # .fini_array + data tables), then entry prologues. The x86-only PLT/
+        # stub-chain pass does not apply and is omitted; the NOP-based gap scan is
+        # disabled (see nextGapCandidate).
         self.locateSymbolCandidates()
+        if self._candidateTimeoutTripped():
+            return
+        self.locatePeExceptionCandidates()
         if self._candidateTimeoutTripped():
             return
         self.locateReferenceCandidates()
@@ -102,6 +111,86 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             if section.virtual_address and (flags & exec_flag):
                 ranges.append((section.virtual_address, section.virtual_address + section.size))
         return ranges
+
+    @staticmethod
+    def _peExecutableSectionRanges(lief_binary, base_addr):
+        # Absolute [start, end) VAs of executable PE sections (IMAGE_SCN_MEM_EXECUTE).
+        ranges = []
+        for section in lief_binary.sections:
+            if section.characteristics & 0x20000000 and section.virtual_size:
+                section_start = base_addr + section.virtual_address
+                ranges.append((section_start, section_start + section.virtual_size))
+        return ranges
+
+    def _isValidArm64UnwindInfo(self, xdata_rva):
+        # ARM64 .xdata header word: FunctionLength[17:0] (in words, must be nonzero),
+        # Vers[19:18] (only version 0 is defined), X[20], E[21], EpilogCount[26:22],
+        # CodeWords[31:27]. Records are 4-byte aligned and must lie inside the image.
+        if xdata_rva == 0 or xdata_rva % 4 != 0:
+            return False
+        header = self.disassembly.getRawBytes(xdata_rva, 4)
+        if header is None or len(header) < 4:
+            return False
+        header_word = int.from_bytes(header, "little")
+        function_length = header_word & 0x3FFFF
+        version = (header_word >> 18) & 0x3
+        return version == 0 and function_length > 0
+
+    def locatePeExceptionCandidates(self):
+        # PE ARM64 exception directory: every RUNTIME_FUNCTION record names a
+        # guaranteed function (or fragment) start, so accepted entries go through
+        # the high-confidence exception-candidate path. Classic ARM64 (0xAA64)
+        # images only; ARM64X/ARM64EC hybrids interleave x64 code and metadata
+        # and are skipped. Bounds come from the Exception Directory data
+        # directory's exact RVA/size, not page-rounded .pdata section bounds.
+        if not self.config.USE_PE_ARM64_PDATA_CANDIDATES:
+            return
+        binary_info = self.disassembly.binary_info
+        lief_binary = binary_info.getLiefBinary()
+        if not isinstance(lief_binary, lief.PE.Binary):
+            return
+        if lief_binary.header.machine != lief.PE.Header.MACHINE_TYPES.ARM64:
+            return
+        # is_arm64x/is_arm64ec and chpe_metadata need lief >= 0.17; on older lief an
+        # ARM64X hybrid cannot be told apart, so absence of the accessors means skip.
+        if getattr(lief_binary, "is_arm64x", True) or getattr(lief_binary, "is_arm64ec", True):
+            return
+        load_config = getattr(lief_binary, "load_configuration", None)
+        if load_config is not None and getattr(load_config, "chpe_metadata", None) is not None:
+            return
+        exception_dir = lief_binary.data_directory(lief.PE.DataDirectory.TYPES.EXCEPTION_TABLE)
+        if exception_dir is None or not exception_dir.rva or not exception_dir.size:
+            return
+        base_addr = binary_info.base_addr
+        exec_ranges = self._peExecutableSectionRanges(lief_binary, base_addr)
+        if not exec_ranges:
+            return
+        # 8-byte records: <BeginRVA, UnwindData>; UnwindData bits 0-1 select the format
+        for record_index, record_rva in enumerate(
+            range(exception_dir.rva, exception_dir.rva + exception_dir.size - 7, 8)
+        ):
+            if record_index % 4096 == 0 and self._candidateTimeoutTripped():
+                return
+            packed_entry = self.disassembly.getRawBytes(record_rva, 8)
+            if packed_entry is None or len(packed_entry) < 8:
+                break
+            begin_rva, unwind_data = struct.unpack("<II", packed_entry)
+            if begin_rva == 0:
+                break
+            flag = unwind_data & 0x3
+            if flag == 0:
+                # UnwindData is the RVA of a full .xdata record; validate its header
+                if not self._isValidArm64UnwindInfo(unwind_data):
+                    continue
+            elif flag != 1:
+                # flag 2: packed fragment of another function's body; flag 3: reserved
+                continue
+            if begin_rva % INSTRUCTION_SIZE != 0:
+                continue
+            addr = base_addr + begin_rva
+            if not any(start <= addr < end for start, end in exec_ranges):
+                continue
+            self.addExceptionCandidate(addr)
 
     def locateDataPointerCandidates(self):
         # Seed candidates from stored function pointers. ELF .init_array/.fini_array

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -56,8 +56,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class FunctionCandidateManager(_IntelFunctionCandidateManager):
-    def init(self, disassembly):
-        super().init(disassembly)
+    def init(self, disassembly, cbAnalysisTimeout=None):
+        super().init(disassembly, cbAnalysisTimeout)
         # The base init() builds an x86 capstone purely for its NOP-based gap scan,
         # which this backend disables (see nextGapCandidate); drop the stale handle.
         self.capstone = None

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -33,6 +33,7 @@ import lief
 
 from smda.common.EhFrameDecoder import decodeEhFrameFdeRanges
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager as _IntelFunctionCandidateManager
+from smda.utility.MachoBinary import get_active_macho_binary, get_macho_address_adjustment, get_macho_stub_ranges
 
 from .definitions import (
     ADD_IMM64_MASK,
@@ -67,9 +68,11 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         # The base init() builds an x86 capstone purely for its NOP-based gap scan,
         # which this backend disables (see nextGapCandidate); drop the stale handle.
         self.capstone = None
-        # Drop the memoized executable-section ranges so a reused manager instance
-        # recomputes them for the new binary instead of leaking stale ranges.
+        # Drop the memoized executable-section ranges and Mach-O fixup state so a
+        # reused manager instance recomputes them for the new binary instead of
+        # leaking stale data.
         self._exec_ranges = None
+        self._macho_fixup_state = None
 
     def locateCandidates(self):
         # AArch64 candidate discovery: symbols, PE ARM64 exception-directory entries
@@ -235,16 +238,159 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             self.addCandidate(fde_start)
             yield fde_start
 
+    def _machoActiveBinaryAndAdjustment(self):
+        binary_info = self.disassembly.binary_info
+        lief_binary = binary_info.getLiefBinary()
+        if not isinstance(lief_binary, (lief.MachO.Binary, lief.MachO.FatBinary)):
+            return None, 0
+        macho = get_active_macho_binary(lief_binary, bitness=binary_info.bitness, architecture=binary_info.architecture)
+        if macho is None or not isinstance(macho, lief.MachO.Binary):
+            return None, 0
+        adjustment = get_macho_address_adjustment(
+            macho,
+            base_addr=binary_info.base_addr,
+            bitness=binary_info.bitness,
+            architecture=binary_info.architecture,
+        )
+        return macho, adjustment
+
+    @staticmethod
+    def _machoInstructionSectionRanges(macho, adjustment, pure_only=False):
+        # SMDA-VA [start, end) ranges of Mach-O sections holding instructions.
+        # pure_only restricts to S_ATTR_PURE_INSTRUCTIONS sections (no mixed
+        # code/data), for scans that decode every word as an instruction.
+        ins_flags = lief.MachO.Section.FLAGS.PURE_INSTRUCTIONS.value
+        if not pure_only:
+            ins_flags += lief.MachO.Section.FLAGS.SOME_INSTRUCTIONS.value
+        ranges = []
+        for section in macho.sections:
+            if section.virtual_address and section.flags.value & ins_flags:
+                start = section.virtual_address + adjustment
+                ranges.append((start, start + section.size))
+        return ranges
+
+    def _machoFixupState(self, macho):
+        """(rebase map {LIEF slot VA -> LIEF target VA}, binding slot VAs, has_chained).
+
+        With dyld chained fixups the mapped image holds packed fixup words, so a
+        stored pointer is only meaningful through its RelocationFixup target; a
+        binding slot holds an import and never a local function pointer.
+        """
+        # getattr: locateCandidates() runs inside the base init() before this
+        # backend's init() epilogue can reset the cache attribute
+        if getattr(self, "_macho_fixup_state", None) is None:
+            rebases = {}
+            for relocation in macho.relocations:
+                target = getattr(relocation, "target", None)
+                if target is not None:
+                    rebases[relocation.address] = target
+            bindings = set()
+            for binding in getattr(macho, "bindings", []):
+                address = getattr(binding, "address", 0)
+                if address:
+                    bindings.add(address)
+            has_chained = getattr(macho, "dyld_chained_fixups", None) is not None
+            self._macho_fixup_state = (rebases, bindings, has_chained)
+        return self._macho_fixup_state
+
+    def _resolveMachoStoredPointer(self, slot_lief_va, adjustment, fixup_state):
+        """Resolve the pointer stored at a Mach-O slot to an SMDA VA, or None."""
+        rebases, bindings, has_chained = fixup_state
+        if slot_lief_va in bindings:
+            return None  # import slot, never a local function
+        if slot_lief_va in rebases:
+            return rebases[slot_lief_va] + adjustment
+        if has_chained:
+            return None  # unresolved chained slot: the raw word is packed metadata
+        raw = self.disassembly.getBytes(slot_lief_va + adjustment, 8)
+        if raw is None or len(raw) != 8:
+            return None
+        value = int.from_bytes(raw, "little") & self.getBitMask()
+        if not value:
+            return None
+        return value + adjustment
+
+    def _locateMachoFunctionPointerMetadataCandidates(self):
+        # Explicit Mach-O function-pointer metadata only - the platform-native
+        # equivalent of ELF .init_array/.fini_array: mod-init/term and TLV-init
+        # pointer sections, __init_offsets tables, and interposing pairs. Broad
+        # regular-data sweeps are deliberately NOT performed; GOT/lazy pointers,
+        # imports and stub islands are excluded.
+        macho, adjustment = self._machoActiveBinaryAndAdjustment()
+        if macho is None:
+            return
+        section_types = lief.MachO.Section.TYPE
+        pointer_types = {
+            section_types.MOD_INIT_FUNC_POINTERS,
+            section_types.MOD_TERM_FUNC_POINTERS,
+            section_types.THREAD_LOCAL_INIT_FUNCTION_POINTERS,
+        }
+        init_offsets_type = getattr(section_types, "INIT_FUNC_OFFSETS", None)
+        interposing_type = section_types.INTERPOSING
+        exec_ranges = self._machoInstructionSectionRanges(macho, adjustment)
+        if not exec_ranges:
+            return
+        binary_info = self.disassembly.binary_info
+        stub_ranges = get_macho_stub_ranges(
+            macho,
+            base_addr=binary_info.base_addr,
+            bitness=binary_info.bitness,
+            architecture=binary_info.architecture,
+        )
+        fixup_state = self._machoFixupState(macho)
+
+        def seed(target, source_va):
+            if target is None or target % INSTRUCTION_SIZE != 0:
+                return
+            if not any(start <= target < end for start, end in exec_ranges):
+                return
+            if any(start <= target < end for start, end in stub_ranges):
+                return
+            if not self._passesCodeFilter(target) or not self.disassembly.isAddrWithinMemoryImage(target):
+                return
+            self.addReferenceCandidate(target, source_va)
+            self.setInitialCandidate(target)
+
+        for section in macho.sections:
+            if not section.virtual_address or not section.size:
+                continue
+            section_type = section.type
+            if section_type in pointer_types:
+                for slot_va in range(section.virtual_address, section.virtual_address + section.size - 7, 8):
+                    if self._candidateTimeoutTripped():
+                        return
+                    seed(self._resolveMachoStoredPointer(slot_va, adjustment, fixup_state), slot_va + adjustment)
+            elif init_offsets_type is not None and section_type == init_offsets_type:
+                # __init_offsets: 32-bit offsets from the image base, no fixups involved
+                for slot_va in range(section.virtual_address, section.virtual_address + section.size - 3, 4):
+                    if self._candidateTimeoutTripped():
+                        return
+                    raw = self.disassembly.getBytes(slot_va + adjustment, 4)
+                    if raw is None or len(raw) != 4:
+                        continue
+                    seed(macho.imagebase + int.from_bytes(raw, "little") + adjustment, slot_va + adjustment)
+            elif section_type == interposing_type:
+                # interposing entries are <replacement, replacee> pointer pairs; only
+                # the replacement of a complete pair is a local function
+                for pair_va in range(section.virtual_address, section.virtual_address + section.size - 15, 16):
+                    if self._candidateTimeoutTripped():
+                        return
+                    seed(self._resolveMachoStoredPointer(pair_va, adjustment, fixup_state), pair_va + adjustment)
+
     def locateDataPointerCandidates(self):
         # Seed candidates from stored function pointers. ELF .init_array/.fini_array
         # entries are authoritative constructor/destructor pointers; other data
         # sections are scanned for aligned words pointing into executable code.
+        # Mach-O images use their explicit function-pointer metadata instead.
         # This recovers functions reached only indirectly (CRT init stubs, pointer
         # / dispatch tables) that no direct BL or recognized prologue would find,
         # and anchors true entries so the prologue scan no longer mislabels an
         # inner block as the function start.
         binary_info = self.disassembly.binary_info
         lief_binary = binary_info.getLiefBinary()
+        if isinstance(lief_binary, (lief.MachO.Binary, lief.MachO.FatBinary)):
+            self._locateMachoFunctionPointerMetadataCandidates()
+            return
         if not isinstance(lief_binary, lief.ELF.Binary) or not lief_binary.sections:
             return
         exec_ranges = self._executableSectionRanges(lief_binary)
@@ -295,9 +441,23 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         # common in position-independent code.
         binary_info = self.disassembly.binary_info
         lief_binary = binary_info.getLiefBinary()
-        if not isinstance(lief_binary, lief.ELF.Binary) or not lief_binary.sections:
+        adjustment = 0
+        macho_fixup_state = None
+        if isinstance(lief_binary, lief.ELF.Binary) and lief_binary.sections:
+            exec_ranges = self._executableSectionRanges(lief_binary)
+        elif self.config.USE_MACHO_ADDRESS_REF_CANDIDATES and isinstance(
+            lief_binary, (lief.MachO.Binary, lief.MachO.FatBinary)
+        ):
+            # opt-in Mach-O extension: scan only S_ATTR_PURE_INSTRUCTIONS sections
+            # (every word is decoded as an instruction) and resolve loaded slots
+            # through local fixups before trusting stored words
+            macho, adjustment = self._machoActiveBinaryAndAdjustment()
+            if macho is None:
+                return
+            exec_ranges = self._machoInstructionSectionRanges(macho, adjustment, pure_only=True)
+            macho_fixup_state = self._machoFixupState(macho)
+        else:
             return
-        exec_ranges = self._executableSectionRanges(lief_binary)
         if not exec_ranges:
             return
         base = binary_info.base_addr
@@ -311,7 +471,15 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             target &= bit_mask
             if target % INSTRUCTION_SIZE != 0 or not in_exec(target):
                 return
-            if self._passesCodeFilter(target) and self.disassembly.isAddrWithinMemoryImage(target):
+            if not (self._passesCodeFilter(target) and self.disassembly.isAddrWithinMemoryImage(target)):
+                return
+            if macho_fixup_state is not None:
+                # Mach-O targets are weak address evidence, not inbound call refs:
+                # register the bare candidate without a reference source so it gains
+                # no call-reference score (addCandidate would touch the queue, which
+                # does not exist yet during candidate identification)
+                self.ensureCandidate(target)
+            else:
                 self.addReferenceCandidate(target, source)
 
         for low, high in exec_ranges:
@@ -348,7 +516,11 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                     if rn in pages:
                         imm = ((word >> 10) & 0xFFF) * 8
                         slot_addr = pages[rn] + imm
-                        if self.disassembly.isAddrWithinMemoryImage(slot_addr):
+                        if macho_fixup_state is not None:
+                            val = self._resolveMachoStoredPointer(slot_addr - adjustment, adjustment, macho_fixup_state)
+                            if val is not None:
+                                seed(val, addr)
+                        elif self.disassembly.isAddrWithinMemoryImage(slot_addr):
                             raw_val = self.disassembly.getBytes(slot_addr, 8)
                             if raw_val and len(raw_val) == 8:
                                 val = struct.unpack("<Q", raw_val)[0]

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -224,6 +224,7 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         def in_exec(addr):
             return any(start <= addr < end for start, end in exec_ranges)
 
+        accepted = []
         for fde_start in sorted({fde_range[0] for fde_range in fde_ranges}):
             if self._candidateTimeoutTripped():
                 return
@@ -231,11 +232,22 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                 continue
             if not self._passesCodeFilter(fde_start):
                 continue
-            # checked lazily per yield: an earlier deferred candidate's analysis
-            # may have claimed this start in the meantime
             if self.disassembly.isCode(fde_start):
                 continue
-            self.addCandidate(fde_start)
+            self.ensureCandidate(fde_start)
+            accepted.append(fde_start)
+        # register ALL accepted starts as known function starts before analyzing
+        # any of them: the branch classifier consults getFunctionStartCandidates()
+        # during analysis, so an earlier deferred function could otherwise absorb
+        # a later FDE start it branches or tailcalls into
+        self._candidate_offsets.update(accepted)
+        for fde_start in accepted:
+            if self._candidateTimeoutTripped():
+                return
+            # re-checked per yield: an earlier deferred candidate's analysis may
+            # still have claimed this start in the meantime (e.g. as a callee)
+            if self.disassembly.isCode(fde_start):
+                continue
             yield fde_start
 
     def _machoActiveBinaryAndAdjustment(self):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -31,6 +31,7 @@ import struct
 
 import lief
 
+from smda.common.EhFrameDecoder import decodeEhFrameFdeRanges
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager as _IntelFunctionCandidateManager
 
 from .definitions import (
@@ -191,6 +192,48 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             if not any(start <= addr < end for start, end in exec_ranges):
                 continue
             self.addExceptionCandidate(addr)
+
+    def locateDeferredCandidates(self):
+        # ELF .eh_frame FDE starts (opt-in): every FDE names a code range that
+        # unwinding treats as one routine, so an FDE start the primary pass left
+        # unclaimed is strong evidence of a missed function (e.g. a wrapper only
+        # reached through data). Runs after the primary pass so code_map claims
+        # can veto entries: an already-claimed start would split existing
+        # functions, which this pass must never do. Accepted starts get ordinary
+        # candidate bookkeeping - deliberately NOT the PE exception-candidate
+        # priority, since .eh_frame commonly also covers non-function ranges.
+        if not self.config.USE_ELF_EH_FRAME_CANDIDATES:
+            return
+        binary_info = self.disassembly.binary_info
+        lief_binary = binary_info.getLiefBinary()
+        if not isinstance(lief_binary, lief.ELF.Binary):
+            return
+        eh_frame = next((section for section in lief_binary.sections if section.name == ".eh_frame"), None)
+        if eh_frame is None or not eh_frame.virtual_address or not eh_frame.size:
+            return
+        section_bytes = self.disassembly.getBytes(eh_frame.virtual_address, eh_frame.size)
+        if not section_bytes:
+            return
+        pointer_size = 8 if binary_info.bitness == 64 else 4
+        fde_ranges = decodeEhFrameFdeRanges(bytes(section_bytes), eh_frame.virtual_address, pointer_size=pointer_size)
+        exec_ranges = self._cachedExecutableSectionRanges()
+
+        def in_exec(addr):
+            return any(start <= addr < end for start, end in exec_ranges)
+
+        for fde_start in sorted({fde_range[0] for fde_range in fde_ranges}):
+            if self._candidateTimeoutTripped():
+                return
+            if fde_start % INSTRUCTION_SIZE != 0 or not in_exec(fde_start):
+                continue
+            if not self._passesCodeFilter(fde_start):
+                continue
+            # checked lazily per yield: an earlier deferred candidate's analysis
+            # may have claimed this start in the meantime
+            if self.disassembly.isCode(fde_start):
+                continue
+            self.addCandidate(fde_start)
+            yield fde_start
 
     def locateDataPointerCandidates(self):
         # Seed candidates from stored function pointers. ELF .init_array/.fini_array

--- a/src/smda/common/EhFrameDecoder.py
+++ b/src/smda/common/EhFrameDecoder.py
@@ -110,12 +110,20 @@ def _parse_cie(data, pos, end, pointer_size):
     # the legacy "eh" augmentation carries an extra raw pointer we do not handle
     if augmentation and (not augmentation.startswith("z") or any(c not in "zRLPSB" for c in augmentation)):
         return unsupported
-    _, pos = _read_uleb128(data, pos, end)  # code alignment factor
-    _, pos = _read_sleb128(data, pos, end)  # data alignment factor
+    code_alignment, pos = _read_uleb128(data, pos, end)
+    if code_alignment is None:
+        return unsupported
+    data_alignment, pos = _read_sleb128(data, pos, end)
+    if data_alignment is None:
+        return unsupported
     if version == 1:
+        if pos >= end:
+            return unsupported
         pos += 1  # return address register (single byte)
     else:
-        _, pos = _read_uleb128(data, pos, end)
+        return_address_register, pos = _read_uleb128(data, pos, end)
+        if return_address_register is None:
+            return unsupported
     fde_encoding = DW_EH_PE_absptr
     if augmentation.startswith("z"):
         aug_length, pos = _read_uleb128(data, pos, end)
@@ -130,7 +138,11 @@ def _parse_cie(data, pos, end, pointer_size):
             elif char == "P":
                 personality_encoding = data[pos]
                 pos += 1
-                _, pos = _read_encoded_value(data, pos, aug_data_end, personality_encoding, pointer_size)
+                personality, pos = _read_encoded_value(data, pos, aug_data_end, personality_encoding, pointer_size)
+                if personality is None:
+                    # unknown personality-pointer size: the cursor cannot advance
+                    # past it, so any following 'R' byte would be misread
+                    return unsupported
             elif char == "R":
                 fde_encoding = data[pos]
                 pos += 1

--- a/src/smda/common/EhFrameDecoder.py
+++ b/src/smda/common/EhFrameDecoder.py
@@ -1,0 +1,195 @@
+"""Bounded .eh_frame FDE-range decoder.
+
+Extracts <initial_location, address_range> pairs from a raw ``.eh_frame``
+section without building full CFI programs: only the CIE fields needed to
+decode each FDE's PC-begin pointer are parsed (augmentation string, the ``zR``
+FDE pointer encoding, and enough of the header to skip the rest).
+
+Format reference: LSB / Linux Standard Base "Exception Frames" chapter
+(4-byte record length with 0xFFFFFFFF extended-length escape, CIE id 0,
+FDE CIE-pointer as a back-offset from its own field, DW_EH_PE pointer
+encodings).
+
+Deliberately conservative: records with unsupported versions, augmentations,
+or pointer encodings are skipped individually (their length field still
+advances the cursor), malformed lengths terminate the scan, and both record
+count and per-record reads are bounded, so a hostile section cannot cause
+quadratic work or giant allocations.
+"""
+
+# DW_EH_PE value formats (low nibble)
+DW_EH_PE_absptr = 0x00
+DW_EH_PE_udata2 = 0x02
+DW_EH_PE_udata4 = 0x03
+DW_EH_PE_udata8 = 0x04
+DW_EH_PE_sdata2 = 0x0A
+DW_EH_PE_sdata4 = 0x0B
+DW_EH_PE_sdata8 = 0x0C
+# DW_EH_PE application modes (high nibble); only absolute and pcrel are supported
+DW_EH_PE_pcrel = 0x10
+DW_EH_PE_indirect = 0x80
+DW_EH_PE_omit = 0xFF
+
+_VALUE_SIZES = {
+    DW_EH_PE_udata2: (2, False),
+    DW_EH_PE_udata4: (4, False),
+    DW_EH_PE_udata8: (8, False),
+    DW_EH_PE_sdata2: (2, True),
+    DW_EH_PE_sdata4: (4, True),
+    DW_EH_PE_sdata8: (8, True),
+}
+
+MAX_RECORDS = 200000
+
+
+def _read_uleb128(data, pos, end):
+    value, shift = 0, 0
+    while pos < end and shift < 64:
+        byte = data[pos]
+        value |= (byte & 0x7F) << shift
+        pos += 1
+        if not byte & 0x80:
+            return value, pos
+        shift += 7
+    return None, pos
+
+
+def _read_sleb128(data, pos, end):
+    value, shift = 0, 0
+    while pos < end and shift < 64:
+        byte = data[pos]
+        value |= (byte & 0x7F) << shift
+        pos += 1
+        shift += 7
+        if not byte & 0x80:
+            if byte & 0x40 and shift < 64:
+                value -= 1 << shift
+            return value, pos
+    return None, pos
+
+
+def _read_encoded_value(data, pos, end, encoding, pointer_size):
+    """Returns (raw value, new pos) for the DW_EH_PE value format bits only
+    (application bits are the caller's concern); (None, pos) if unsupported."""
+    value_format = encoding & 0x0F
+    if value_format == DW_EH_PE_absptr:
+        size, signed = pointer_size, False
+    elif value_format in _VALUE_SIZES:
+        size, signed = _VALUE_SIZES[value_format]
+    else:
+        # uleb128/sleb128-encoded pointers are rare in .eh_frame; not supported
+        return None, pos
+    if pos + size > end:
+        return None, pos
+    value = int.from_bytes(data[pos : pos + size], "little", signed=signed)
+    return value, pos + size
+
+
+class _CieInfo:
+    __slots__ = ("fde_encoding", "supported")
+
+    def __init__(self, fde_encoding, supported):
+        self.fde_encoding = fde_encoding
+        self.supported = supported
+
+
+def _parse_cie(data, pos, end, pointer_size):
+    """Parses the CIE body starting after the id field; returns a _CieInfo."""
+    unsupported = _CieInfo(DW_EH_PE_omit, False)
+    if pos >= end:
+        return unsupported
+    version = data[pos]
+    pos += 1
+    if version not in (1, 3):
+        return unsupported
+    aug_end = data.find(b"\x00", pos, end)
+    if aug_end < 0:
+        return unsupported
+    augmentation = data[pos:aug_end].decode("ascii", errors="replace")
+    pos = aug_end + 1
+    # the legacy "eh" augmentation carries an extra raw pointer we do not handle
+    if augmentation and (not augmentation.startswith("z") or any(c not in "zRLPSB" for c in augmentation)):
+        return unsupported
+    _, pos = _read_uleb128(data, pos, end)  # code alignment factor
+    _, pos = _read_sleb128(data, pos, end)  # data alignment factor
+    if version == 1:
+        pos += 1  # return address register (single byte)
+    else:
+        _, pos = _read_uleb128(data, pos, end)
+    fde_encoding = DW_EH_PE_absptr
+    if augmentation.startswith("z"):
+        aug_length, pos = _read_uleb128(data, pos, end)
+        if aug_length is None or pos + aug_length > end:
+            return unsupported
+        aug_data_end = pos + aug_length
+        for char in augmentation[1:]:
+            if pos >= aug_data_end:
+                return unsupported
+            if char == "L":
+                pos += 1
+            elif char == "P":
+                personality_encoding = data[pos]
+                pos += 1
+                _, pos = _read_encoded_value(data, pos, aug_data_end, personality_encoding, pointer_size)
+            elif char == "R":
+                fde_encoding = data[pos]
+                pos += 1
+            # 'S' (signal frame) and 'B' (AArch64 PAC) carry no augmentation data
+    if fde_encoding & DW_EH_PE_indirect:
+        return unsupported
+    if (fde_encoding & 0x70) not in (0x00, DW_EH_PE_pcrel):
+        # datarel/textrel/funcrel/aligned application modes are not supported
+        return unsupported
+    return _CieInfo(fde_encoding, True)
+
+
+def decodeEhFrameFdeRanges(data, section_va, pointer_size=8, max_records=MAX_RECORDS):
+    """Decodes FDE <initial_location, address_range> pairs from .eh_frame bytes.
+
+    ``section_va`` is the virtual address the section bytes live at in the
+    analyzed image (needed for DW_EH_PE_pcrel). Returns a list of
+    ``(initial_location, address_range)`` tuples for every decodable FDE;
+    undecodable records are skipped, a zero-length terminator or malformed
+    length ends the scan.
+    """
+    ranges = []
+    cies = {}
+    pos = 0
+    total = len(data)
+    for _ in range(max_records):
+        if pos + 4 > total:
+            break
+        record_start = pos
+        length = int.from_bytes(data[pos : pos + 4], "little")
+        pos += 4
+        if length == 0:
+            break  # ZERO terminator
+        if length == 0xFFFFFFFF:
+            # 8-byte extended length; read it so oversized records can be skipped
+            if pos + 8 > total:
+                break
+            length = int.from_bytes(data[pos : pos + 8], "little")
+            pos += 8
+        record_end = pos + length
+        if length > total or record_end > total:
+            break  # malformed/truncated record: cannot trust the cursor anymore
+        id_pos = pos
+        cie_id = int.from_bytes(data[pos : pos + 4], "little") if pos + 4 <= record_end else None
+        pos += 4
+        if cie_id is None:
+            break
+        if cie_id == 0:
+            cies[record_start] = _parse_cie(data, pos, record_end, pointer_size)
+        else:
+            cie = cies.get(id_pos - cie_id)
+            if cie is not None and cie.supported:
+                field_pos = pos
+                initial_location, pos = _read_encoded_value(data, pos, record_end, cie.fde_encoding, pointer_size)
+                address_range, pos = _read_encoded_value(data, pos, record_end, cie.fde_encoding & 0x0F, pointer_size)
+                if initial_location is not None and address_range is not None:
+                    if (cie.fde_encoding & 0x70) == DW_EH_PE_pcrel:
+                        initial_location += section_va + field_pos
+                    if initial_location >= 0 and address_range >= 0:
+                        ranges.append((initial_location, address_range))
+        pos = record_end
+    return ranges

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -414,7 +414,7 @@ class RecursiveDisassembler:
         # once we are initialized, add OEP
         if binary_info.oep is not None:
             self.fc_manager.symbol_addresses.append(binary_info.base_addr + binary_info.oep)
-        self.fc_manager.init(self.disassembly)
+        self.fc_manager.init(self.disassembly, cbAnalysisTimeout)
         self.capstone = self.backend.createCapstone(self.disassembly.binary_info.bitness)
         self._tfidf = self.backend.createTfIdf(self.disassembly.binary_info.bitness)
         LOGGER.debug("Starting heuristical analysis.")

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -427,6 +427,12 @@ class RecursiveDisassembler:
             "Finished heuristical analysis, functions: %d",
             len(self.disassembly.functions),
         )
+        # deferred candidate sources need the primary pass's code_map claims to filter
+        # against; they run before gap analysis so accepted starts anchor real functions
+        for deferred_addr in self.fc_manager.locateDeferredCandidates():
+            if cbAnalysisTimeout and cbAnalysisTimeout():
+                break
+            state = self.analyzeFunction(deferred_addr)
         # second pass, analyze remaining gaps for additional candidates in an iterative way
         gap_candidate = self.fc_manager.nextGapCandidate()
         while gap_candidate is not None:

--- a/src/smda/ida/IdaExporter.py
+++ b/src/smda/ida/IdaExporter.py
@@ -87,6 +87,9 @@ class IdaExporter:
         self.disassembly.function_symbols = self.ida_interface.getFunctionSymbols()
         api_map = self.ida_interface.getApiMap()
         for function_offset in self.ida_interface.getFunctions():
+            if cb_analysis_timeout and cb_analysis_timeout():
+                self.disassembly.analysis_timeout = True
+                break
             if self.ida_interface.isExternalFunction(function_offset):
                 continue
             converted_function = []

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -546,6 +546,12 @@ class FunctionCandidateManager:
         self.locateStubChainCandidates()
         self.identified_alignment = self._identifyAlignment()
 
+    def locateDeferredCandidates(self):
+        """Deferred candidate sources that need the primary pass's results (e.g.
+        code_map claims) before they can be filtered; yields addresses the engine
+        analyzes between the primary pass and gap analysis. No sources here."""
+        return ()
+
     def _buildQueue(self):
         LOGGER.debug("Located %d function candidates", len(self.candidates))
         # increase lookup speed with static set

--- a/tests/testAArch64MachoMetadataCandidates.py
+++ b/tests/testAArch64MachoMetadataCandidates.py
@@ -1,0 +1,265 @@
+#!/usr/bin/python
+"""Mach-O function-pointer metadata candidates and the opt-in address-ref scan.
+
+Builds minimal thin (and fat-wrapped) MH_EXECUTE arm64 Mach-O images in memory:
+__TEXT holds __text (pure instructions) and __stubs, __DATA holds whatever
+metadata sections each test needs. Loaded through FileLoader(map_file=True) and
+driven via the AArch64 FunctionCandidateManager directly, mirroring the PE
+exception-directory tests.
+
+The committed Mach-O corpus contains no mod-init/init-offsets/interposing
+sections at all, so these synthetic images are the only coverage exercising
+the metadata scan (a zero corpus delta says nothing about it).
+"""
+
+import struct
+import unittest
+
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+
+BASE = 0x100000000
+TEXT_VA = BASE + 0x1000
+STUBS_VA = BASE + 0x1800
+DATA_VA = BASE + 0x2000
+
+MH_MAGIC_64 = 0xFEEDFACF
+CPU_ARM64 = 0x0100000C
+LC_SEGMENT_64 = 0x19
+
+S_ATTR_PURE_INSTRUCTIONS = 0x80000000
+S_ATTR_SOME_INSTRUCTIONS = 0x00000400
+S_REGULAR = 0x0
+S_SYMBOL_STUBS = 0x8
+S_MOD_INIT_FUNC_POINTERS = 0x9
+S_MOD_TERM_FUNC_POINTERS = 0xA
+S_INTERPOSING = 0xD
+S_THREAD_LOCAL_INIT_FUNCTION_POINTERS = 0x15
+S_INIT_FUNC_OFFSETS = 0x16
+
+RET = 0xD65F03C0
+
+
+def _section(sectname, segname, addr, size, offset, flags):
+    return struct.pack("<16s16sQQIIIIIIII", sectname, segname, addr, size, offset, 3, 0, 0, flags, 0, 0, 0)
+
+
+def _segment(segname, vmaddr, vmsize, fileoff, filesize, prot, sections):
+    cmdsize = 72 + 80 * len(sections)
+    return struct.pack(
+        "<II16sQQQQiiII",
+        LC_SEGMENT_64,
+        cmdsize,
+        segname,
+        vmaddr,
+        vmsize,
+        fileoff,
+        filesize,
+        prot,
+        prot,
+        len(sections),
+        0,
+    ) + b"".join(sections)
+
+
+def _build_arm64_macho(data_sections, text_words=None, fat=False):
+    """Thin (or fat-wrapped) arm64 Mach-O; __DATA sections are laid out from
+    DATA_VA in 0x100 strides as (name, type/attr flags, content) tuples."""
+    text_words = text_words or [RET] * 64
+    text_bytes = b"".join(word.to_bytes(4, "little") for word in text_words)
+    text_bytes += b"\x00" * (0x800 - len(text_bytes))
+    stub_bytes = b"".join(word.to_bytes(4, "little") for word in [RET] * 8)
+
+    data_blob = bytearray(0x1000)
+    section_headers = []
+    for index, (name, type_flags, content) in enumerate(data_sections):
+        section_va = DATA_VA + 0x100 * index
+        data_blob[0x100 * index : 0x100 * index + len(content)] = content
+        section_headers.append(
+            _section(name, b"__DATA", section_va, max(len(content), 1), 0x2000 + 0x100 * index, type_flags)
+        )
+
+    text_seg = _segment(
+        b"__TEXT",
+        BASE,
+        0x2000,
+        0,
+        0x2000,
+        5,
+        [
+            _section(
+                b"__text",
+                b"__TEXT",
+                TEXT_VA,
+                len(text_bytes),
+                0x1000,
+                S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS,
+            ),
+            _section(
+                b"__stubs",
+                b"__TEXT",
+                STUBS_VA,
+                len(stub_bytes),
+                0x1800,
+                S_SYMBOL_STUBS | S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS,
+            ),
+        ],
+    )
+    data_seg = _segment(b"__DATA", DATA_VA, 0x1000, 0x2000, 0x1000, 3, section_headers)
+
+    commands = text_seg + data_seg
+    header = struct.pack("<IiiIIIII", MH_MAGIC_64, CPU_ARM64, 0, 2, 2, len(commands), 0, 0)
+    blob = bytearray(0x3000)
+    blob[0 : len(header)] = header
+    blob[len(header) : len(header) + len(commands)] = commands
+    blob[0x1000 : 0x1000 + len(text_bytes)] = text_bytes
+    blob[0x1800 : 0x1800 + len(stub_bytes)] = stub_bytes
+    blob[0x2000:0x3000] = data_blob
+    thin = bytes(blob)
+    if not fat:
+        return thin
+    # big-endian FAT_MAGIC header with one arm64 slice at offset 0x4000
+    fat_header = struct.pack(">II", 0xCAFEBABE, 1)
+    fat_arch = struct.pack(">iiIII", CPU_ARM64, 0, 0x4000, len(thin), 14)
+    return fat_header + fat_arch + b"\x00" * (0x4000 - len(fat_header) - len(fat_arch)) + thin
+
+
+def _ptr(value):
+    return struct.pack("<Q", value)
+
+
+def _manager_for(blob, use_address_refs=False):
+    loader = FileLoader("/", map_file=True)
+    loader._loadFile(blob)
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+    config = SmdaConfig()
+    config.USE_MACHO_ADDRESS_REF_CANDIDATES = use_address_refs
+    fcm = FunctionCandidateManager(config)
+    fcm.init(disassembly)
+    return fcm
+
+
+class MachoMetadataPointerTestSuite(unittest.TestCase):
+    def test_mod_init_term_and_tlv_pointers_are_seeded(self):
+        blob = _build_arm64_macho(
+            [
+                (b"__mod_init_func", S_MOD_INIT_FUNC_POINTERS, _ptr(TEXT_VA + 8)),
+                (b"__mod_term_func", S_MOD_TERM_FUNC_POINTERS, _ptr(TEXT_VA + 16)),
+                (b"__thread_init", S_THREAD_LOCAL_INIT_FUNCTION_POINTERS, _ptr(TEXT_VA + 24)),
+            ]
+        )
+        fcm = _manager_for(blob)
+        for target in (TEXT_VA + 8, TEXT_VA + 16, TEXT_VA + 24):
+            self.assertIn(target, fcm.candidates)
+            self.assertTrue(fcm.candidates[target].is_initial_candidate)
+
+    def test_regular_data_sections_are_not_swept(self):
+        # the same pointer in a REGULAR section must NOT seed a candidate:
+        # Mach-O discovery is metadata-only, without broad data sweeps
+        blob = _build_arm64_macho([(b"__data", S_REGULAR, _ptr(TEXT_VA + 8))])
+        self.assertNotIn(TEXT_VA + 8, _manager_for(blob).candidates)
+
+    def test_init_offsets_resolve_from_image_base(self):
+        blob = _build_arm64_macho([(b"__init_offsets", S_INIT_FUNC_OFFSETS, struct.pack("<II", 0x1008, 0x1010))])
+        fcm = _manager_for(blob)
+        self.assertIn(BASE + 0x1008, fcm.candidates)
+        self.assertIn(BASE + 0x1010, fcm.candidates)
+
+    def test_interposing_seeds_only_the_replacement_of_each_pair(self):
+        blob = _build_arm64_macho([(b"__interpose", S_INTERPOSING, _ptr(TEXT_VA + 0x10) + _ptr(TEXT_VA + 0x20))])
+        fcm = _manager_for(blob)
+        self.assertIn(TEXT_VA + 0x10, fcm.candidates)
+        self.assertNotIn(TEXT_VA + 0x20, fcm.candidates)
+
+    def test_stub_misaligned_and_data_targets_are_excluded(self):
+        blob = _build_arm64_macho(
+            [
+                (
+                    b"__mod_init_func",
+                    S_MOD_INIT_FUNC_POINTERS,
+                    _ptr(STUBS_VA) + _ptr(TEXT_VA + 2) + _ptr(DATA_VA + 0x40) + _ptr(0),
+                )
+            ]
+        )
+        fcm = _manager_for(blob)
+        self.assertNotIn(STUBS_VA, fcm.candidates)  # stub island, not a local function
+        self.assertNotIn(TEXT_VA + 2, fcm.candidates)  # not instruction-aligned
+        self.assertNotIn(DATA_VA + 0x40, fcm.candidates)  # not in instruction sections
+
+    def test_fat_slice_pointers_are_seeded(self):
+        blob = _build_arm64_macho([(b"__mod_init_func", S_MOD_INIT_FUNC_POINTERS, _ptr(TEXT_VA + 8))], fat=True)
+        self.assertIn(TEXT_VA + 8, _manager_for(blob).candidates)
+
+
+class MachoStoredPointerResolutionTestSuite(unittest.TestCase):
+    """Fixup-aware slot resolution: bindings are imports, chained slots hold
+    packed metadata unless a RelocationFixup names their target."""
+
+    def _bare_manager(self, blob):
+        loader = FileLoader("/", map_file=True)
+        loader._loadFile(blob)
+        disassembly = DisassemblyResult()
+        disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+        fcm = FunctionCandidateManager(SmdaConfig())
+        fcm.disassembly = disassembly
+        fcm.bitness = disassembly.binary_info.bitness
+        return fcm
+
+    def test_binding_slot_is_never_a_local_pointer(self):
+        fcm = self._bare_manager(_build_arm64_macho([]))
+        fixup_state = ({}, {DATA_VA}, False)
+        self.assertIsNone(fcm._resolveMachoStoredPointer(DATA_VA, 0, fixup_state))
+
+    def test_rebase_target_wins_over_raw_bytes_and_gets_adjusted(self):
+        fcm = self._bare_manager(_build_arm64_macho([]))
+        fixup_state = ({DATA_VA: TEXT_VA + 8}, set(), True)
+        self.assertEqual(fcm._resolveMachoStoredPointer(DATA_VA, 0x1000, fixup_state), TEXT_VA + 8 + 0x1000)
+
+    def test_unresolved_chained_slot_is_skipped(self):
+        blob = _build_arm64_macho([(b"__data", S_REGULAR, _ptr(TEXT_VA + 8))])
+        fcm = self._bare_manager(blob)
+        fixup_state = ({}, set(), True)
+        self.assertIsNone(fcm._resolveMachoStoredPointer(DATA_VA, 0, fixup_state))
+
+    def test_classic_slot_reads_raw_mapped_bytes(self):
+        blob = _build_arm64_macho([(b"__data", S_REGULAR, _ptr(TEXT_VA + 8))])
+        fcm = self._bare_manager(blob)
+        fixup_state = ({}, set(), False)
+        self.assertEqual(fcm._resolveMachoStoredPointer(DATA_VA, 0, fixup_state), TEXT_VA + 8)
+
+
+class MachoAddressRefCandidateTestSuite(unittest.TestCase):
+    """Opt-in adr/adrp+add discovery over pure-instruction Mach-O sections."""
+
+    @staticmethod
+    def _adr_blob():
+        # adr x1, #0x40 -> TEXT_VA + 0x40; adrp x2, #0 (page = BASE + 0x1000) +
+        # add x2, x2, #0x50 -> TEXT_VA + 0x50
+        words = [
+            0x10000201,  # 0x...1000  adr x1, #0x40
+            0x90000002,  # 0x...1004  adrp x2, #0
+            0x91014042,  # 0x...1008  add x2, x2, #0x50
+            RET,
+        ]
+        return _build_arm64_macho([], text_words=words + [RET] * 4)
+
+    def test_default_off_records_no_address_refs(self):
+        self.assertFalse(SmdaConfig().USE_MACHO_ADDRESS_REF_CANDIDATES)
+        fcm = _manager_for(self._adr_blob(), use_address_refs=False)
+        self.assertNotIn(TEXT_VA + 0x40, fcm.candidates)
+        self.assertNotIn(TEXT_VA + 0x50, fcm.candidates)
+
+    def test_opt_in_records_targets_as_weak_evidence(self):
+        fcm = _manager_for(self._adr_blob(), use_address_refs=True)
+        for target in (TEXT_VA + 0x40, TEXT_VA + 0x50):
+            self.assertIn(target, fcm.candidates)
+            # weak address evidence: no inbound call references were recorded
+            self.assertEqual(fcm.candidates[target].call_ref_sources, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAArch64PdataExtraction.py
+++ b/tests/testAArch64PdataExtraction.py
@@ -1,0 +1,199 @@
+#!/usr/bin/python
+"""PE ARM64 exception-directory candidate discovery (opt-in).
+
+Builds a minimal spec-valid PE32+ ARM64 image in memory (4-byte e_lfanew,
+real PE\\0\\0 signature per the repo's PE fixture convention) with .text,
+.pdata and .xdata sections, loads it through FileLoader(map_file=True), and
+drives the AArch64 FunctionCandidateManager directly.
+
+ARM64 .pdata records are 8 bytes: <BeginRVA, UnwindData>, where UnwindData
+bits 0-1 select the format: 0 = RVA of a full .xdata record, 1 = packed
+unwind data (primary), 2 = packed fragment, 3 = reserved.
+"""
+
+import struct
+import unittest
+
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+
+IMAGE_BASE = 0x140000000
+TEXT_RVA, PDATA_RVA, XDATA_RVA = 0x1000, 0x2000, 0x3000
+FILE_ALIGN, SECT_ALIGN = 0x200, 0x1000
+
+# minimal valid ARM64 .xdata header: CodeWords=1, Vers=0, FunctionLength=0x10 words
+VALID_XDATA = struct.pack("<I", (1 << 27) | 0x10)
+
+
+def _build_arm64_pe(
+    pdata_bytes, xdata_bytes=VALID_XDATA, machine=0xAA64, image_base=IMAGE_BASE, exc_rva=PDATA_RVA, exc_size=None
+):
+    """Minimal PE32+ image: .text (RX) @0x1000, .pdata @0x2000, .xdata @0x3000."""
+    if exc_size is None:
+        exc_size = len(pdata_bytes)
+    text_bytes = struct.pack("<II", 0xD65F03C0, 0xD503201F) * 64  # ret; nop filler
+
+    dos = bytearray(0x40)
+    dos[0:2] = b"MZ"
+    dos[0x3C:0x40] = struct.pack("<I", 0x40)  # e_lfanew
+
+    coff = struct.pack("<HHIIIHH", machine, 3, 0, 0, 0, 240, 0x0022)
+
+    data_dirs = [(0, 0)] * 16
+    data_dirs[3] = (exc_rva, exc_size)  # IMAGE_DIRECTORY_ENTRY_EXCEPTION
+    opt = struct.pack(
+        "<HBBIIIIIQIIHHHHHHIIIIHHQQQQII",
+        0x20B,  # magic PE32+
+        14,
+        0,  # linker versions
+        len(text_bytes),
+        0,
+        0,  # sizes of code / initialized / uninitialized data
+        TEXT_RVA,  # entrypoint
+        TEXT_RVA,  # base of code
+        image_base,
+        SECT_ALIGN,
+        FILE_ALIGN,
+        6,
+        0,  # OS version
+        0,
+        0,  # image version
+        6,
+        0,  # subsystem version
+        0,  # win32 version
+        0x4000,  # size of image
+        FILE_ALIGN,  # size of headers
+        0,  # checksum
+        3,
+        0,  # subsystem CUI, dll characteristics
+        0x100000,
+        0x1000,
+        0x100000,
+        0x1000,  # stack/heap reserve+commit
+        0,  # loader flags
+        16,  # number of rva and sizes
+    ) + b"".join(struct.pack("<II", rva, size) for rva, size in data_dirs)
+
+    def shdr(name, rva, vsize, raw_off, raw_size, characteristics):
+        return struct.pack("<8sIIIIIIHHI", name, vsize, rva, raw_size, raw_off, 0, 0, 0, 0, characteristics)
+
+    sections = (
+        shdr(b".text", TEXT_RVA, len(text_bytes), 0x200, 0x200, 0x60000020)  # CODE|EXECUTE|READ
+        + shdr(b".pdata", PDATA_RVA, max(len(pdata_bytes), 1), 0x400, 0x200, 0x40000040)  # IDATA|READ
+        + shdr(b".xdata", XDATA_RVA, max(len(xdata_bytes), 1), 0x600, 0x200, 0x40000040)
+    )
+
+    headers = bytes(dos) + b"PE\x00\x00" + coff + opt + sections
+    assert len(headers) <= FILE_ALIGN
+    blob = bytearray(0x800)
+    blob[0 : len(headers)] = headers
+    blob[0x200 : 0x200 + len(text_bytes)] = text_bytes
+    blob[0x400 : 0x400 + len(pdata_bytes)] = pdata_bytes
+    blob[0x600 : 0x600 + len(xdata_bytes)] = xdata_bytes
+    return bytes(blob)
+
+
+def _record(begin_rva, unwind_data):
+    return struct.pack("<II", begin_rva, unwind_data)
+
+
+def _candidates_for(blob, use_pdata=True, cb_timeout=None):
+    loader = FileLoader("/", map_file=True)
+    loader._loadFile(blob)
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+    config = SmdaConfig()
+    config.USE_PE_ARM64_PDATA_CANDIDATES = use_pdata
+    fcm = FunctionCandidateManager(config)
+    fcm.init(disassembly, cb_timeout)
+    return fcm
+
+
+class AArch64PdataExtractionTestSuite(unittest.TestCase):
+    def test_accepts_xdata_and_packed_primary_records(self):
+        records = _record(TEXT_RVA, XDATA_RVA) + _record(TEXT_RVA + 8, (0x10 << 2) | 1)
+        fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertIn(IMAGE_BASE + TEXT_RVA + 8, fcm.candidates)
+        self.assertTrue(fcm.candidates[IMAGE_BASE + TEXT_RVA].is_exception_handler)
+        self.assertTrue(fcm.candidates[IMAGE_BASE + TEXT_RVA + 8].is_exception_handler)
+
+    def test_default_off_produces_no_exception_candidates(self):
+        records = _record(TEXT_RVA, XDATA_RVA)
+        self.assertFalse(SmdaConfig().USE_PE_ARM64_PDATA_CANDIDATES)
+        fcm = _candidates_for(_build_arm64_pe(records), use_pdata=False)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+
+    def test_skips_fragment_and_reserved_flags(self):
+        records = _record(TEXT_RVA, (0x10 << 2) | 2) + _record(TEXT_RVA + 8, (0x10 << 2) | 3)
+        fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, fcm.candidates)
+
+    def test_skips_invalid_xdata_records(self):
+        bad_version = struct.pack("<I", (1 << 27) | (1 << 18) | 0x10)  # Vers=1
+        zero_length = struct.pack("<I", 1 << 27)  # FunctionLength=0
+        records = (
+            _record(TEXT_RVA, XDATA_RVA + len(bad_version))  # -> zero_length record
+            + _record(TEXT_RVA + 8, XDATA_RVA + 2)  # unaligned .xdata RVA
+            + _record(TEXT_RVA + 16, 0x00080000)  # .xdata RVA outside the image
+            + _record(TEXT_RVA + 24, XDATA_RVA)  # -> bad_version record
+        )
+        fcm = _candidates_for(_build_arm64_pe(records, xdata_bytes=bad_version + zero_length))
+        for offset in (0, 8, 16, 24):
+            self.assertNotIn(IMAGE_BASE + TEXT_RVA + offset, fcm.candidates)
+
+    def test_skips_misaligned_and_non_executable_starts(self):
+        records = (
+            _record(TEXT_RVA + 2, XDATA_RVA)  # not 4-aligned
+            + _record(XDATA_RVA, XDATA_RVA)  # aligned but in a non-executable section
+            + _record(0x8000, XDATA_RVA)  # aligned but outside any section
+        )
+        fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 2, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + XDATA_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + 0x8000, fcm.candidates)
+
+    def test_rebased_image_seeds_candidates_at_new_base(self):
+        new_base = 0x180000000
+        records = _record(TEXT_RVA, XDATA_RVA)
+        fcm = _candidates_for(_build_arm64_pe(records, image_base=new_base))
+        self.assertIn(new_base + TEXT_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+
+    def test_truncated_directory_stops_at_image_end(self):
+        # the directory claims 3 records but the mapped image ends after the first;
+        # the valid prefix is kept and the scan stops without raising
+        blob = bytearray(_build_arm64_pe(b"", exc_rva=0x31F8, exc_size=24))
+        blob[0x7F8:0x800] = _record(TEXT_RVA, (0x10 << 2) | 1)
+        fcm = _candidates_for(bytes(blob))
+        self.assertIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+
+    def test_zero_record_terminates_scan(self):
+        records = _record(TEXT_RVA, XDATA_RVA) + _record(0, 0) + _record(TEXT_RVA + 8, (0x10 << 2) | 1)
+        fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, fcm.candidates)
+
+    def test_duplicate_records_yield_single_candidate(self):
+        records = _record(TEXT_RVA, XDATA_RVA) * 2
+        fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertEqual(sum(1 for addr in fcm.candidates if addr == IMAGE_BASE + TEXT_RVA), 1)
+
+    def test_non_arm64_machine_is_ignored(self):
+        # ARM64EC images carry machine AMD64 (0x8664); the classic-machine gate skips them
+        records = _record(TEXT_RVA, XDATA_RVA)
+        fcm = _candidates_for(_build_arm64_pe(records, machine=0x8664))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+
+    def test_tripped_timeout_skips_scan(self):
+        records = _record(TEXT_RVA, XDATA_RVA)
+        fcm = _candidates_for(_build_arm64_pe(records), cb_timeout=lambda: True)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAnalysisTimeoutCallback.py
+++ b/tests/testAnalysisTimeoutCallback.py
@@ -9,6 +9,7 @@ scan-produced candidates (prologue/call-reference) are absent, on both backends.
 """
 
 import unittest
+from types import SimpleNamespace
 
 from smda.aarch64.AArch64Disassembler import AArch64Disassembler
 from smda.common.BinaryInfo import BinaryInfo
@@ -62,6 +63,31 @@ class TimeoutCallbackReachesCandidateScansTestSuite(unittest.TestCase):
         result = disassembler.analyzeBuffer(_aarch64_binary_info(), cbAnalysisTimeout=lambda: True)
         self.assertNotIn(0x401010, disassembler.fc_manager.candidates)
         self.assertTrue(result.analysis_timeout)
+
+
+class IdaExporterTimeoutTestSuite(unittest.TestCase):
+    def test_tripped_callback_halts_ida_function_collection(self):
+        # IdaExporter.analyzeBuffer accepted cb_analysis_timeout but never polled
+        # it; a tripping callback must stop function collection and flag the report
+        from smda.DisassemblyResult import DisassemblyResult
+        from smda.ida.IdaExporter import IdaExporter
+
+        exporter = IdaExporter.__new__(IdaExporter)  # no IDA environment available
+        exporter.bitness = 64
+        exporter.architecture = "intel"
+        exporter.capstone = None
+        exporter.disassembly = DisassemblyResult()
+        exporter.ida_interface = SimpleNamespace(
+            getArchitecture=lambda: "intel",
+            getFunctionSymbols=dict,
+            getApiMap=dict,
+            getFunctions=lambda: [0x1000, 0x2000],
+            isExternalFunction=lambda offset: False,
+            getBlocks=lambda offset: [],
+        )
+        result = exporter.analyzeBuffer(_intel_binary_info(), cb_analysis_timeout=lambda: True)
+        self.assertTrue(result.analysis_timeout)
+        self.assertEqual(result.functions, {})
 
 
 if __name__ == "__main__":

--- a/tests/testAnalysisTimeoutCallback.py
+++ b/tests/testAnalysisTimeoutCallback.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+"""The live analysis-timeout callback must reach candidate identification.
+
+RecursiveDisassembler.analyzeBuffer received cbAnalysisTimeout but did not pass it
+to fc_manager.init(), so a tripping callback could never halt the candidate scans
+themselves — only the per-function analysis loops afterwards. These tests drive
+analyzeBuffer end-to-end with an already-tripped callback and assert that the
+scan-produced candidates (prologue/call-reference) are absent, on both backends.
+"""
+
+import unittest
+
+from smda.aarch64.AArch64Disassembler import AArch64Disassembler
+from smda.common.BinaryInfo import BinaryInfo
+from smda.Disassembler import Disassembler
+from smda.intel.IntelDisassembler import IntelDisassembler
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+from tests.testAArch64Disassembler import _build_aarch64_elf, _fixture_code
+
+# push rbp; mov rbp, rsp; pop rbp; ret — a common-prologue function at base
+INTEL_BUF = b"\x55\x48\x89\xe5\x5d\xc3"
+INTEL_BASE = 0x1000
+
+
+def _intel_binary_info():
+    binary_info = BinaryInfo(INTEL_BUF)
+    binary_info.base_addr = INTEL_BASE
+    binary_info.bitness = 64
+    binary_info.architecture = "intel"
+    return binary_info
+
+
+def _aarch64_binary_info():
+    loader = FileLoader("/", map_file=True)
+    loader._loadFile(_build_aarch64_elf(_fixture_code()))
+    return Disassembler()._populateBinaryInfo(loader)
+
+
+class TimeoutCallbackReachesCandidateScansTestSuite(unittest.TestCase):
+    def test_intel_tripped_callback_halts_candidate_identification(self):
+        config = SmdaConfig()
+        control = IntelDisassembler(config)
+        control.analyzeBuffer(_intel_binary_info(), cbAnalysisTimeout=None)
+        self.assertIn(INTEL_BASE, control.fc_manager.candidates)
+
+        disassembler = IntelDisassembler(config)
+        result = disassembler.analyzeBuffer(_intel_binary_info(), cbAnalysisTimeout=lambda: True)
+        self.assertNotIn(INTEL_BASE, disassembler.fc_manager.candidates)
+        self.assertTrue(result.analysis_timeout)
+
+    def test_aarch64_tripped_callback_halts_candidate_identification(self):
+        # f2 @ 0x401010 is discovered by the BL call-reference scan, which runs
+        # after the first timeout check (the OEP/symbol pass before it still seeds
+        # 0x401000 even when tripped, so assert on the scan-produced candidate).
+        config = SmdaConfig()
+        control = AArch64Disassembler(config)
+        control.analyzeBuffer(_aarch64_binary_info(), cbAnalysisTimeout=None)
+        self.assertIn(0x401010, control.fc_manager.candidates)
+
+        disassembler = AArch64Disassembler(config)
+        result = disassembler.analyzeBuffer(_aarch64_binary_info(), cbAnalysisTimeout=lambda: True)
+        self.assertNotIn(0x401010, disassembler.fc_manager.candidates)
+        self.assertTrue(result.analysis_timeout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testEhFrameCandidates.py
+++ b/tests/testEhFrameCandidates.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python
+"""ELF .eh_frame FDE decoding and the deferred AArch64 candidate pass (opt-in).
+
+Decoder unit tests craft raw .eh_frame byte streams; the integration tests run
+the real aarch64_static_xored fixture, where the conservative opt-in pass must
+recover exactly the one wrapper the primary pass leaves unclaimed (278 -> 279)
+without disturbing any existing function.
+"""
+
+import struct
+import unittest
+
+from smda.common.EhFrameDecoder import decodeEhFrameFdeRanges
+from smda.Disassembler import Disassembler
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager as IntelFunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+from tests.testAArch64Disassembler import AARCH64_STATIC_FIXTURE, _load_xored_fixture
+
+SECTION_VA = 0x10000
+
+
+def _uleb(value):
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def _cie(augmentation=b"zR", fde_encoding=0x00, version=1, aug_extra=b""):
+    body = bytes([version]) + augmentation + b"\x00"
+    body += _uleb(1)  # code alignment factor
+    body += b"\x7c"  # data alignment factor: SLEB -4
+    body += bytes([30]) if version == 1 else _uleb(30)  # return address register
+    if augmentation.startswith(b"z"):
+        aug_data = aug_extra + bytes([fde_encoding]) if b"R" in augmentation else aug_extra
+        body += _uleb(len(aug_data)) + aug_data
+    return _record(0, body)
+
+
+def _record(cie_id, body):
+    payload = struct.pack("<I", cie_id) + body
+    if len(payload) % 4:
+        payload += b"\x00" * (4 - len(payload) % 4)  # DW_CFA_nop padding
+    return struct.pack("<I", len(payload)) + payload
+
+
+def _fde(cie_offset_from_stream_start, stream_pos, initial_location, address_range, fmt):
+    # the CIE pointer counts back from the FDE's own id field (stream_pos + 4)
+    body = struct.pack(fmt, initial_location) + struct.pack(fmt, address_range)
+    return _record(stream_pos + 4 - cie_offset_from_stream_start, body)
+
+
+class EhFrameDecoderTestSuite(unittest.TestCase):
+    def test_absptr_encoding(self):
+        stream = _cie(fde_encoding=0x00)
+        stream += _fde(0, len(stream), 0x401000, 0x40, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x40)])
+
+    def test_pcrel_sdata4_encoding(self):
+        cie = _cie(fde_encoding=0x1B)  # pcrel | sdata4
+        stream = cie
+        fde_field_va = SECTION_VA + len(stream) + 8  # length + id precede the pointer
+        stream += _fde(0, len(stream), 0x401000 - fde_field_va, 0x40, "<i")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x40)])
+
+    def test_multiple_cies_with_distinct_encodings(self):
+        stream = _cie(fde_encoding=0x00)
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        second_cie_at = len(stream)
+        stream += _cie(fde_encoding=0x03)  # absolute udata4
+        stream += _fde(second_cie_at, len(stream), 0x402000, 0x20, "<I")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x10), (0x402000, 0x20)])
+
+    def test_zero_terminator_stops_scan(self):
+        stream = _cie(fde_encoding=0x00)
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        terminated = stream + b"\x00\x00\x00\x00"
+        ignored_cie_at = len(terminated)
+        terminated += _cie(fde_encoding=0x00)
+        terminated += _fde(ignored_cie_at, len(terminated), 0x402000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(terminated, SECTION_VA), [(0x401000, 0x10)])
+
+    def test_dangling_cie_reference_skips_fde_only(self):
+        # a record whose CIE back-pointer resolves to no parsed CIE is skipped,
+        # but the well-formed sibling after it still decodes
+        stream = _cie(fde_encoding=0x00)
+        stream += _record(0xDEAD, struct.pack("<QQ", 0x999000, 0x10))
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x10)])
+
+    def test_unsupported_pointer_encoding_skips_cie_fdes(self):
+        stream = _cie(fde_encoding=0x01)  # uleb128-encoded pointers: unsupported
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        supported_cie_at = len(stream)
+        stream += _cie(fde_encoding=0x00)
+        stream += _fde(supported_cie_at, len(stream), 0x402000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x402000, 0x10)])
+
+    def test_datarel_application_mode_is_unsupported(self):
+        stream = _cie(fde_encoding=0x33)  # datarel | udata4
+        stream += _fde(0, len(stream), 0x1000, 0x10, "<I")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [])
+
+    def test_length_overflow_terminates_scan(self):
+        stream = _cie(fde_encoding=0x00)
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        truncated = stream + struct.pack("<I", 0x1000) + b"\x00" * 8  # claims bytes past the end
+        self.assertEqual(decodeEhFrameFdeRanges(truncated, SECTION_VA), [(0x401000, 0x10)])
+
+    def test_extended_length_record_is_skipped_safely(self):
+        # 0xFFFFFFFF escape with an 8-byte length covering an opaque record
+        extended = struct.pack("<I", 0xFFFFFFFF) + struct.pack("<Q", 8) + b"\x00" * 8
+        stream = extended + _cie(fde_encoding=0x00)
+        stream += _fde(len(extended), len(stream), 0x401000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x10)])
+
+    def test_personality_and_lsda_augmentation_parses(self):
+        # zPLR: personality encoding 0x03 (udata4) + 4-byte pointer, LSDA encoding byte
+        aug_extra = bytes([0x03]) + struct.pack("<I", 0x5000) + bytes([0x03])
+        stream = _cie(augmentation=b"zPLR", fde_encoding=0x00, aug_extra=aug_extra)
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x10)])
+
+    def test_version3_cie_with_uleb_return_register(self):
+        stream = _cie(fde_encoding=0x00, version=3)
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x10)])
+
+    def test_record_cap_bounds_work(self):
+        stream = _cie(fde_encoding=0x00)
+        for index in range(8):
+            stream += _fde(0, len(stream), 0x401000 + index * 0x10, 0x10, "<Q")
+        capped = decodeEhFrameFdeRanges(stream, SECTION_VA, max_records=3)
+        self.assertEqual(len(capped), 2)  # cap includes the CIE record
+        self.assertEqual(len(decodeEhFrameFdeRanges(stream, SECTION_VA)), 8)
+
+    def test_intel_manager_has_no_deferred_sources(self):
+        self.assertEqual(tuple(IntelFunctionCandidateManager(SmdaConfig()).locateDeferredCandidates()), ())
+
+
+class EhFrameFixtureTestSuite(unittest.TestCase):
+    """Real-fixture behavior: default off is covered by the 278-function
+    assertions in testAArch64Disassembler; opting in must add exactly the one
+    unclaimed wrapper (0x411f50) and change nothing else."""
+
+    def test_opt_in_recovers_unclaimed_wrapper(self):
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        config.USE_ELF_EH_FRAME_CANDIDATES = True
+        report = Disassembler(config).disassembleUnmappedBuffer(_load_xored_fixture(AARCH64_STATIC_FIXTURE))
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.num_functions, 279)
+        self.assertIn(0x411F50, {function.offset for function in report.getFunctions()})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testEhFrameCandidates.py
+++ b/tests/testEhFrameCandidates.py
@@ -126,6 +126,22 @@ class EhFrameDecoderTestSuite(unittest.TestCase):
         stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
         self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [(0x401000, 0x10)])
 
+    def test_truncated_cie_header_marks_cie_unsupported(self):
+        # CIE body ends inside the code-alignment ULEB (continuation bit set on the
+        # record's last byte); the CIE must be rejected and its FDE skipped
+        truncated_cie = _record(0, bytes([1]) + b"\x00" + b"\x80\x80")
+        stream = truncated_cie + _fde(0, len(truncated_cie), 0x401000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [])
+
+    def test_unsupported_personality_encoding_marks_cie_unsupported(self):
+        # zPR with a uleb128-encoded personality pointer (0x01): its size is unknown,
+        # so the cursor cannot reach the R byte reliably - the CIE must be rejected
+        # rather than misreading a data byte as the FDE encoding
+        aug_extra = bytes([0x01, 0x00])
+        stream = _cie(augmentation=b"zPR", fde_encoding=0x00, aug_extra=aug_extra)
+        stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")
+        self.assertEqual(decodeEhFrameFdeRanges(stream, SECTION_VA), [])
+
     def test_version3_cie_with_uleb_return_register(self):
         stream = _cie(fde_encoding=0x00, version=3)
         stream += _fde(0, len(stream), 0x401000, 0x10, "<Q")

--- a/tests/testEhFrameCandidates.py
+++ b/tests/testEhFrameCandidates.py
@@ -159,6 +159,91 @@ class EhFrameDecoderTestSuite(unittest.TestCase):
         self.assertEqual(tuple(IntelFunctionCandidateManager(SmdaConfig()).locateDeferredCandidates()), ())
 
 
+def _build_aarch64_elf_with_ehframe(code, eh_frame, base=0x400000, vaddr=0x401000, eh_vaddr=0x402000):
+    """ELF64/AArch64 with one R+X PT_LOAD plus a real .eh_frame section (non-exec)."""
+    em_aarch64, ehsize, phentsize, shentsize = 183, 64, 56, 64
+    shstrtab = b"\x00.text\x00.eh_frame\x00.shstrtab\x00"
+    name_text = shstrtab.index(b".text")
+    name_eh = shstrtab.index(b".eh_frame")
+    name_str = shstrtab.index(b".shstrtab")
+
+    text_off = ehsize + phentsize
+    eh_off = eh_vaddr - base  # keep file offset == vaddr - base for the whole segment
+    shstr_off = eh_off + len(eh_frame)
+    sh_off = shstr_off + len(shstrtab)
+
+    ehdr = struct.pack(
+        "<16sHHIQQQIHHHHHH",
+        b"\x7fELF\x02\x01\x01" + b"\x00" * 9,
+        2,
+        em_aarch64,
+        1,
+        vaddr,  # e_entry
+        ehsize,
+        sh_off,
+        0,
+        ehsize,
+        phentsize,
+        1,
+        shentsize,
+        4,  # e_shnum
+        3,  # e_shstrndx
+    )
+    phdr = struct.pack("<IIQQQQQQ", 1, 5, 0, base, base, sh_off, sh_off, 0x1000)
+
+    def shdr(name, sh_type, flags, addr, offset, size, align, entsize):
+        return struct.pack("<IIQQQQIIQQ", name, sh_type, flags, addr, offset, size, 0, 0, align, entsize)
+
+    blob = bytearray(sh_off + 4 * shentsize)
+    blob[0:ehsize] = ehdr
+    blob[ehsize : ehsize + phentsize] = phdr
+    blob[text_off : text_off + len(code)] = code
+    blob[eh_off : eh_off + len(eh_frame)] = eh_frame
+    blob[shstr_off : shstr_off + len(shstrtab)] = shstrtab
+    sections = (
+        shdr(0, 0, 0, 0, 0, 0, 0, 0)
+        + shdr(name_text, 1, 0x2 | 0x4, vaddr, text_off, len(code), 4, 0)  # ALLOC|EXECINSTR
+        + shdr(name_eh, 1, 0x2, eh_vaddr, eh_off, len(eh_frame), 8, 0)  # ALLOC only
+        + shdr(name_str, 3, 0, 0, shstr_off, len(shstrtab), 1, 0)
+    )
+    blob[sh_off : sh_off + len(sections)] = sections
+    return bytes(blob)
+
+
+class EhFrameDeferredOrderingTestSuite(unittest.TestCase):
+    def test_earlier_deferred_function_does_not_absorb_later_fde_start(self):
+        # f1 (0x401004) tail-branches into f2 (0x40100c); both are reachable only
+        # via .eh_frame. All accepted FDE starts must be registered as function
+        # starts BEFORE f1 is analyzed, or f1 absorbs f2's bytes and f2 is then
+        # skipped as already-claimed code.
+        # the branch must not be f1's first instruction (a lone-branch stub is
+        # already left unabsorbed by the STUB-TAILCALL case) and the target must
+        # be forward and nearby (backward / far targets hit the tailcall cases)
+        code = b"".join(
+            word.to_bytes(4, "little")
+            for word in [
+                0xD65F03C0,  # 0x401000 entry: ret (claimed by the OEP/symbol pass)
+                0xD2800020,  # 0x401004 f1: mov x0, #1
+                0x14000001,  # 0x401008     b 0x40100c (tail-branch into f2)
+                0xD65F03C0,  # 0x40100c f2: ret
+            ]
+        )
+        eh_vaddr = 0x402000
+        eh_frame = _cie(fde_encoding=0x00)
+        eh_frame += _fde(0, len(eh_frame), 0x401004, 8, "<Q")
+        eh_frame += _fde(0, len(eh_frame), 0x40100C, 4, "<Q")
+        blob = _build_aarch64_elf_with_ehframe(code, eh_frame, eh_vaddr=eh_vaddr)
+
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        config.USE_ELF_EH_FRAME_CANDIDATES = True
+        report = Disassembler(config).disassembleUnmappedBuffer(blob)
+        self.assertEqual(report.status, "ok")
+        offsets = {function.offset for function in report.getFunctions()}
+        self.assertIn(0x401004, offsets)
+        self.assertIn(0x40100C, offsets)
+
+
 class EhFrameFixtureTestSuite(unittest.TestCase):
     """Real-fixture behavior: default off is covered by the 278-function
     assertions in testAArch64Disassembler; opting in must add exactly the one


### PR DESCRIPTION
## Summary

AArch64 platform boosts: three new function-candidate sources that exploit authoritative platform metadata, plus a fix that finally lets the analysis-timeout callback stop candidate identification itself. Every behavioral addition is evidence-gated — the two sources that could change results on unvalidated formats land **default-off** behind config flags, and the one default-on source is verified byte-identical on the committed Mach-O corpus.

## Motivation

The AArch64 backend so far only consumed generic evidence (symbols, BL refs, prologues, ELF init arrays). PE ARM64 exception directories, ELF `.eh_frame` FDEs, and Mach-O function-pointer metadata are authoritative platform tables the backend ignored. Separately, `cbAnalysisTimeout` never reached the candidate managers, so the wall-clock timeout could not interrupt the (potentially large) candidate scans.

## Changes

1. **`fix(core)`: timeout callback wired into candidate identification.** `RecursiveDisassembler.analyzeBuffer` received `cbAnalysisTimeout` but dropped it at the `fc_manager.init()` call site — the intel manager's `_cb_analysis_timeout` polling was dead code. Now forwarded on both backends; all new scans poll it. The same dropped-callback class was swept tree-wide, which surfaced and fixed a sibling: `IdaExporter.analyzeBuffer` accepted `cb_analysis_timeout` but never consulted it.
2. **`feat(aarch64)`: PE ARM64 exception directory** (`USE_PE_ARM64_PDATA_CANDIDATES = False`). Classic `0xAA64` images only — ARM64X/ARM64EC hybrids are skipped (incl. via CHPE load-config metadata; on lief builds that cannot distinguish hybrids the pass conservatively does nothing). Bounds come from the Exception Directory data directory's exact RVA/size, not page-rounded section bounds. 8-byte `<BeginRVA, UnwindData>` records: flag-0 entries require a validated in-image `.xdata` header, flag-1 packed-primary entries are accepted, flag-2 fragments and flag-3 reserved entries are skipped; starts must be 4-aligned and executable. Accepted starts use the existing high-confidence exception-candidate path shared with x64 `.pdata`.
3. **`feat(aarch64)`: ELF `.eh_frame` FDE candidates** (`USE_ELF_EH_FRAME_CANDIDATES = False`) via a bounded pure decoder (`smda.common.EhFrameDecoder`: extended-length escape, `z*` augmentations with fully validated CIE header reads, absolute + pcrel DW_EH_PE encodings; malformed records skip or terminate safely; record count and reads are capped) and a new deferred-candidate engine hook (`locateDeferredCandidates()`, no-op on the base manager) that runs after the primary pass so existing `code_map` claims veto promotions — an already-claimed FDE start is dropped instead of splitting a function. All accepted starts are registered (including in the function-start candidate set) **before** any is analyzed, so an earlier deferred function cannot absorb a later FDE start it tail-branches into; the candidate cap is respected. Promoted starts get ordinary candidate bookkeeping, deliberately below exception-candidate priority.
4. **`feat(aarch64)`: Mach-O function-pointer metadata** (default on — platform-native equivalent of the ELF `.init_array` source): `MOD_INIT_FUNC_POINTERS`, `MOD_TERM_FUNC_POINTERS`, `THREAD_LOCAL_INIT_FUNCTION_POINTERS`, `INIT_FUNC_OFFSETS` (32-bit image-base offsets), and the replacement slot of interposing pairs only — no broad data sweeps. Slot resolution is fixup-aware: binding slots (imports) never count, chained-fixup slots only count when a LIEF `RelocationFixup` names their target, classic images read the stored unslid pointer and apply the fat-slice address adjustment. Targets must be instruction-aligned, inside instruction-flagged sections, outside `__stubs`. Plus `USE_MACHO_ADDRESS_REF_CANDIDATES = False`: opt-in extension of the adr/adrp scan to `S_ATTR_PURE_INSTRUCTIONS` sections, recording targets as weak evidence (no call-ref score). Per-binary caches reset before base initialization so reused manager instances cannot consume stale fixup state.
5. **`docs`**: README support wording (x86/x64 + AArch64 backends, PE/ELF/Mach-O incl. fat binaries, Python 3.10+).

## Validation

- `make lint` clean; full suite green (495 passed, 1 skipped).
- New tests: `tests/testAnalysisTimeoutCallback.py`, `tests/testAArch64PdataExtraction.py` (11 synthetic spec-valid PE32+ cases), `tests/testEhFrameCandidates.py` (16 decoder cases incl. truncated/malformed CIE headers, a deferred-ordering regression, and real-fixture integration), `tests/testAArch64MachoMetadataCandidates.py` (12 synthetic thin+fat Mach-O cases). Every bug-shaped fix has a regression test verified to fail on the pre-fix code.
- Real-fixture evidence for `.eh_frame`: the decoder yields 276 FDE ranges on the static AArch64 fixture; defaults keep exactly 278 functions; opting in recovers only the one unclaimed wrapper (279 total, no ownership changes).
- Mach-O default-on source: per-fixture function sets across all 12 corpus samples are byte-identical before/after (the corpus contains no such metadata sections — synthetic images carry the coverage, and the opt-in flags stay off until real-format ground truth supports flipping them).

## Prior review

This change was reviewed on the fork as r0ny123#101 (gemini-code-assist, codex, and CodeRabbit passes): three findings were confirmed and are folded into these commits — full CIE-header-read validation in the `.eh_frame` decoder, pre-registration of all deferred FDE starts before analysis, and per-binary cache reset ordering plus candidate-cap enforcement in the deferred pass. Fork CI is fully green.
