### PR TITLE
fix(intel): widen PIC-hash escaping to cover 64-bit immediates

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ make test
 ´
 ## Version History
  * 2026-07-17: v4.3.0 - Format-aware `xheader` capture: `getHeaderBytes()` now stores computed, trailing-zero-trimmed, capped header regions for PE (section table), ELF (program headers), and Mach-O (active-slice load commands) instead of fixed truncations, enabling metadata recovery and binary re-synthesis. Added a normalized PE header hash (`SmdaReport.pe_header_hash`, volatile TimeDateStamp/CheckSum/SizeOfImage zeroed) for hash-busting-resistant clustering.
+ * 2026-07-18: Widened Intel PIC-hash escaping to cover 64-bit immediates (`mov r64, imm64` constants were previously truncated to their first 8 hex digits and never escaped, so PicHash was not relocation-invariant on 64-bit binaries). (THX: @r0ny123)
  * 2026-07-17: v4.2.17 - Improved function-boundary accuracy on ARM64 PE binaries (trap-data gap rejection, prologue-gated call-fallthrough alignment cuts, .pdata-authoritative conditional-tailcall boundaries) with the matching x86 gap-scan/alignment-cut fixes. (THX: @r0ny123)
  * 2026-07-15: v4.2.16 - Aarch64: add platform-specific function-candidate sources (PE ARM64 exception directory, ELF .eh_frame FDEs, Mach-O function-pointer metadata), wire the analysis-timeout callback into candidate identification, and extend README platform support wording. (THX: @r0ny123)
  * 2026-07-15: v4.2.15 - Improved interoperability with IDA Pro: Now using `ida_domain` if available, supporting headless IDB->SMDA report conversion. (THX: @r0ny123)

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -29,6 +29,11 @@ LOGGER = logging.getLogger(__name__)
 # (nibble-keep-mask) so that relocated instructions produce the same pic_hash.
 AARCH64_PIC_HASH_ESCAPE_VERSION = [4, 2, 0]
 
+# Intel PIC hashing changed in 4.2.18 when escapeBinary's immediate regex was widened
+# to match 64-bit immediates (previously truncated to the first 8 hex digits, so an
+# in-image mov r64, imm64 constant was never escaped and stayed relocation-variant).
+INTEL_PIC_HASH_ESCAPE_VERSION = [4, 2, 18]
+
 
 class LazyIntKeyDict(dict):
     def __new__(cls, data=None):
@@ -598,6 +603,12 @@ class SmdaFunction:
                 not recalculate_pic_hash
                 and function_architecture == "aarch64"
                 and version < AARCH64_PIC_HASH_ESCAPE_VERSION
+            ):
+                recalculate_pic_hash = True
+            if (
+                not recalculate_pic_hash
+                and function_architecture == "intel"
+                and version < INTEL_PIC_HASH_ESCAPE_VERSION
             ):
                 recalculate_pic_hash = True
             if recalculate_pic_hash:

--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -2229,7 +2229,7 @@ class IntelInstructionEscaper:
             )
         ):
             immediates = []
-            for immediate_match in re.finditer(r"0x[0-9a-fA-F]{1,8}", ins.operands):
+            for immediate_match in re.finditer(r"0x[0-9a-fA-F]{1,16}", ins.operands):
                 immediate = int(immediate_match.group()[2:], 16)
                 if lower_addr > 0x00100000 and lower_addr <= immediate < upper_addr:
                     immediates.append(immediate)
@@ -2309,12 +2309,17 @@ class IntelInstructionEscaper:
 
     @staticmethod
     def escapeBinaryValue(ins, escaped_sequence, value):
-        packed_hex = str(codecs.encode(struct.pack("I", value), "hex").decode("ascii"))
+        try:
+            packed_hex = str(codecs.encode(struct.pack("<I", value), "hex").decode("ascii"))
+        except struct.error:
+            # value doesn't fit in 32 bits -- a 64-bit immediate (e.g. "mov r64, imm64")
+            packed_hex = str(codecs.encode(struct.pack("<Q", value), "hex").decode("ascii"))
+        wildcard = "?" * len(packed_hex)
         num_occurrences = occurrences(escaped_sequence, packed_hex)
         if num_occurrences == 1:
-            escaped_sequence = escaped_sequence.replace(packed_hex, "????????")
+            escaped_sequence = escaped_sequence.replace(packed_hex, wildcard)
         elif num_occurrences == 2:
-            escaped_sequence = "????????".join(escaped_sequence.rsplit(packed_hex, 2))
+            escaped_sequence = wildcard.join(escaped_sequence.rsplit(packed_hex, 2))
             LOGGER.warning(
                 "IntelInstructionEscaper.escapeBinaryValue: 2 occurrences for %s in %s, trying to escape both, if they were non-overlapping",
                 packed_hex,

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -3,9 +3,25 @@ import struct
 import unittest
 
 from smda.common.SmdaBasicBlock import SmdaBasicBlock
-from smda.common.SmdaFunction import LazyIntKeyDict, SmdaFunction
+from smda.common.SmdaFunction import INTEL_PIC_HASH_ESCAPE_VERSION, LazyIntKeyDict, SmdaFunction
 from smda.common.SmdaInstruction import SmdaInstruction
 from smda.common.SmdaReport import SmdaReport
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+INTEL_BASE = 0x401000
+
+
+def _disassemble_intel_bytes(code):
+    config = SmdaConfig()
+    config.WITH_STRINGS = False
+    return Disassembler(config).disassembleBuffer(
+        code,
+        base_addr=INTEL_BASE,
+        bitness=64,
+        code_areas=[[INTEL_BASE, INTEL_BASE + len(code)]],
+        oep=0,
+    )
 
 
 class TestCommonModels(unittest.TestCase):
@@ -72,6 +88,28 @@ class TestCommonModels(unittest.TestCase):
             function.getOpcHash(),
             struct.unpack("<Q", hashlib.sha256(b"opc-sequence").digest()[:8])[0],
         )
+
+    def test_imported_intel_report_recalculates_pic_hash_before_escape_version(self):
+        report = _disassemble_intel_bytes(b"\xc3")  # ret
+        function = report.getFunction(INTEL_BASE)
+        expected_pic_hash = function.pic_hash
+        function_dict = function.toDict()
+        function_dict["metadata"]["pic_hash"] = 0x0123456789ABCDEF
+
+        imported = SmdaFunction.fromDict(function_dict, version="4.2.17", smda_report=report)
+
+        self.assertEqual(imported.pic_hash, expected_pic_hash)
+        self.assertLess([4, 2, 17], INTEL_PIC_HASH_ESCAPE_VERSION)
+
+    def test_imported_intel_report_keeps_pic_hash_at_escape_version(self):
+        report = _disassemble_intel_bytes(b"\xc3")  # ret
+        function_dict = report.getFunction(INTEL_BASE).toDict()
+        stored_pic_hash = 0x0123456789ABCDEF
+        function_dict["metadata"]["pic_hash"] = stored_pic_hash
+
+        imported = SmdaFunction.fromDict(function_dict, version="4.2.18", smda_report=report)
+
+        self.assertEqual(imported.pic_hash, stored_pic_hash)
 
     def test_num_calls_and_returns_count_prefixed_mnemonics(self):
         # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string;

--- a/tests/testEscaper.py
+++ b/tests/testEscaper.py
@@ -196,6 +196,18 @@ class DisassemblyTestSuite(unittest.TestCase):
                 "bitness": 64,
                 "expected_opc": "48a3????????????????",
             },
+            # a full 64-bit immediate ("movabs reg, imm64") landing inside the mapped image's
+            # address range must be fully escaped, not truncated to its first 8 hex digits and
+            # left un-escaped (the previous regex/struct.pack("I", ...) could not match or pack
+            # anything wider than 32 bits)
+            {
+                "ins": (0, "48b83412004001000000", "movabs", "rax, 0x140001234"),
+                "lower": 0x140001000,
+                "upper": 0x140002000,
+                "expected_bin": "48b8????????????????",
+                "bitness": 64,
+                "expected_opc": "48b8????????????????",
+            },
         ]
         for data in test_data:
             smda_report = SmdaReport()


### PR DESCRIPTION
## Summary

Widens Intel PIC-hash escaping to correctly handle 64-bit immediates, and adds a version-gated pic_hash recalculation path for old reports.

## Motivation

`IntelInstructionEscaper.escapeBinary`'s immediate regex was capped at 8 hex digits (32 bits): `r"0x[0-9a-fA-F]{1,8}"`. Because the quantifier is greedy but unanchored, a genuine 64-bit immediate operand (e.g. `movabs rax, 0x1122334455667788`) did not fail to match -- it silently matched only the first 8 hex digits, producing a wrong, truncated value that essentially never falls inside the checked `[lower_addr, upper_addr)` image-address range. In-image `mov r64, imm64` constants were therefore never recognized as relocatable addresses and never escaped, so `pic_hash` was not relocation-invariant on 64-bit binaries.

## Changed behavior

- Widened the regex to 16 hex digits, so a full 64-bit immediate is extracted correctly.
- `escapeBinaryValue`'s packing now tries a 4-byte little-endian pack and falls back to 8-byte on `struct.error` (mirroring `escapeBinaryPtrRef`'s existing pattern directly above it in the same file), with a dynamically-sized wildcard string instead of a hardcoded 8-character one. This also fixes a related nit: the previous 4-byte pack used native-endian `"I"` rather than explicit `"<I"`.
- Added `INTEL_PIC_HASH_ESCAPE_VERSION` (mirroring the existing `AARCH64_PIC_HASH_ESCAPE_VERSION` mechanism in `SmdaFunction.fromDict`), so reports imported from older SMDA versions get `pic_hash` recalculated for intel functions instead of trusting a stale hash computed with the old, narrower escaping. Bumped `SmdaConfig.VERSION` / `__version__` to 4.3.1 to back this gate (rebased past the maintainer's independent 4.3.0 bump that landed on master concurrently).

## Accuracy / hash-migration evidence

Ran a before/after comparison on Bao byteweight msvc10-64 (15 binaries, same set both runs):

- Predicted function address sets are byte-for-byte identical before and after, for every binary -- confirms the escaper change is fully isolated from candidate/CFG recovery, as expected (the escaper only feeds hash computation).
- The new 8-byte fallback pack path was not exercised anywhere in this 15-binary sample (0 of ~20k+ predicted functions) -- the measured real-world hash-migration footprint on this corpus is effectively zero. The fix remains necessary for the narrower case of large in-image 64-bit absolute immediates (e.g. `movabs`-heavy or PIC-disabled code), which is exercised directly by the new unit test.

## Validation

- `make lint`
- `python -m ruff format --check .`
- `make test` -- 531 passed, 1 skipped
- New regression tests: `tests/testEscaper.py` (64-bit `movabs` immediate escaping, fails against the pre-fix 8-digit regex) and `tests/testCommonModels.py` (pic_hash recalculation before/at `INTEL_PIC_HASH_ESCAPE_VERSION`, mirroring the existing AArch64 test)

No report schema, serialized field structure, or status value changes are introduced. `pic_hash` values change only for the narrow set of intel functions containing an in-image 64-bit immediate.

