### PR TITLE
perf(core): reduce native disassembly hot-path overhead

### DIFF
--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -35,6 +35,7 @@ class DisassemblyResult:
         self.code_refs_to = {}
         # key: address of API in target DLL, value: {referencing_addr, api_name, dll_name}
         self.apis = {}
+        self._api_ref_sources = {}
         self.addr_to_api = {}
         # address:name
         self.function_symbols = {}
@@ -317,6 +318,22 @@ class DisassemblyResult:
             api = self.apis[api_offset]
             for ref in api["referencing_addr"]:
                 self.addr_to_api[ref] = "{}!{}".format(api["dll_name"], api["api_name"])
+
+    def addApiReference(self, api_addr, referencing_addr, dll_name, api_name):
+        api_entry = self.apis.get(
+            api_addr,
+            {"referencing_addr": [], "dll_name": dll_name, "api_name": api_name},
+        )
+        if api_addr not in self.apis:
+            self._api_ref_sources[api_addr] = set()
+        ref_sources = self._api_ref_sources.get(api_addr)
+        if ref_sources is None:
+            ref_sources = set(api_entry["referencing_addr"])
+            self._api_ref_sources[api_addr] = ref_sources
+        if referencing_addr not in ref_sources:
+            ref_sources.add(referencing_addr)
+            api_entry["referencing_addr"].append(referencing_addr)
+        self.apis[api_addr] = api_entry
 
     def getAllApiRefs(self):
         all_api_refs = {}

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -214,9 +214,7 @@ class AArch64Backend(ArchBackend):
             elif self._isBackwardTailcallTarget(target, state) or self._isShortBranchStub(d, state, target):
                 # A direct branch to code before the current entry, or from a short
                 # no-frame stub, is a tailcall/shared thunk target, not a local block.
-                tailcall_added = d.fc_manager.addTailcallCandidate(target)
-                if tailcall_added:
-                    d.fc_manager.candidates[target].addCallRef(i_address)
+                d.fc_manager.addTailcallCandidate(target, reference_source=i_address)
                 state.setSanelyEnding(True)
             elif target in d.fc_manager.getFunctionStartCandidates():
                 # case = "TAILCALL?" — leave for its own analysis

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -618,14 +618,19 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             self.addPrologueCandidate(addr)
             self.setInitialCandidate(addr)
 
-    def addTailcallCandidate(self, addr):
+    def addTailcallCandidate(self, addr, reference_source=None):
         if not self._passesCodeFilter(addr):
             return False
-        self.ensureCandidate(addr)
-        self.candidates[addr].setIsTailcallCandidate(True)
+        is_new = self.ensureCandidate(addr)
+        if addr not in self.candidates:
+            return False
+        candidate = self.candidates[addr]
+        candidate.setIsTailcallCandidate(True)
+        score_changed = self._addCappedCallRef(candidate, reference_source) if reference_source is not None else False
         self._candidate_offsets.add(addr)
-        self.candidate_queue.add(self.candidates[addr])
-        self.candidate_queue.update()
+        self.candidate_queue.add(candidate)
+        if score_changed and not is_new:
+            self.candidate_queue.update(candidate)
         return True
 
     def _cachedExecutableSectionRanges(self):

--- a/src/smda/aarch64/analyzers.py
+++ b/src/smda/aarch64/analyzers.py
@@ -473,16 +473,7 @@ class AArch64IndirectCallAnalyzer:
                 analysis_state.setLeaf(False)
                 dll, api = d.resolveApi(candidate, candidate)
                 if dll or api:
-                    api_entry = {
-                        "referencing_addr": [],
-                        "dll_name": dll,
-                        "api_name": api,
-                    }
-                    if candidate in d.disassembly.apis:
-                        api_entry = d.disassembly.apis[candidate]
-                    if calling_addr not in api_entry["referencing_addr"]:
-                        api_entry["referencing_addr"].append(calling_addr)
-                    d.disassembly.apis[candidate] = api_entry
+                    d.disassembly.addApiReference(candidate, calling_addr, dll, api)
                 elif d.disassembly.isAddrWithinMemoryImage(candidate):
                     d.fc_manager.addCandidate(candidate, reference_source=calling_addr)
 

--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -29,6 +29,7 @@ class FunctionAnalysisState:
         self.instructions = []
         self._instructions_sorted = True
         self.instruction_start_bytes = set()
+        self.max_instruction_start = -1
         self.processed_blocks = set()
         self.processed_bytes = set()
         self.jump_targets = set()
@@ -74,6 +75,8 @@ class FunctionAnalysisState:
         self.instructions.append(ins)
         self._instructions_sorted = False
         self.instruction_start_bytes.add(ins[0])
+        if ins[0] > self.max_instruction_start:
+            self.max_instruction_start = ins[0]
         self.current_block.append(ins)
         self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:

--- a/src/smda/common/FunctionCandidate.py
+++ b/src/smda/common/FunctionCandidate.py
@@ -85,12 +85,20 @@ class FunctionCandidate:
         raise NotImplementedError
 
     def addCallRef(self, source_addr):
+        previous_size = len(self.call_ref_sources)
         self.call_ref_sources.add(source_addr)
-        self._score = None
+        changed = len(self.call_ref_sources) != previous_size
+        if changed:
+            self._score = None
+        return changed
 
     def removeCallRefs(self, source_addrs):
+        previous_size = len(self.call_ref_sources)
         self.call_ref_sources.difference_update(source_addrs)
-        self._score = None
+        changed = len(self.call_ref_sources) != previous_size
+        if changed:
+            self._score = None
+        return changed
 
     def setIsTailcallCandidate(self, is_tailcall):
         self.is_tailcall = is_tailcall

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -10,6 +10,7 @@ timeout guard. A backend subclass supplies its architecture through the
 instruction encodings.
 """
 
+import bisect
 import logging
 import struct
 
@@ -109,32 +110,41 @@ class FunctionCandidateManager:
         if self.config.HIGH_ACCURACY:
             conflicts = state.identifyCallConflicts(self._all_call_refs)
             if conflicts:
+                dirty_candidates = []
                 for candidate_addr, conflict in conflicts.items():
-                    self.candidates[candidate_addr].removeCallRefs(conflict)
-                    # depending on implementation, update candidates individually
-                    self.candidate_queue.update(self.candidates[candidate_addr])
-                self.candidate_queue.update()
+                    candidate = self.candidates[candidate_addr]
+                    if candidate.removeCallRefs(conflict):
+                        dirty_candidates.append(candidate)
+                if isinstance(self.candidate_queue, BracketQueue):
+                    for candidate in dirty_candidates:
+                        self.candidate_queue.update(candidate)
+                elif dirty_candidates:
+                    self.candidate_queue.update()
 
     def _addCappedCallRef(self, candidate, source_ref):
         """add an inbound call reference, honoring MAX_CALL_REFS_PER_CANDIDATE to bound set growth and rescoring."""
         cap = getattr(self.config, "MAX_CALL_REFS_PER_CANDIDATE", 0)
         if cap == 0 or len(candidate.call_ref_sources) < cap:
-            candidate.addCallRef(source_ref)
+            return candidate.addCallRef(source_ref)
+        return False
 
     def addCandidate(self, addr, is_gap=False, reference_source=None):
         if not self._passesCodeFilter(addr):
             return False
-        self.ensureCandidate(addr)
+        is_new = self.ensureCandidate(addr)
         if addr not in self.candidates:
             return False
-        self.candidates[addr].setIsGapCandidate(is_gap)
+        candidate = self.candidates[addr]
+        candidate.setIsGapCandidate(is_gap)
+        score_changed = False
         if reference_source:
             # register in _all_call_refs as well so late references still
             # participate in HIGH_ACCURACY call-conflict resolution
             self._all_call_refs[reference_source] = addr
-            self._addCappedCallRef(self.candidates[addr], reference_source)
-        self.candidate_queue.add(self.candidates[addr])
-        self.candidate_queue.update()
+            score_changed = self._addCappedCallRef(candidate, reference_source)
+        self.candidate_queue.add(candidate)
+        if score_changed and not is_new:
+            self.candidate_queue.update(candidate)
 
     def getNextFunctionStartCandidate(self):
         for candidate in self.candidate_queue:
@@ -198,10 +208,9 @@ class FunctionCandidateManager:
 
     def getNextGap(self, dont_skip=False):
         next_gap = self.getBitMask()
-        for gap in self.function_gaps:
-            if gap[0] > self.gap_pointer:
-                next_gap = gap[0]
-                break
+        gap_index = bisect.bisect_right(self.function_gaps, self.gap_pointer, key=lambda gap: gap[0])
+        if gap_index < len(self.function_gaps):
+            next_gap = self.function_gaps[gap_index][0]
         LOGGER.debug(
             "getNextGap(%s) for 0x%08x based on gap_map: 0x%08x",
             dont_skip,

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -187,12 +187,7 @@ class RecursiveDisassembler:
                 LOGGER.debug("potentially uncovered DLL address: 0x%08x", to_addr)
 
     def _updateApiInformation(self, from_addr, to_addr, dll, api):
-        api_entry = {"referencing_addr": [], "dll_name": dll, "api_name": api}
-        if to_addr in self.disassembly.apis:
-            api_entry = self.disassembly.apis[to_addr]
-        if from_addr not in api_entry["referencing_addr"]:
-            api_entry["referencing_addr"].append(from_addr)
-        self.disassembly.apis[to_addr] = api_entry
+        self.disassembly.addApiReference(to_addr, from_addr, dll, api)
 
     def _getDisasmWindowBuffer(self, addr):
         relative_start = addr - self.disassembly.binary_info.base_addr
@@ -219,12 +214,9 @@ class RecursiveDisassembler:
         owner_state = self.backend.createAnalysisState(owner_fn, self.disassembly)
         # Rebuild a minimal state from the disassembly's stored instructions
         # so revertAnalysis can undo code_map/ins2fn/function_borders entries.
-        fn_min, fn_max = self.disassembly.function_borders[owner_fn]
-        owner_state.instructions = []
-        for addr in sorted(self.disassembly.instructions.keys()):
-            if fn_min <= addr < fn_max:
-                mnemonic, size = self.disassembly.instructions[addr]
-                owner_state.instructions.append((addr, size, mnemonic, "", b""))
+        owner_state.instructions = [
+            instruction for block in self.disassembly.functions[owner_fn] for instruction in block
+        ]
         owner_state.code_refs = set()
         owner_state.data_refs = set()
         owner_state.revertAnalysis()

--- a/src/smda/common/arch/ArchBackend.py
+++ b/src/smda/common/arch/ArchBackend.py
@@ -106,4 +106,6 @@ class ArchBackend:
 
     @classmethod
     def _getImportStubRanges(cls, binary_info):
-        return cls._getPltRanges(binary_info) + cls._getMachoStubRanges(binary_info)
+        if not hasattr(binary_info, "_import_stub_ranges"):
+            binary_info._import_stub_ranges = cls._getPltRanges(binary_info) + cls._getMachoStubRanges(binary_info)
+        return binary_info._import_stub_ranges

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -71,23 +71,33 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # single strong single-byte case (0x55 "push ebp/rbp") clears it too.
         return FunctionCandidate(self.disassembly.binary_info, addr).getFunctionStartScore() >= _ENTRY_SHAPE_MIN_SCORE
 
-    def isAlignmentSequence(self, instruction_sequence):
+    def isAlignmentSequence(self, instruction_sequence, raw_bytes=None):
         is_alignment_sequence = False
         instructions_analyzed = 0
         if len(instruction_sequence) > 0:
-            current_offset = instruction_sequence[0].address
+            start_addr = instruction_sequence[0].address if raw_bytes is None else instruction_sequence[0][0]
+            current_offset = start_addr
             for instruction in instruction_sequence:
-                if instruction.bytes in GAP_SEQUENCES[len(instruction.bytes)]:
+                if raw_bytes is None:
+                    size = len(instruction.bytes)
+                    instruction_bytes = instruction.bytes
+                else:
+                    address, size, _mnemonic, _operands = instruction
+                    instruction_bytes = raw_bytes[address - start_addr : address - start_addr + size]
+                if instruction_bytes in GAP_SEQUENCES[size]:
                     instructions_analyzed += 1
-                    current_offset += len(instruction.bytes)
+                    current_offset += size
                     if current_offset % 16 == 0:
                         is_alignment_sequence = True
                         break
                 else:
                     break
-        if len(instruction_sequence) > instructions_analyzed and instruction_sequence[
-            instructions_analyzed
-        ].mnemonic.split(" ")[-1] in [
+        if len(instruction_sequence) > instructions_analyzed:
+            trailing_instruction = instruction_sequence[instructions_analyzed]
+            trailing_mnemonic = trailing_instruction.mnemonic if raw_bytes is None else trailing_instruction[2]
+        else:
+            trailing_mnemonic = ""
+        if trailing_mnemonic.split(" ")[-1] in [
             "leave",
             "ret",
             "retn",

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -183,16 +183,7 @@ class IndirectCallAnalyzer:
                     dll, api = self.disassembler.resolveApi(candidate, candidate)
                     if dll or api:
                         LOGGER.debug("successfully resolved: %s %s", dll, api)
-                        api_entry = {
-                            "referencing_addr": [],
-                            "dll_name": dll,
-                            "api_name": api,
-                        }
-                        if candidate in self.disassembly.apis:
-                            api_entry = self.disassembly.apis[candidate]
-                        if self.current_calling_addr not in api_entry["referencing_addr"]:
-                            api_entry["referencing_addr"].append(self.current_calling_addr)
-                        self.disassembly.apis[candidate] = api_entry
+                        self.disassembly.addApiReference(candidate, self.current_calling_addr, dll, api)
                     elif self.disassembly.isAddrWithinMemoryImage(candidate):
                         LOGGER.debug("successfully resolved: 0x%x", candidate)
                         self.disassembler.fc_manager.addCandidate(candidate, reference_source=self.current_calling_addr)

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -410,13 +410,13 @@ class X86Backend(ArchBackend):
                     i_address,
                 )
         elif previous_address is not None and i_address != start_addr and previous_mnemonic == "call":
-            instruction_sequence = list(d.capstone.disasm(d._getDisasmWindowBuffer(i_address), i_address))
-            is_alignment_evidence = d.disassembly.language["_guess"] != "go" and d.fc_manager.isAlignmentSequence(
-                instruction_sequence
-            )
+            instruction_bytes = d._getDisasmWindowBuffer(i_address)
+            instruction_sequence = list(d.capstone.disasm_lite(instruction_bytes, i_address))
+            has_alignment_sequence = d.fc_manager.isAlignmentSequence(instruction_sequence, instruction_bytes)
+            is_alignment_evidence = d.disassembly.language["_guess"] != "go" and has_alignment_sequence
             is_candidate_evidence = d.fc_manager.isFunctionCandidate(i_address)
             if is_alignment_evidence and not is_candidate_evidence and d.disassembly.binary_info._getLiefType() == "PE":
-                if d.fc_manager.isHotpatchPrologue(d._getDisasmWindowBuffer(i_address)[:5]):
+                if d.fc_manager.isHotpatchPrologue(instruction_bytes[:5]):
                     seed_address = i_address
                 else:
                     seed_address = previous_address + (16 - previous_address % 16)
@@ -438,7 +438,10 @@ class X86Backend(ArchBackend):
                 # LLVM and GCC sometimes tends to produce lots of tailcalls that basically mess with function end detection, we cut whenever we find effective nops after calls
                 # however, Go tends to insert alignment NOPs after calls, too, but in this case, they are no tailcall indicator
                 # apparently calls are frequently padded with NOPs, so one last chance to continue disassembly is when we already have instructions for our function beyond this call.
-                if not any(disassembled_addr > i_address for disassembled_addr in state.instruction_start_bytes):
+                max_instruction_start = getattr(state, "max_instruction_start", None)
+                if max_instruction_start is None:
+                    max_instruction_start = max(state.instruction_start_bytes, default=-1)
+                if max_instruction_start <= i_address:
                     LOGGER.debug(
                         "    current function: 0x%x ---> ran into alignment sequence after call -> 0x%08x, cutting block here.",
                         start_addr,
@@ -450,12 +453,12 @@ class X86Backend(ArchBackend):
                     state.setBlockEndingInstruction(True)
                     state.endBlock()
                     state.setSanelyEnding(True)
-                    if d.fc_manager.isAlignmentSequence(instruction_sequence):
+                    if has_alignment_sequence:
                         # A hotpatch stub right after a call can look like alignment padding
                         # (its leading `mov edi, edi` is an effective NOP), but that byte pair
                         # is the next function's true entry. Seed it directly rather than the
                         # 16-byte-rounded address, which would land two bytes late.
-                        if d.fc_manager.isHotpatchPrologue(d._getDisasmWindowBuffer(i_address)[:5]):
+                        if d.fc_manager.isHotpatchPrologue(instruction_bytes[:5]):
                             next_candidate_address = i_address
                         else:
                             next_candidate_address = previous_address + (16 - previous_address % 16)

--- a/tests/testIndirectCallAnalyzer.py
+++ b/tests/testIndirectCallAnalyzer.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
+from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.IndirectCallAnalyzer import IndirectCallAnalyzer
 
 
@@ -115,7 +116,7 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         import_slot = 0x403000
         memory_value = 0x500000
         disassembler = MagicMock()
-        disassembler.disassembly.apis = {}
+        disassembler.disassembly = DisassemblyResult()
         disassembler.resolveApi.return_value = ("kernel32.dll", "CreateFileA")
         analyzer = IndirectCallAnalyzer(disassembler)
         analyzer.getDword = MagicMock(return_value=memory_value)
@@ -145,6 +146,15 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
                 "api_name": "CreateFileA",
             },
         )
+
+    def test_api_reference_deduplication_preserves_list_shape(self):
+        disassembly = DisassemblyResult()
+
+        disassembly.addApiReference(0x403000, 0x401006, "kernel32.dll", "CreateFileA")
+        disassembly.addApiReference(0x403000, 0x401006, "kernel32.dll", "CreateFileA")
+        disassembly.addApiReference(0x403000, 0x401010, "kernel32.dll", "CreateFileA")
+
+        self.assertEqual(disassembly.apis[0x403000]["referencing_addr"], [0x401006, 0x401010])
 
     def test_processBlock_uses_dword_when_pointer_is_not_import_slot(self):
         disassembler = MagicMock()

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -650,6 +650,37 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertFalse(manager.isAlignmentSequence(instruction_sequence))
 
+    def test_alignment_sequence_accepts_lite_tuples(self):
+        manager = FunctionCandidateManager(SmdaConfig())
+        instruction_bytes = b"\x90\xc3"
+        instruction_sequence = [
+            (0x100F, 1, "nop", ""),
+            (0x1010, 1, "ret", ""),
+        ]
+
+        self.assertFalse(manager.isAlignmentSequence(instruction_sequence, instruction_bytes))
+
+    def test_function_state_tracks_max_instruction_start(self):
+        state = FunctionAnalysisState(0x1000, SimpleNamespace())
+        state.is_next_instruction_reachable = False
+
+        state.addInstruction(0x1005, 1, "nop", "", b"\x90")
+        state.addInstruction(0x1001, 1, "nop", "", b"\x90")
+
+        self.assertEqual(state.max_instruction_start, 0x1005)
+
+    def test_import_stub_ranges_are_cached(self):
+        binary_info = SimpleNamespace(
+            _plt_ranges=[(0x1000, 0x1010)],
+            _macho_stub_ranges=[(0x2000, 0x2010)],
+        )
+
+        first = X86Backend._getImportStubRanges(binary_info)
+        second = X86Backend._getImportStubRanges(binary_info)
+
+        self.assertIs(first, second)
+        self.assertEqual(first, [(0x1000, 0x1010), (0x2000, 0x2010)])
+
     def test_gap_stub_with_prefixed_jmp_is_accepted(self):
         # a single bnd-prefixed jmp stub discovered via gap-scanning (e.g. a misaligned
         # import-jmp thunk) must still be accepted as a legitimate function, matching the

--- a/tests/testLateCandidateProduction.py
+++ b/tests/testLateCandidateProduction.py
@@ -3,6 +3,7 @@
 import logging
 import types
 import unittest
+from unittest.mock import patch
 
 from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager as AArch64FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
@@ -57,9 +58,7 @@ class LateCandidateTestBase:
         self.assertIsNotNone(first)
 
         late_addr = 0x35E0
-        self.manager.addTailcallCandidate(late_addr)
-        # The backend calls addCallRef *after* addTailcallCandidate.
-        self.manager.candidates[late_addr].addCallRef(0x5000)
+        self.manager.addTailcallCandidate(late_addr, reference_source=0x5000)
 
         produced = [c.addr for c in gen]
         self.assertIn(
@@ -79,8 +78,7 @@ class LateCandidateTestBase:
         # Another analysis path created the candidate earlier (in candidates only).
         self.manager.ensureCandidate(late_addr)
         # Now addTailcallCandidate fires — should re-add to queue.
-        self.manager.addTailcallCandidate(late_addr)
-        self.manager.candidates[late_addr].addCallRef(0x6000)
+        self.manager.addTailcallCandidate(late_addr, reference_source=0x6000)
 
         produced = [c.addr for c in self.manager.getNextFunctionStartCandidate()]
         self.assertIn(
@@ -100,8 +98,7 @@ class LateCandidateTestBase:
 
         late_addr = 0x45E0
         self.manager.ensureCandidate(late_addr)  # candidates only
-        self.manager.addTailcallCandidate(late_addr)  # re-adds to queue
-        self.manager.candidates[late_addr].addCallRef(0x6000)
+        self.manager.addTailcallCandidate(late_addr, reference_source=0x6000)  # re-adds to queue
 
         produced = [c.addr for c in gen]
         self.assertIn(
@@ -157,10 +154,8 @@ class LateCandidateTestBase:
 
         late_a = 0x75E0
         late_b = 0x85E0
-        self.manager.addTailcallCandidate(late_a)
-        self.manager.candidates[late_a].addCallRef(0x8000)
-        self.manager.addTailcallCandidate(late_b)
-        self.manager.candidates[late_b].addCallRef(0x9000)
+        self.manager.addTailcallCandidate(late_a, reference_source=0x8000)
+        self.manager.addTailcallCandidate(late_b, reference_source=0x9000)
 
         produced = [c.addr for c in gen]
         self.assertIn(late_a, produced)
@@ -172,8 +167,7 @@ class LateCandidateTestBase:
     def test_late_tailcall_with_callref_has_nonzero_score(self):
         """addCallRef resets _score to None; getScore recalculates > 0."""
         late_addr = 0x95E0
-        self.manager.addTailcallCandidate(late_addr)
-        self.manager.candidates[late_addr].addCallRef(0xA000)
+        self.manager.addTailcallCandidate(late_addr, reference_source=0xA000)
 
         gen = self.manager.getNextFunctionStartCandidate()
         produced = [c.addr for c in gen]
@@ -182,6 +176,26 @@ class LateCandidateTestBase:
             produced,
             f"Candidate 0x{late_addr:x} with upcoming addCallRef should be produced [queue={self.queue_type}]",
         )
+
+    def test_new_scored_candidate_does_not_rebuild_queue(self):
+        with patch.object(self.manager.candidate_queue, "update", wraps=self.manager.candidate_queue.update) as update:
+            self.manager.addTailcallCandidate(0xA5E0, reference_source=0xB000)
+
+        update.assert_not_called()
+
+    def test_tailcall_candidate_respects_candidate_cap(self):
+        rejected_addr = 0xB5E0
+        self.config.MAX_FUNCTION_CANDIDATES = len(self.manager.candidates)
+
+        self.assertFalse(self.manager.addTailcallCandidate(rejected_addr, reference_source=0xC000))
+        self.assertNotIn(rejected_addr, self.manager.candidates)
+        self.assertNotIn(rejected_addr, self.manager._candidate_offsets)
+        if hasattr(self.manager.candidate_queue, "heap"):
+            self.assertNotIn(rejected_addr, [item.element.addr for item in self.manager.candidate_queue.heap])
+        else:
+            self.assertFalse(
+                any(rejected_addr in bracket for bracket in self.manager.candidate_queue.brackets.values())
+            )
 
 
 class PriorityQueueTestCase(LateCandidateTestBase, unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR reduces CPU overhead in native disassembly hot paths while preserving candidate order and report-visible data shapes.

- Rebuild candidate heaps only when an existing candidate's score actually changes.
- Use binary search for monotone gap traversal.
- Deduplicate API reference sources with a parallel set while retaining the public list representation.
- Revert gap functions from their stored blocks instead of sorting the whole instruction map.
- Use Capstone `disasm_lite` for alignment windows and maintain the maximum analyzed instruction start incrementally.
- Cache import-stub ranges and remove duplicate AArch64 data-reference decoding.

## Motivation

Candidate insertion rebuilt complete queues even when a new candidate was already correctly placed or a repeated reference did not change its score. Gap lookup and gap-function rollback performed whole-collection scans, API reference deduplication was linear, and several frequently called helpers repeated decoding or range construction.

## Compatibility

- Candidate score changes still trigger the appropriate queue update for both queue implementations.
- API references remain serialized as insertion-ordered lists.
- Alignment checks retain the existing Capstone-instruction path for callers that need it and add a tuple/raw-byte path for `disasm_lite`.
- The 57-sample function and instruction outputs are identical to the baseline.
- No report schema or status value changes are introduced.

## Performance

Randomized paired benchmark across eight bundled fixtures, with three warmups and 30 pairs per fixture:

- Aggregate process CPU: `-1.47%`
- 95% bootstrap confidence interval: `-1.83%` to `-1.14%`
- Asprox: `-2.43%`
- Cutwail: `-4.03%`
- Bashlite: `-2.10%`

Non-targeted Dalvik/CIL fixtures remained within their observed noise intervals. Every paired run matched status, function, instruction, and block counts.

## Validation

- `make lint`
- `make test`
- Eight-fixture randomized paired benchmark with correctness assertions
- Fresh 57-sample Plohmann/Malpedia function and instruction identity comparison — byte-identical outputs
- Focused queue, late-candidate, indirect-call, alignment, and API-reference tests
