### PR TITLE
fix(intel): restore dead reachable-collision cleanup in getBlocks

### DIFF
--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -231,13 +231,13 @@ class FunctionAnalysisState:
                 current_mnemonic = current[2].split(" ")[-1]
                 block.append(current)
                 # if one code reference is to another address than the next
-                if (
-                    current[0] in self.code_refs_from
-                    and current_mnemonic not in self.CALL_MNEMONICS
-                    and i != len(self.instructions) - 1
-                    and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
-                ):
-                    break
+                if current[0] in self.code_refs_from:
+                    if (
+                        current_mnemonic not in self.CALL_MNEMONICS
+                        and i != len(self.instructions) - 1
+                        and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
+                    ):
+                        break
                     # if we can reach a colliding address from here, the block is broken and should end.
                     reachable_collisions = self.code_refs_from[current[0]].intersection(self.colliding_addresses)
                     next_addr = current[0] + current[1]

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -639,6 +639,27 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual([[ins[0] for ins in block] for block in state.getBlocks()], [[0x1000, 0x1006, 0x1008]])
 
+    def test_reachable_collision_ends_block_and_removes_code_ref(self):
+        # 0x1000's only outgoing code ref is its own fall-through to 0x1006 (no mismatch,
+        # so the ordinary "jump ref points elsewhere" cut does NOT fire), but 0x1006 has
+        # separately been marked a colliding address (belongs to another function). getBlocks()
+        # must still end the block at 0x1000 and drop the now-invalid code ref to 0x1006.
+        state = FunctionAnalysisState(0x1000, SimpleNamespace())
+        state.instructions = [
+            (0x1000, 6, "mov", "eax, 1", b""),
+            (0x1006, 2, "xor", "eax, eax", b""),
+            (0x1008, 1, "ret", "", b""),
+        ]
+        state.instruction_start_bytes = {0x1000, 0x1006, 0x1008}
+        state.addCodeRef(0x1000, 0x1006, by_jump=False)
+        state.addCollision(0x1006)
+
+        blocks = state.getBlocks()
+
+        self.assertEqual([[ins[0] for ins in block] for block in blocks], [[0x1000]])
+        self.assertNotIn(0x1006, state.code_refs_from.get(0x1000, set()))
+        self.assertNotIn((0x1000, 0x1006), state.code_refs)
+
     def test_alignment_sequence_recognizes_prefixed_ret(self):
         # a bnd-prefixed ret right after a run of alignment padding is still real code, not
         # more padding - isAlignmentSequence() must recognize it like a plain "ret".


### PR DESCRIPTION
## Summary

Restores a dead cleanup step in `FunctionAnalysisState.getBlocks()` that a prior refactor accidentally made unreachable.

## Motivation

A 2025-07-28 refactor collapsed two independent checks -- both originally gated by the same outer condition (`current[0] in self.code_refs_from`) -- into a single flattened boolean `and`-chain terminating in one `break`. That orphaned the second check, a "reachable collision" cleanup, as dead code sitting textually after the `break`: it removed a stale cross-function code reference and ended the block whenever the fall-through address was already known to belong to another function (`state.addCollision()`, raised by the recursive engine on a gap-function-revert collision). Verified via `git show` on the refactor commit that the pre-refactor code ran both checks independently.

## Changed behavior

- `getBlocks()` now removes the stale code reference and ends the block at the instruction whose fall-through collides with another function, instead of silently retaining the cross-function edge.
- No change to the ordinary "jump reference points elsewhere" cut path, and no change to mnemonic-prefix normalization.
- AArch64 inherits the fix automatically (its `FunctionAnalysisState` subclasses this one and does not override `getBlocks()`). CIL and Dalvik were swept and are unaffected: neither backend's disassembly driver ever calls `addCollision()`, so the corresponding cleanup is a structural no-op in both regardless of this change.

## Accuracy evidence

Ran a before/after comparison on Bao byteweight msvc10-64 (15 binaries, same set both runs):

- The cleanup path fires 27-35 times across the sample (not a rare edge case).
- Function PPV/TPR/F1 identical before and after (99.48 / 99.72 / 99.60), and a full per-binary diff shows 0 of 15 predicted function sets differ.

Interpretation: this is a CFG-edge correctness fix (removes a stale cross-function reference), not a function-boundary change -- it fires often but does not alter which functions get recovered.

## Validation

- `make lint`
- `python -m ruff format --check .`
- `make test` -- 530 passed, 1 skipped
- New regression test: `tests/testIntelDisassembler.py::test_reachable_collision_ends_block_and_removes_code_ref` (fails against the pre-fix flattened condition, passes against this fix)

No report schema, serialized field, hash format, or status value changes are introduced.
