### PR TITLE
perf(core): batch backend processed-byte tracking

### DIFF
--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -46,8 +46,7 @@ class FunctionAnalysisState:
         ins = (i_address, i_size, i_mnemonic, i_op_str, i_bytes)
         self.instructions.append(ins)
         self.instruction_start_bytes.add(ins[0])
-        for byte in range(i_size):
-            self.processed_bytes.add(i_address + byte)
+        self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:
             self.addCodeRef(i_address, i_address + i_size, self.is_jmp)
         self.is_jmp = False

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -84,8 +84,7 @@ class DalvikFunctionAnalysisState:
         self.instructions.append(ins)
         self.instruction_start_bytes.add(ins[0])
         self.current_block.append(ins)
-        for byte in range(i_size):
-            self.processed_bytes.add(i_address + byte)
+        self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:
             self.addCodeRef(i_address, i_address + i_size)
 


### PR DESCRIPTION
## Summary

This PR applies the low-risk remainder of the memory/performance wave: batch contiguous processed-byte insertion in the CIL and Dalvik analysis states using `set.update(range(...))`, matching the existing Intel implementation.

## Motivation

Both backends inserted every byte through a Python loop and individual `set.add` calls. `set.update` consumes the same range in native code, removes interpreter-level loop overhead, and produces exactly the same set contents for positive, zero, and empty ranges.

The broader persistent coverage-map redesign is intentionally excluded because it did not demonstrate a statistically significant aggregate CPU improvement over the existing dictionaries. This PR keeps only the small behavior-preserving optimization.

## Performance

- Representative local primitive benchmark: `-18.25%` for `set.update(range(...))` versus per-byte insertion.
- Eight-fixture randomized paired end-to-end CPU: `-0.15%`, with a 95% interval of `-0.57%` to `+0.19%`.

The end-to-end result is therefore treated as performance parity rather than an aggregate speedup claim.

## Compatibility

- Output-identical across eight bundled Intel, AArch64, Dalvik, and CIL fixtures.
- No persistent map, report schema, serialized field, or status value changes.
- No new dependency or public API surface.

## Validation

- `make lint`
- `python -m ruff format --check .`
- `make test` — 535 passed, 1 skipped
- Eight-fixture output-equivalence oracle
- Fresh Plohmann/Malpedia evaluation — 57/57 samples; macro function PPV/TPR/F1 `92.98 / 98.46 / 95.31`
- The 57-sample prediction JSON is byte-identical to the previous validated result.
