### PR TITLE
fix(aarch64): improve function-boundary accuracy on ARM64 PE binaries

### DIFF
--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -142,8 +142,18 @@ class AArch64Backend(ArchBackend):
             return cursor
         if skipped_nop and cursor % 16 == 0:
             word = cls._wordAt(d, cursor)
-            if word not in (None, 0, NOP):
-                return cursor
+            if word in (None, 0, NOP):
+                return None
+            # MSVC ARM64 nop-aligns loop heads MID-function, so on PE images an
+            # aligned word after call-fallthrough padding is only a boundary when
+            # it actually looks like a function entry (real starts are seeded by
+            # .pdata/candidates anyway). clang/Go pad between functions and emit
+            # prologue-less entries, so other formats keep the plain alignment cut.
+            if d.disassembly.binary_info._getLiefType() == "PE" and not (
+                is_function_prologue(word) or is_bti_landing_pad(word)
+            ):
+                return None
+            return cursor
         return None
 
     def _analyzeCondBranch(self, d, instruction, state):

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -164,8 +164,11 @@ class AArch64Backend(ArchBackend):
         target = self._branchTarget(i_op_str)
         d.tailcall_analyzer.addJump(i_address, target if target is not None else 0)
         if target is not None:
-            if target in d.disassembly.functions:
-                # taken edge into an already-recovered function: a conditional tailcall edge
+            if target in d.disassembly.functions or self._isExceptionRecordStart(d, target):
+                # taken edge into an already-recovered function, or into a start named
+                # by the image's exception records (PE .pdata — authoritative
+                # boundaries): a conditional tailcall edge, leave the target for its
+                # own analysis instead of absorbing it.
                 state.setSanelyEnding(True)
             else:
                 # AArch64 conditional branches are ordinary intra-function CFG edges.
@@ -174,6 +177,18 @@ class AArch64Backend(ArchBackend):
                 state.addBlockToQueue(target)
             state.addCodeRef(i_address, target, by_jump=True)
         state.setBlockEndingInstruction(True)
+
+    @classmethod
+    def _isExceptionRecordStart(cls, d, addr):
+        # An exception-record-seeded candidate (PE .pdata) is only treated as an
+        # authoritative boundary when it also opens like a function entry: exception
+        # records name funclets and function fragments too, and those continue the
+        # enclosing function (their record start is a mid-body word, not a prologue).
+        candidate = d.fc_manager.candidates.get(addr)
+        if candidate is None or not candidate.is_exception_handler:
+            return False
+        word = cls._wordAt(d, addr)
+        return word is not None and (is_function_prologue(word) or is_bti_landing_pad(word))
 
     @staticmethod
     def _isBackwardTailcallTarget(target, state):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -59,6 +59,7 @@ from .definitions import (
     is_bti_landing_pad,
     is_conditional_branch,
     is_function_prologue,
+    is_trap,
     rd_field,
     rn_field,
 )
@@ -673,6 +674,7 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
             or (prev_word & BR_MASK) == BR_VALUE
             or (prev_word & B_MASK) == B_VALUE
             or (prev_word & BL_MASK) == BL_VALUE
+            or is_trap(prev_word)
             or auth_or_exception_return
         )
 
@@ -680,8 +682,8 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
         # AArch64 gap scan: a fixed-stride linear sweep of unanalyzed executable bytes
         # for functions that no prologue, call reference or stored pointer reached
         # (typically unreferenced / indirect-only routines). Guards keep each gap
-        # candidate at a plausible function entry: skip padding (nop / zero) and a
-        # leading conditional branch, constrain to genuine executable sections (the
+        # candidate at a plausible function entry: skip padding (nop / zero), a
+        # leading conditional branch or trap, constrain to genuine executable sections (the
         # loader's code_areas can be a coarse segment covering data), and drop runs
         # that flow into the interior of an already-mapped function.
         if self.gap_pointer is None:
@@ -723,6 +725,9 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if is_conditional_branch(word):  # a function never opens with a cond branch
+                self.gap_pointer += INSTRUCTION_SIZE
+                continue
+            if is_trap(word):  # udf-space data words / trap filler, never an entry
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if self.previously_analyzed_gap == self.gap_pointer:

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -150,6 +150,27 @@ def is_conditional_branch(word):
     )
 
 
+# --- trap / permanently-undefined encodings --------------------------------
+# udf #imm16 occupies the reserved all-zero-top-halfword space (0x0000iiii);
+# brk/hlt carry imm16 at bits [20:5]. Verified live against capstone 5.0.7.
+UDF_MASK = 0xFFFF0000
+UDF_VALUE = 0x00000000
+BRK_MASK = 0xFFE0001F
+BRK_VALUE = 0xD4200000
+HLT_MASK = 0xFFE0001F
+HLT_VALUE = 0xD4400000
+
+
+def is_trap(word):
+    """True for udf/brk/hlt (trap and permanently-undefined encodings).
+
+    A function never opens with one of these: in unclaimed gaps such words are
+    embedded data that happens to decode into the udf space, or trap filler
+    between functions, so the gap scan must not promote them to entries.
+    """
+    return (word & UDF_MASK) == UDF_VALUE or (word & BRK_MASK) == BRK_VALUE or (word & HLT_MASK) == HLT_VALUE
+
+
 # --- function-entry prologues ---------------------------------------------
 # AArch64 has no single dominant byte prologue (no `push ebp`). The recognized
 # strong, position-independent function-start markers are, in rough frequency

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -165,10 +165,12 @@ GAP_SEQUENCES = {
     1: [
         b"\x90",  # NOP1_OVERRIDE_NOP - AMD / nop - INTEL
         b"\xcc",  # int3
+        b"\xf4",  # hlt - trap filler, a function never opens with it
         b"\x00",  # pass over sequences of null bytes
     ],
     2: [
         b"\x66\x90",  # NOP2_OVERRIDE_NOP - AMD / nop - INTEL
+        b"\x0f\x0b",  # ud2 - trap filler, a function never opens with it
         b"\x8b\xc0",  # mov eax, eax
         b"\x89\xc0",  # mov eax, eax
         b"\x8b\xff",  # mov edi, edi

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -28,7 +28,12 @@ import lief
 from smda.aarch64.AArch64Backend import AArch64Backend
 from smda.aarch64.AArch64CapstoneVerification import is_control_flow_mnemonic
 from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper
-from smda.aarch64.definitions import EXCEPTION_RETURN_INS, adrp_page_value, is_conditional_branch
+from smda.aarch64.definitions import (
+    EXCEPTION_RETURN_INS,
+    adrp_page_value,
+    is_conditional_branch,
+    is_trap,
+)
 from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaReport import SmdaReport
@@ -1300,6 +1305,55 @@ class TestAArch64GapScan(unittest.TestCase):
         self.assertEqual(report.status, "ok")
         self.assertEqual({f.offset for f in report.getFunctions()}, {BASE, BASE + 0x14})
 
+    def _gap_scan_skips_leading_trap_word(self, trap_word):
+        # A gap that opens with a trap encoding (udf/brk/hlt) must never be promoted
+        # to a function: such words are embedded data or filler, not code entries.
+        # The real function f3 immediately after the trap word is still recovered by
+        # the gap scan, proving the sweep continues past the trap rather than stalling.
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        code = b"".join(
+            w.to_bytes(4, "little")
+            for w in [
+                0xA9BF7BFD,  # 0x401000 f1: stp x29, x30, [sp, #-16]!  (prologue -> found)
+                0x52800000,  # 0x401004     mov w0, #0
+                0xA8C17BFD,  # 0x401008     ldp x29, x30, [sp], #16
+                0xD65F03C0,  # 0x40100c     ret
+                0xD503201F,  # 0x401010     nop  (inter-function padding)
+                trap_word,  # 0x401014     trap / data word (must NOT become a function)
+                0xA9BF7BFD,  # 0x401018 f3: stp x29, x30, [sp, #-16]!  (prologue -> found)
+                0x52800020,  # 0x40101c     mov w0, #1
+                0xA8C17BFD,  # 0x401020     ldp x29, x30, [sp], #16
+                0xD65F03C0,  # 0x401024     ret
+            ]
+        )
+        report = Disassembler(config, backend="aarch64").disassembleBuffer(
+            code,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + len(code)]],
+            architecture="aarch64",
+        )
+        self.assertEqual(report.status, "ok")
+        offsets = {f.offset for f in report.getFunctions()}
+        self.assertNotIn(BASE + 0x14, offsets)
+        self.assertEqual(offsets, {BASE, BASE + 0x18})
+
+    def test_gap_scan_skips_leading_udf_trap_word(self):
+        self._gap_scan_skips_leading_trap_word(0x00000036)  # udf #0x36
+
+    def test_gap_scan_skips_leading_brk_trap_word(self):
+        self._gap_scan_skips_leading_trap_word(0xD4200020)  # brk #1
+
+    def test_is_trap_recognizes_udf_brk_hlt_and_rejects_ordinary_code(self):
+        self.assertTrue(is_trap(0x00000036))  # udf #0x36
+        self.assertTrue(is_trap(0x00000000))  # udf #0 (also the all-zero encoding)
+        self.assertTrue(is_trap(0xD4200020))  # brk #1
+        self.assertTrue(is_trap(0xD4400020))  # hlt #1
+        self.assertFalse(is_trap(0xD503201F))  # nop
+        self.assertFalse(is_trap(0xD65F03C0))  # ret
+        self.assertFalse(is_trap(0xA9BF7BFD))  # stp x29, x30, [sp, #-16]!  (prologue)
+
     def test_bti_after_authenticated_return_is_not_suppressed_as_interior(self):
         binary = b"".join(
             word.to_bytes(4, "little")
@@ -1315,6 +1369,25 @@ class TestAArch64GapScan(unittest.TestCase):
         manager._candidate_offsets = set()
 
         self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4))
+
+    def test_bti_after_trap_is_not_suppressed_as_interior(self):
+        # a trap (brk/udf/hlt) ends control flow like ret/b, so a BTI right after a
+        # trap-terminated body (or trap filler) is a legitimate entry landing pad.
+        for trap_word in (0xD4200020, 0x00000036, 0xD4400020):  # brk #1, udf #0x36, hlt #1
+            binary = b"".join(
+                word.to_bytes(4, "little")
+                for word in [
+                    trap_word,
+                    0xD503245F,  # bti c
+                ]
+            )
+            binary_info = BinaryInfo(binary)
+            binary_info.base_addr = BASE
+            manager = FunctionCandidateManager(SmdaConfig())
+            manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={})
+            manager._candidate_offsets = set()
+
+            self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4))
 
     def test_bti_after_drps_is_not_suppressed_as_interior(self):
         # drps (Debug Restore PState) transfers control to ELR_ELx like eret*, so a BTI

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -1010,6 +1010,30 @@ class TestAArch64FunctionBoundaries(unittest.TestCase):
             [second, second + 4, second + 8],
         )
 
+    def test_call_fallthrough_alignment_cut_is_format_scoped_not_prologue_scoped(self):
+        # Control case for the PE-only prologue/BTI gate in _callFallthroughFunctionStart:
+        # a plain mapped buffer (not a PE image) keeps the old unconditional alignment cut
+        # even when the aligned word is definitely NOT a function entry (a mid-body ldr).
+        second = BASE + 0x10
+        report = self._disassemble_words(
+            [
+                0xA9BF7BFD,  # stp x29, x30, [sp, #-16]!
+                _encode_bl(BASE + 4, BASE),  # bl 0x401000
+                0xD503201F,  # nop
+                0xD503201F,  # nop
+                0xF94013A0,  # ldr x0, [x29, #0x20]  -- NOT a recognized function prologue
+                0xD2800020,  # mov x0, #1
+                0xD65F03C0,  # ret
+            ]
+        )
+        self.assertEqual(report.status, "ok")
+        self.assertEqual({f.offset for f in report.getFunctions()}, {BASE, second})
+        self.assertEqual([ins.offset for ins in report.getFunction(BASE).getInstructions()], [BASE, BASE + 4])
+        self.assertEqual(
+            [ins.offset for ins in report.getFunction(second).getInstructions()],
+            [second, second + 4, second + 8],
+        )
+
     def test_call_fallthrough_directly_before_prologue_terminates_function(self):
         second = BASE + 0x8
         report = self._disassemble_words(

--- a/tests/testAArch64PdataExtraction.py
+++ b/tests/testAArch64PdataExtraction.py
@@ -29,12 +29,19 @@ VALID_XDATA = struct.pack("<I", (1 << 27) | 0x10)
 
 
 def _build_arm64_pe(
-    pdata_bytes, xdata_bytes=VALID_XDATA, machine=0xAA64, image_base=IMAGE_BASE, exc_rva=PDATA_RVA, exc_size=None
+    pdata_bytes,
+    xdata_bytes=VALID_XDATA,
+    machine=0xAA64,
+    image_base=IMAGE_BASE,
+    exc_rva=PDATA_RVA,
+    exc_size=None,
+    text_bytes=None,
 ):
     """Minimal PE32+ image: .text (RX) @0x1000, .pdata @0x2000, .xdata @0x3000."""
     if exc_size is None:
         exc_size = len(pdata_bytes)
-    text_bytes = struct.pack("<II", 0xD65F03C0, 0xD503201F) * 64  # ret; nop filler
+    if text_bytes is None:
+        text_bytes = struct.pack("<II", 0xD65F03C0, 0xD503201F) * 64  # ret; nop filler
 
     dos = bytearray(0x40)
     dos[0:2] = b"MZ"
@@ -193,6 +200,63 @@ class AArch64PdataExtractionTestSuite(unittest.TestCase):
         records = _record(TEXT_RVA, XDATA_RVA)
         fcm = _candidates_for(_build_arm64_pe(records), cb_timeout=lambda: True)
         self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+
+
+class AArch64CallFallthroughAlignmentTestSuite(unittest.TestCase):
+    """MSVC ARM64 nop-aligns loop heads MID-function; on PE images an aligned word
+    after a bl-fallthrough gap must only be treated as a new function start when it
+    actually looks like a function entry (stp/str prologue, PAC, or BTI). A plain
+    16-aligned non-entry word (e.g. a mid-body ldr) must stay inside the calling
+    function instead of being promoted to a bogus function start."""
+
+    # stp x29,x30,[sp,#-16]!
+    STP_PROLOGUE = 0xA9BF7BFD
+    # bl <delta=0x28> -> targets the stp prologue at .text+0x2C
+    BL_TO_0x2C = 0x9400000A
+    NOP = 0xD503201F
+    # ldr x0,[x29,#0x20]: 16-aligned, but NOT a recognized function prologue
+    LDR_MID_BODY = 0xF94013A0
+    MOV_X0_1 = 0xD2800020
+    RET = 0xD65F03C0
+
+    def _words(self):
+        return [
+            self.STP_PROLOGUE,  # +0x00: function entry
+            self.BL_TO_0x2C,  # +0x04: bl call
+            self.NOP,  # +0x08: skipped padding
+            self.NOP,  # +0x0C: skipped padding
+            self.LDR_MID_BODY,  # +0x10: 16-aligned, NOT an entry -> must stay in caller
+            self.MOV_X0_1,  # +0x14
+            self.RET,  # +0x18: caller's own return
+            self.NOP,  # +0x1C
+            self.NOP,  # +0x20
+            self.NOP,  # +0x24
+            self.NOP,  # +0x28
+            self.STP_PROLOGUE,  # +0x2C: bl target, a real function entry
+            self.RET,  # +0x30
+        ]
+
+    def _disassemble_pe(self):
+        code = b"".join(w.to_bytes(4, "little") for w in self._words())
+        blob = _build_arm64_pe(b"", text_bytes=code)
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        return Disassembler(config).disassembleUnmappedBuffer(blob)
+
+    def test_aligned_mid_body_word_does_not_split_pe_function(self):
+        report = self._disassemble_pe()
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.architecture, "aarch64")
+        starts = {f.offset for f in report.getFunctions()}
+        # the aligned ldr at +0x10 must NOT be its own function start
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 0x10, starts)
+        caller = report.getFunction(IMAGE_BASE + TEXT_RVA)
+        self.assertEqual(
+            [ins.mnemonic for ins in caller.getInstructions()],
+            ["stp", "bl", "nop", "nop", "ldr", "mov", "ret"],
+        )
+        # the bl's real target (a genuine prologue) is still recovered as its own function
+        self.assertIn(IMAGE_BASE + TEXT_RVA + 0x2C, starts)
 
 
 if __name__ == "__main__":

--- a/tests/testAArch64PdataExtraction.py
+++ b/tests/testAArch64PdataExtraction.py
@@ -259,5 +259,81 @@ class AArch64CallFallthroughAlignmentTestSuite(unittest.TestCase):
         self.assertIn(IMAGE_BASE + TEXT_RVA + 0x2C, starts)
 
 
+class AArch64CondBranchExceptionBoundaryTestSuite(unittest.TestCase):
+    """A conditional-branch taken edge into a .pdata-named start must only be treated
+    as an authoritative boundary (left for its own analysis) when that start also
+    opens like a real function entry. .pdata also names funclets/fragments whose
+    record start is a mid-body word — those must still be absorbed into the caller."""
+
+    # cmp x0, #0
+    CMP_X0_0 = 0xF100001F
+    # b.ne +0xC (from the b.ne word itself at +0x04, targets +0x10)
+    BNE_TO_0x10 = 0x54000061
+    RET = 0xD65F03C0
+    NOP = 0xD503201F
+    # stp x29,x30,[sp,#-0x20]!: a real function entry
+    STP_PROLOGUE = 0xA9BE7BFD
+    # ldp x29,x30,[sp],#0x20
+    LDP_EPILOGUE = 0xA8C27BFD
+    # mov w8, #0: 16-aligned mid-body word, NOT a recognized function entry
+    MOV_W8_0 = 0x52800008
+
+    def _pdata_records(self):
+        return _record(TEXT_RVA, (0x10 << 2) | 1) + _record(TEXT_RVA + 0x10, (0x10 << 2) | 1)
+
+    def _disassemble(self, words):
+        code = b"".join(w.to_bytes(4, "little") for w in words)
+        blob = _build_arm64_pe(self._pdata_records(), text_bytes=code)
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        config.USE_PE_ARM64_PDATA_CANDIDATES = True
+        return Disassembler(config).disassembleUnmappedBuffer(blob)
+
+    def test_pdata_named_prologue_target_splits_out_of_guard_stub(self):
+        words = [
+            self.CMP_X0_0,  # +0x00: guard stub A (also named by a .pdata record)
+            self.BNE_TO_0x10,  # +0x04: b.ne into B's real entry
+            self.RET,  # +0x08: A's own fall-through return
+            self.NOP,  # +0x0C: padding up to B's 16-aligned start
+            self.STP_PROLOGUE,  # +0x10: B, a real function entry, also named by .pdata
+            self.LDP_EPILOGUE,  # +0x14
+            self.RET,  # +0x18
+        ]
+        report = self._disassemble(words)
+        self.assertEqual(report.status, "ok")
+        starts = {f.offset for f in report.getFunctions()}
+        # both the guard stub and the real function it conditionally branches into
+        # must be recovered as their own functions, not merged into one
+        self.assertIn(IMAGE_BASE + TEXT_RVA, starts)
+        self.assertIn(IMAGE_BASE + TEXT_RVA + 0x10, starts)
+        guard = report.getFunction(IMAGE_BASE + TEXT_RVA)
+        self.assertEqual(
+            [ins.mnemonic for ins in guard.getInstructions()],
+            ["cmp", "b.ne", "ret"],
+        )
+
+    def test_pdata_named_funclet_continuation_stays_absorbed(self):
+        words = [
+            self.CMP_X0_0,  # +0x00: guard stub A (also named by a .pdata record)
+            self.BNE_TO_0x10,  # +0x04: b.ne into the funclet's .pdata-named start
+            self.RET,  # +0x08: A's own fall-through return
+            self.NOP,  # +0x0C: padding
+            self.MOV_W8_0,  # +0x10: .pdata names this word, but it is NOT an entry shape
+            self.RET,  # +0x14
+        ]
+        report = self._disassemble(words)
+        self.assertEqual(report.status, "ok")
+        starts = {f.offset for f in report.getFunctions()}
+        # the .pdata record at +0x10 names a funclet/fragment continuation, not an
+        # independent function start -- it must stay absorbed into the guard stub
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 0x10, starts)
+        self.assertIn(IMAGE_BASE + TEXT_RVA, starts)
+        guard = report.getFunction(IMAGE_BASE + TEXT_RVA)
+        self.assertEqual(
+            [ins.mnemonic for ins in guard.getInstructions()],
+            ["cmp", "b.ne", "ret", "mov", "ret"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -469,6 +469,12 @@ class TestIntelDisassembler(unittest.TestCase):
         # as an effective NOP and skipped, so it is never returned as the candidate start.
         self.assertNotEqual(self._first_gap_candidate(b"\x8b\xff\x90\x90\x90"), 0x1010)
 
+    def test_gap_scan_skips_hlt_and_ud2_trap_filler(self):
+        # hlt (0xf4) and ud2 (0x0f 0x0b) are trap filler a function never opens with;
+        # the gap scanner must skip them like int3 and promote the code behind them.
+        self.assertEqual(self._first_gap_candidate(b"\xf4\x55\x8b\xec"), 0x1011)
+        self.assertEqual(self._first_gap_candidate(b"\x0f\x0b\x55\x8b\xec"), 0x1012)
+
     def test_is_hotpatch_prologue_predicate(self):
         # The shared predicate backs both the gap scanner and the post-call alignment-cut
         # path, so lock its contract directly: both `mov edi, edi` encodings of the MSVC


### PR DESCRIPTION
## Summary

Fixes three pre-existing function-boundary bug classes in the AArch64 backend (plus one sibling in the intel gap scan), found while validating SMDA against IDA ground truth on real ARM64 PE binaries (wermgr.exe, ping.exe, robocopy.exe, bcrypt.dll — Microsoft-signed system binaries). All three classes reproduce independently of the `.pdata` feature from #185 (they occur with `USE_PE_ARM64_PDATA_CANDIDATES` off), so they are fixed here on their own branch.

## Bug classes and fixes (one commit each)

**1. Data misread as code — trap-opening gap candidates** (`449acbe`, `c1058f7`)
`nextGapCandidate()` rejected gap candidates opening with a conditional branch but not ones opening with a trap encoding. On ARM64, `udf #imm16` encodes as `0x0000_iiii`, so exception-data words in executable sections were promoted to function starts. Fix: raw-word trap predicates (`udf`/`brk`/`hlt`) in `definitions.py`, used to skip trap-opening gap candidates and to count trap words as valid boundaries for the interior-BTI check. The intel gap scan had the same blind spot for `hlt`/`ud2` trap filler (`c1058f7`).

**2. Mid-function splits after alignment NOPs** (`108c669`)
`_callFallthroughFunctionStart()` promoted any 16-aligned non-padding word after a `bl` + NOP run to a function start. MSVC ARM64 nop-aligns loop heads *mid-function*, so hot-loop heads were split into bogus functions. Fix: on PE images, the aligned word must also look like a function entry (prologue or BTI landing pad). Deliberately scoped to PE: clang/Go (Mach-O/ELF) pad between functions and emit prologue-less entries, so other formats keep the plain alignment cut — an unscoped gate cost ~150 real function starts on the Mach-O corpus.

**3. Guard stubs absorbing `.pdata`-named functions across conditional branches** (`c5b3f0f`)
`_analyzeCondBranch()` absorbed the taken target of a `b.<cond>` unless the target was already a recovered function — unlike `_analyzeUncondBranch()`, it never consulted candidate state. A small guard stub ending in `b.ne <real_function>` swallowed the entire following function even when `.pdata` explicitly named it. Fix: treat an exception-record-seeded candidate as an authoritative boundary (conditional tailcall edge) — but only when its first word is entry-shaped, because `.pdata` also names funclets/fragments whose record start is a mid-body word and those must stay absorbed (an unconditional guard added +34 false starts on bcrypt.dll).

## Results (function starts vs IDA, `.pdata` candidates enabled)

| sample | FP before → after | FN before → after |
|---|---|---|
| wermgr.exe | 87 → 71 | 22 → 21 |
| robocopy.exe | 118 → 78 | 19 → 18 |
| ping.exe | 11 → 10 | 5 → 4 |
| bcrypt.dll | 74 → 74 | 10 → 9 |

With `.pdata` candidates off, wermgr.exe improves 118 → 102 FP. Exact per-fixture function-*set* diffs (not counts) on the 12-sample Mach-O corpus and the static ELF fixture are byte-for-byte neutral for fixes 2–3; fix 1 removes only byte-verified data starts.

## Tests

Regression tests for each class (each verified to fail on pre-fix code): trap-opening gap rejection, PE call-fallthrough alignment gating (plus a non-PE control asserting the alignment cut still applies), and cond-branch exception-boundary behavior including a funclet-continuation control. `make test`: 525 passed, 1 skipped; ruff clean.
