### PR TITLE
fix(intel): prefer exact Go evidence in language guess, export language

### DIFF
--- a/src/smda/common/LanguageAnalyzer.py
+++ b/src/smda/common/LanguageAnalyzer.py
@@ -191,9 +191,31 @@ class LanguageAnalyzer:
 
         # guess the programming language and
         # return dict with probabilities for the use of certain programming languages
+        result["_guess"] = self._deriveGuess(result)
+        return result
+
+    @staticmethod
+    def _deriveGuess(result):
         guess = None
         for lang in [key for key in result if not key.startswith("_")]:
             if not (guess and result[guess] > result[lang]):
                 guess = lang
-        result["_guess"] = guess
+        if result.get("go", 0) > 0.5:
+            # an exact "Go build ID" string match is unambiguous evidence that must win over
+            # any other heuristic score -- especially the c++ thiscall score, which is called
+            # here (identify()) before any function exists, so it always divides by 1 and can
+            # spuriously outscore a real Go binary (see rescore()).
+            guess = "go"
+        return guess
+
+    def rescore(self, result, function_count):
+        """
+        Re-normalize scores that depend on the function count, which is only known once
+        disassembly has finished (identify() runs at candidate-discovery time, before any
+        function exists). Called once analysis completes so the exported SmdaReport.language
+        reflects the true function count instead of identify()'s pre-disassembly snapshot.
+        """
+        thiscall_count = result.get("_count_thiscalls", 0)
+        result["c++"] = min(1, 6.0 * thiscall_count / max(1, function_count))
+        result["_guess"] = self._deriveGuess(result)
         return result

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -474,6 +474,14 @@ class RecursiveDisassembler:
                 candidate.setTfIdf(function_tfidf)
                 candidate.getConfidence()
             self.disassembly.candidates[addr] = candidate
+        lang_analyzer = getattr(self.fc_manager, "lang_analyzer", None)
+        if lang_analyzer is not None:
+            # identify() ran before any function existed (candidate-discovery time), so its
+            # c++ score always divided by 1; re-normalize now that the real function count
+            # is known, so the exported SmdaReport.language reflects it correctly.
+            self.disassembly.language = lang_analyzer.rescore(
+                self.disassembly.language, len(self.disassembly.functions)
+            )
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
         if cbAnalysisTimeout and cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -40,6 +40,7 @@ class SmdaReport:
     identified_alignment = None
     is_library = None
     is_buffer = None
+    language = None
     message = None
     oep = None
     sha256 = None
@@ -97,6 +98,7 @@ class SmdaReport:
             self.identified_alignment = disassembly.identified_alignment
             self.is_library = disassembly.binary_info.is_library
             self.is_buffer = disassembly.binary_info.is_buffer
+            self.language = disassembly.language
             self.message = "Analysis finished regularly."
             self.oep = disassembly.binary_info.getOep()
             self.sha256 = disassembly.binary_info.sha256
@@ -286,6 +288,8 @@ class SmdaReport:
                 smda_report.filename = report_dict["metadata"]["filename"]
             if "is_library" in report_dict["metadata"]:
                 smda_report.is_library = report_dict["metadata"]["is_library"]
+            if "language" in report_dict["metadata"]:
+                smda_report.language = report_dict["metadata"]["language"]
             if "version" in report_dict["metadata"]:
                 smda_report.version = report_dict["metadata"]["version"]
             smda_report.is_buffer = report_dict["metadata"].get("is_buffer", False)
@@ -366,6 +370,7 @@ class SmdaReport:
                 "filename": self.filename,
                 "is_library": self.is_library,
                 "is_buffer": self.is_buffer,
+                "language": self.language,
                 "version": self.version,
             },
             "message": self.message,

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -6,6 +6,8 @@ from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.SmdaFunction import LazyIntKeyDict, SmdaFunction
 from smda.common.SmdaInstruction import SmdaInstruction
 from smda.common.SmdaReport import SmdaReport
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
 
 
 class TestCommonModels(unittest.TestCase):
@@ -72,6 +74,29 @@ class TestCommonModels(unittest.TestCase):
             function.getOpcHash(),
             struct.unpack("<Q", hashlib.sha256(b"opc-sequence").digest()[:8])[0],
         )
+
+    def test_report_exports_language_metadata(self):
+        # SmdaReport previously had no `language` attribute at all and dropped the whole
+        # feature from toDict(); it must now be exported and round-trip through fromDict.
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        func = b"\x55\x48\x89\xe5\x5d\xc3"  # push rbp; mov rbp, rsp; pop rbp; ret
+        code = func * 10
+        thiscall_tail = b"\x8b\x4d\x04\xe8\x01\x02\x03\x00"
+        buf = code + thiscall_tail
+        base = 0x401000
+        report = Disassembler(config).disassembleBuffer(
+            buf, base_addr=base, bitness=64, code_areas=[[base, base + len(code)]]
+        )
+
+        self.assertIsInstance(report.language, dict)
+        self.assertIn("_guess", report.language)
+
+        report_dict = report.toDict()
+        self.assertEqual(report_dict["metadata"]["language"], report.language)
+
+        restored = SmdaReport.fromDict(report_dict)
+        self.assertEqual(restored.language, report.language)
 
     def test_num_calls_and_returns_count_prefixed_mnemonics(self):
         # capstone prepends mandatory prefixes (bnd/rep/lock/...) to the mnemonic string;

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -249,6 +249,29 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertIn(0x1028, result.functions)
         self.assertIn(0x1028, result.code_refs_from.get(0x100C, set()))
 
+    def test_language_rescore_uses_real_function_count_after_analysis(self):
+        # LanguageAnalyzer.identify() runs before any function exists (candidate-discovery
+        # time), so its c++ score always divides by max(1, 0) == 1. RecursiveDisassembler
+        # must re-normalize it once real functions are known, so report-visible language
+        # reflects the true function count, not the pre-disassembly zero-function artifact.
+        func = b"\x55\x48\x89\xe5\x5d\xc3"  # push rbp; mov rbp, rsp; pop rbp; ret
+        code = func * 10
+        thiscall_tail = b"\x8b\x4d\x04\xe8\x01\x02\x03\x00"  # one thiscall-shaped pattern hit
+        buf = code + thiscall_tail
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 64
+        binary_info.architecture = "intel"
+        binary_info.code_areas = [[0x1000, 0x1000 + len(code)]]
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertGreater(len(result.functions), 1)
+        thiscall_count = result.language["_count_thiscalls"]
+        expected_cpp = min(1, 6.0 * thiscall_count / len(result.functions))
+        self.assertEqual(result.language["c++"], expected_cpp)
+        self.assertLess(result.language["c++"], 1)  # proves it's not the pre-disassembly artifact
+
     def test_direct_import_stub_calls_resolve_at_original_caller(self):
         base = 0x1000
         import_slot = 0x2000

--- a/tests/testLanguageAnalyzer.py
+++ b/tests/testLanguageAnalyzer.py
@@ -35,6 +35,33 @@ class TestLanguageAnalyzer(unittest.TestCase):
         self.assertEqual(len({call[0] for call in findall_calls}), 2)
         self.assertTrue(all(call[1] == binary for call in findall_calls))
 
+    def test_identify_prefers_go_build_id_over_zero_function_cpp_artifact(self):
+        # identify() runs at candidate-discovery time, before any function exists, so its
+        # c++ score always divides by 1 (max(1, len(functions))) and is inflated to 1.0 by
+        # even a single thiscall-shaped byte pattern. An exact "Go build ID" match must still
+        # win the guess, or a real Go binary gets misclassified as c++ (defeating the
+        # Go-specific alignment exception in X86Backend).
+        binary = b'Go build ID: "abc123def456"' + b"\x8b\x4d\x04\xe8\x01\x02\x03\x00" * 3
+        analyzer = LanguageAnalyzer(_DummyDisassembly(binary, functions={}))
+
+        result = analyzer.identify()
+
+        self.assertGreater(result["go"], 0.5)
+        self.assertEqual(result["c++"], 1)  # the pre-disassembly zero-function artifact
+        self.assertEqual(result["_guess"], "go")
+
+    def test_rescore_renormalizes_cpp_score_and_guess_with_real_function_count(self):
+        binary = b'Go build ID: "abc123def456"' + b"\x8b\x4d\x04\xe8\x01\x02\x03\x00" * 3
+        analyzer = LanguageAnalyzer(_DummyDisassembly(binary, functions={}))
+        result = analyzer.identify()
+        thiscall_count = result["_count_thiscalls"]
+
+        rescored = analyzer.rescore(result, 100)
+
+        self.assertEqual(rescored["c++"], min(1, 6.0 * thiscall_count / 100))
+        self.assertLess(rescored["c++"], 1)
+        self.assertEqual(rescored["_guess"], "go")
+
     def test_uses_bytes_for_pe_and_language_markers(self):
         binary = bytearray(b"MZ" + b"\x00" * 0x100)
         binary[0x3C:0x40] = (0x80).to_bytes(4, "little")


### PR DESCRIPTION
## Summary

Fixes a language-identification bug that could misclassify Go binaries, and exports the computed `language` guess in `SmdaReport` (it was previously computed and used internally, then silently dropped from reports).

## Motivation

`LanguageAnalyzer.identify()` is called from `FunctionCandidateManager.init()` before any function exists, so its C++ score (`6.0 * thiscall_count / max(1, len(functions))`) always divides by 1 -- any single thiscall-shaped byte pattern inflates it to 1.0. Since `_guess` picked the max-scoring key, this could crowd out a real Go binary's `go` score (0.6) even when an exact "Go build ID" string is present in the binary, defeating a Go-specific exception in `X86Backend` that otherwise skips a CFG cut at alignment padding after a call -- a Go PE containing even one thiscall-shaped byte sequence could get its CFG corrupted by a cut meant only for non-Go toolchains.

Separately, the whole `language` dict was never exported: `SmdaReport` had no `language` attribute and `toDict()` didn't include it.

## Changed behavior

- `LanguageAnalyzer._deriveGuess()` now unconditionally prefers `"go"` whenever an exact Go build ID match is present (`result["go"] > 0.5`), regardless of the (structurally noisy, at that point in analysis) c++ score.
- A new `LanguageAnalyzer.rescore()` re-normalizes the c++ score using the real function count once disassembly completes, and re-derives the guess the same way. `RecursiveDisassembler.analyzeBuffer` (shared by intel and aarch64) calls it right before finishing analysis; it's a no-op for aarch64/cil/dalvik, which have no `lang_analyzer`.
- `SmdaReport.language` is now populated in `__init__`, exported under `toDict()["metadata"]["language"]`, and restored in `fromDict()`.

## Evidence

- Targeted unit tests reproduce the exact bug scenario (a Go build ID string plus a thiscall-shaped pattern, zero functions) and confirm `_guess` now resolves to `"go"` instead of `"c++"`, both at `identify()` time and after `rescore()` with a real function count.
- An integration-level test confirms the `rescore()` hook fires end-to-end during a real `analyzeBuffer()` call and correctly re-normalizes the c++ score using the true function count.
- A schema test confirms `SmdaReport.language` round-trips through `toDict()`/`fromDict()`.
- No Go-identifiable sample exists in the locally available accuracy corpus (checked the full Bao/Plohmann groundtruth tree via `grep` for "Go build ID" -- zero matches; this repo's bundled xored fixtures were checked by filename/family only, since they can't be grepped without deobfuscating them). The guess-flip itself is therefore demonstrated only via the unit tests above, not against real-world ground truth.
- A before/after run on Bao byteweight msvc10-64 (15 binaries, ordinary non-Go MSVC code) shows byte-for-byte identical predicted function sets, confirming the fix does not perturb ordinary binaries where the Go override never activates.

## Mandatory sweep

Also found a genuinely separate report-export gap during the sweep: `DisassemblyResult.thunk_functions` is computed identically to its `recursive_functions`/`leaf_functions` siblings but has no `num_thunk_functions` counterpart anywhere in the report. This is a different root cause (a missing export, not a compute-order/normalization bug) so it isn't bundled into this PR; filed as a separate follow-up.

## Validation

- `make lint`
- `python -m ruff format --check .`
- `make test` -- 533 passed, 1 skipped

No report schema field is removed or renamed; `language` is a new optional key nested under `metadata`, tolerant of absence on older reports.
