### PR TITLE
feat(aarch64): enable PE ARM64 exception-directory candidates by default

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -32,8 +32,10 @@ class SmdaConfig:
     USE_ALIGNMENT = True
     USE_SYMBOLS_AS_CANDIDATES = True
     # seed AArch64 function candidates from the PE ARM64 exception directory (classic 0xAA64
-    # images only); off until validated against real ARM64 PE samples with independent labels
-    USE_PE_ARM64_PDATA_CANDIDATES = False
+    # images only); funclet/fragment records are filtered at seeding, and IDA-labeled ARM64
+    # system binaries (wermgr/ping/robocopy/bcrypt) show equal-or-better boundary accuracy
+    # with the directory enabled, so it is on by default
+    USE_PE_ARM64_PDATA_CANDIDATES = True
     # promote unclaimed ELF .eh_frame FDE starts as late AArch64 candidates (after the primary
     # pass, before gap analysis); off until validated against ground-truth function boundaries
     USE_ELF_EH_FRAME_CANDIDATES = False

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -31,6 +31,7 @@ from .definitions import (
     UNCOND_JUMP_INS,
     adrp_page_value,
     is_bti_landing_pad,
+    is_exception_record_entry,
     is_function_prologue,
     rd_field,
     rn_field,
@@ -183,12 +184,12 @@ class AArch64Backend(ArchBackend):
         # An exception-record-seeded candidate (PE .pdata) is only treated as an
         # authoritative boundary when it also opens like a function entry: exception
         # records name funclets and function fragments too, and those continue the
-        # enclosing function (their record start is a mid-body word, not a prologue).
+        # enclosing function (their record start is a mid-body word, not an entry).
         candidate = d.fc_manager.candidates.get(addr)
         if candidate is None or not candidate.is_exception_handler:
             return False
         word = cls._wordAt(d, addr)
-        return word is not None and (is_function_prologue(word) or is_bti_landing_pad(word))
+        return word is not None and is_exception_record_entry(word)
 
     @staticmethod
     def _isBackwardTailcallTarget(target, state):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -58,6 +58,7 @@ from .definitions import (
     adrp_page_value,
     is_bti_landing_pad,
     is_conditional_branch,
+    is_exception_record_entry,
     is_function_prologue,
     is_trap,
     rd_field,
@@ -199,6 +200,17 @@ class FunctionCandidateManager(_IntelFunctionCandidateManager):
                 continue
             addr = base_addr + begin_rva
             if not any(start <= addr < end for start, end in exec_ranges):
+                continue
+            # Exception records also name funclets and function fragments, whose
+            # begin address is a mid-body word continuing the enclosing function;
+            # seeding those as authoritative starts splits real functions. Only a
+            # record whose first word looks like a function entry (prologue, BTI
+            # pad, or a thunk shape) names an independent function start.
+            begin_word_bytes = self.disassembly.getRawBytes(begin_rva, 4)
+            if begin_word_bytes is None or len(begin_word_bytes) < 4:
+                continue
+            begin_word = int.from_bytes(begin_word_bytes, "little")
+            if not is_exception_record_entry(begin_word):
                 continue
             self.addExceptionCandidate(addr)
 

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -247,3 +247,40 @@ def is_function_prologue(word):
         and word & STR_IMM9_NEGATIVE
         and (word & 0x1F) == _LINK_REGISTER
     )
+
+
+# movz (64-bit, any hw shift); Rd in the intra-procedure-call scratch registers
+# x16/x17 marks veneer/thunk immediate setup - compilers reserve IP0/IP1 for
+# linker-generated stubs, so ordinary function bodies do not load them first.
+MOVZ_64_MASK = 0xFF800000
+MOVZ_64_VALUE = 0xD2800000
+_IP_REGISTERS = frozenset({16, 17})
+
+
+def is_exception_record_entry(word):
+    """Whether an exception record's begin word looks like an independent
+    function entry rather than a funclet/fragment continuation.
+
+    PE ARM64 exception records also name funclets and function fragments,
+    whose begin address is an ordinary mid-body word (ldr/mov/adrp/branch)
+    continuing the enclosing function. Independent entries named by records
+    open with a recognized prologue or BTI pad, or with one of the
+    thunk-shaped bodies MSVC emits records for: a bare indirect branch
+    (``br xN`` import/guard dispatch), a single callee-saved pre-index store
+    (``str x{19..28}, [sp, #-imm]!``), or veneer immediate setup
+    (``movz x16/x17, #imm``).
+    """
+    if is_function_prologue(word):
+        return True
+    # br xN: single-instruction dispatch/import thunk
+    if (word & BR_MASK) == BR_VALUE:
+        return True
+    # callee-saved single-register save: str x{19..28}, [sp, #-imm]!
+    if (
+        (word & STR_PREINDEX_MASK) == STR_PREINDEX_VALUE
+        and ((word >> 5) & 0x1F) == _SP
+        and word & STR_IMM9_NEGATIVE
+        and (word & 0x1F) in _CALLEE_SAVED_GPR
+    ):
+        return True
+    return (word & MOVZ_64_MASK) == MOVZ_64_VALUE and (word & 0x1F) in _IP_REGISTERS

--- a/tests/testAArch64PdataExtraction.py
+++ b/tests/testAArch64PdataExtraction.py
@@ -169,9 +169,9 @@ class AArch64PdataExtractionTestSuite(unittest.TestCase):
         for offset in (0, 8, 16):
             self.assertIn(IMAGE_BASE + TEXT_RVA + offset, _exception_candidates(fcm))
 
-    def test_default_off_produces_no_exception_candidates(self):
+    def test_enabled_by_default_and_flag_off_produces_no_exception_candidates(self):
         records = _record(TEXT_RVA, XDATA_RVA)
-        self.assertFalse(SmdaConfig().USE_PE_ARM64_PDATA_CANDIDATES)
+        self.assertTrue(SmdaConfig().USE_PE_ARM64_PDATA_CANDIDATES)
         fcm = _candidates_for(_build_arm64_pe(records), use_pdata=False)
         self.assertNotIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
 

--- a/tests/testAArch64PdataExtraction.py
+++ b/tests/testAArch64PdataExtraction.py
@@ -41,7 +41,9 @@ def _build_arm64_pe(
     if exc_size is None:
         exc_size = len(pdata_bytes)
     if text_bytes is None:
-        text_bytes = struct.pack("<II", 0xD65F03C0, 0xD503201F) * 64  # ret; nop filler
+        # stp x29,x30,[sp,#-16]!; ret filler: every 8-aligned word is entry-shaped,
+        # so records targeting TEXT_RVA+8k pass the funclet/fragment begin-word gate
+        text_bytes = struct.pack("<II", 0xA9BF7BFD, 0xD65F03C0) * 64
 
     dos = bytearray(0x40)
     dos[0:2] = b"MZ"
@@ -119,26 +121,65 @@ def _candidates_for(blob, use_pdata=True, cb_timeout=None):
     return fcm
 
 
+def _exception_candidates(fcm):
+    # entry-shaped begin words are also picked up by the prologue scanner, so
+    # membership in fcm.candidates alone cannot prove the exception path ran
+    return {addr for addr, candidate in fcm.candidates.items() if candidate.is_exception_handler}
+
+
 class AArch64PdataExtractionTestSuite(unittest.TestCase):
     def test_accepts_xdata_and_packed_primary_records(self):
         records = _record(TEXT_RVA, XDATA_RVA) + _record(TEXT_RVA + 8, (0x10 << 2) | 1)
         fcm = _candidates_for(_build_arm64_pe(records))
-        self.assertIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
-        self.assertIn(IMAGE_BASE + TEXT_RVA + 8, fcm.candidates)
-        self.assertTrue(fcm.candidates[IMAGE_BASE + TEXT_RVA].is_exception_handler)
-        self.assertTrue(fcm.candidates[IMAGE_BASE + TEXT_RVA + 8].is_exception_handler)
+        self.assertIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
+        self.assertIn(IMAGE_BASE + TEXT_RVA + 8, _exception_candidates(fcm))
+
+    def test_skips_records_with_non_entry_shaped_begin_words(self):
+        # funclets/fragments: .pdata names them too, but their begin word is a
+        # mid-body instruction, not a prologue/BTI — they must not be seeded
+        # (covers both the xdata-RVA and the packed-primary record forms)
+        records = (
+            _record(TEXT_RVA + 4, XDATA_RVA)  # -> ret (mid-body word)
+            + _record(TEXT_RVA + 12, (0x10 << 2) | 1)  # packed primary -> ret
+        )
+        fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 4, _exception_candidates(fcm))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 12, _exception_candidates(fcm))
+
+    def test_accepts_bti_landing_pad_begin_word(self):
+        text = struct.pack("<III", 0xD503245F, 0xD2800020, 0xD65F03C0)  # bti c; mov x0,#1; ret
+        records = _record(TEXT_RVA, XDATA_RVA)
+        fcm = _candidates_for(_build_arm64_pe(records, text_bytes=text))
+        self.assertIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
+
+    def test_accepts_thunk_shaped_begin_words(self):
+        # MSVC emits .pdata records for thunk-shaped functions too: bare indirect
+        # branch, callee-saved single-register save, veneer immediate setup
+        text = struct.pack(
+            "<IIIIII",
+            0xD61F0120,  # +0x00: br x9
+            0xD503201F,  # +0x04: nop
+            0xF81F0FF3,  # +0x08: str x19, [sp, #-0x10]!
+            0xD65F03C0,  # +0x0C: ret
+            0xD2B00010,  # +0x10: mov x16, #0x80000000
+            0xD65F03C0,  # +0x14: ret
+        )
+        records = _record(TEXT_RVA, XDATA_RVA) + _record(TEXT_RVA + 8, XDATA_RVA) + _record(TEXT_RVA + 16, XDATA_RVA)
+        fcm = _candidates_for(_build_arm64_pe(records, text_bytes=text))
+        for offset in (0, 8, 16):
+            self.assertIn(IMAGE_BASE + TEXT_RVA + offset, _exception_candidates(fcm))
 
     def test_default_off_produces_no_exception_candidates(self):
         records = _record(TEXT_RVA, XDATA_RVA)
         self.assertFalse(SmdaConfig().USE_PE_ARM64_PDATA_CANDIDATES)
         fcm = _candidates_for(_build_arm64_pe(records), use_pdata=False)
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
 
     def test_skips_fragment_and_reserved_flags(self):
         records = _record(TEXT_RVA, (0x10 << 2) | 2) + _record(TEXT_RVA + 8, (0x10 << 2) | 3)
         fcm = _candidates_for(_build_arm64_pe(records))
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, _exception_candidates(fcm))
 
     def test_skips_invalid_xdata_records(self):
         bad_version = struct.pack("<I", (1 << 27) | (1 << 18) | 0x10)  # Vers=1
@@ -151,7 +192,7 @@ class AArch64PdataExtractionTestSuite(unittest.TestCase):
         )
         fcm = _candidates_for(_build_arm64_pe(records, xdata_bytes=bad_version + zero_length))
         for offset in (0, 8, 16, 24):
-            self.assertNotIn(IMAGE_BASE + TEXT_RVA + offset, fcm.candidates)
+            self.assertNotIn(IMAGE_BASE + TEXT_RVA + offset, _exception_candidates(fcm))
 
     def test_skips_misaligned_and_non_executable_starts(self):
         records = (
@@ -160,16 +201,16 @@ class AArch64PdataExtractionTestSuite(unittest.TestCase):
             + _record(0x8000, XDATA_RVA)  # aligned but outside any section
         )
         fcm = _candidates_for(_build_arm64_pe(records))
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 2, fcm.candidates)
-        self.assertNotIn(IMAGE_BASE + XDATA_RVA, fcm.candidates)
-        self.assertNotIn(IMAGE_BASE + 0x8000, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 2, _exception_candidates(fcm))
+        self.assertNotIn(IMAGE_BASE + XDATA_RVA, _exception_candidates(fcm))
+        self.assertNotIn(IMAGE_BASE + 0x8000, _exception_candidates(fcm))
 
     def test_rebased_image_seeds_candidates_at_new_base(self):
         new_base = 0x180000000
         records = _record(TEXT_RVA, XDATA_RVA)
         fcm = _candidates_for(_build_arm64_pe(records, image_base=new_base))
-        self.assertIn(new_base + TEXT_RVA, fcm.candidates)
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertIn(new_base + TEXT_RVA, _exception_candidates(fcm))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
 
     def test_truncated_directory_stops_at_image_end(self):
         # the directory claims 3 records but the mapped image ends after the first;
@@ -177,29 +218,30 @@ class AArch64PdataExtractionTestSuite(unittest.TestCase):
         blob = bytearray(_build_arm64_pe(b"", exc_rva=0x31F8, exc_size=24))
         blob[0x7F8:0x800] = _record(TEXT_RVA, (0x10 << 2) | 1)
         fcm = _candidates_for(bytes(blob))
-        self.assertIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
 
     def test_zero_record_terminates_scan(self):
         records = _record(TEXT_RVA, XDATA_RVA) + _record(0, 0) + _record(TEXT_RVA + 8, (0x10 << 2) | 1)
         fcm = _candidates_for(_build_arm64_pe(records))
-        self.assertIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, fcm.candidates)
+        self.assertIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, _exception_candidates(fcm))
 
     def test_duplicate_records_yield_single_candidate(self):
         records = _record(TEXT_RVA, XDATA_RVA) * 2
         fcm = _candidates_for(_build_arm64_pe(records))
+        self.assertIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
         self.assertEqual(sum(1 for addr in fcm.candidates if addr == IMAGE_BASE + TEXT_RVA), 1)
 
     def test_non_arm64_machine_is_ignored(self):
         # ARM64EC images carry machine AMD64 (0x8664); the classic-machine gate skips them
         records = _record(TEXT_RVA, XDATA_RVA)
         fcm = _candidates_for(_build_arm64_pe(records, machine=0x8664))
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
 
     def test_tripped_timeout_skips_scan(self):
         records = _record(TEXT_RVA, XDATA_RVA)
         fcm = _candidates_for(_build_arm64_pe(records), cb_timeout=lambda: True)
-        self.assertNotIn(IMAGE_BASE + TEXT_RVA, fcm.candidates)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA, _exception_candidates(fcm))
 
 
 class AArch64CallFallthroughAlignmentTestSuite(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow-up to #185/#186: filters funclet and function-fragment records when seeding AArch64 function candidates from the PE ARM64 exception directory, and — with that filter in place — enables `USE_PE_ARM64_PDATA_CANDIDATES` by default.

## Motivation / root cause

The ARM64 exception directory names every unwind region, not just function entries: exception funclets and multi-record function fragments get their own `.pdata` records whose begin address points into the middle of a function body. Seeding those as authoritative function starts split real functions and reported the fragments as separate functions — on an IDA-labeled `bcrypt.dll` this accounted for +31 false-positive function starts, which is why the flag had stayed off by default.

## Changed behavior

- Commit 1: `locatePeExceptionCandidates` now reads each record's begin word and only seeds it when the word looks like an independent function entry (`is_exception_record_entry` in `smda/aarch64/definitions.py`). The predicate accepts standard prologues and BTI/PAC landing pads plus the thunk shapes MSVC emits records for: an indirect `br xN` dispatch, a callee-saved single-register pre-index store (`str x19..x28, [sp, #-imm]!`), and a `movz x16/x17, #imm` veneer setup. Funclet begin words (ordinary mid-body loads/moves/branches) are rejected. `_isExceptionRecordStart` in the backend reuses the same predicate, so the seeding filter and the absorption-immunity check from #186 stay consistent.
- Commit 2: `USE_PE_ARM64_PDATA_CANDIDATES` defaults to `True`. With funclet records filtered, the directory-enabled runs are equal or better on every labeled sample, so classic ARM64 PE images now get the exception-directory candidates without opt-in. Setting the flag to `False` restores the previous behavior exactly.

## Validation

Function starts vs. IDA Pro labels on four Microsoft-signed ARM64 PE binaries (directory enabled, before -> after this PR):

| sample | FP | FN |
|---|---|---|
| wermgr.exe | 71 -> 71 | 21 -> 21 |
| ping.exe | 10 -> 10 | 4 -> 4 |
| robocopy.exe | 78 -> 78 | 18 -> 18 |
| bcrypt.dll | 74 -> **43** | 9 -> 9 |

The eliminated bcrypt starts were confirmed to be exception funclets (begin words are mid-body instructions). Flag-off results are byte-identical on all four samples, and a 13-fixture AArch64 ELF/Mach-O corpus shows exactly zero function-set changes (the code path is PE-ARM64-only).

- `make lint` clean, `make test` green (532 passed, 1 skipped).
- New tests in `tests/testAArch64PdataExtraction.py`: non-entry-shaped begin words are skipped (fails without the fix), BTI landing pads and the three thunk shapes are still accepted, and the default-flag assertion is updated.
