### PR TITLE
fix(intel): report num_thunk_functions and detect x86 import-jmp thunks

### DIFF
--- a/src/smda/DisassemblyStatistics.py
+++ b/src/smda/DisassemblyStatistics.py
@@ -2,6 +2,7 @@ class DisassemblyStatistics:
     num_functions = None
     num_recursive_functions = None
     num_leaf_functions = None
+    num_thunk_functions = None
     num_basic_blocks = None
     num_instructions = None
     num_api_calls = None
@@ -12,6 +13,7 @@ class DisassemblyStatistics:
         "num_functions",
         "num_recursive_functions",
         "num_leaf_functions",
+        "num_thunk_functions",
         "num_basic_blocks",
         "num_instructions",
         "num_api_calls",
@@ -25,6 +27,7 @@ class DisassemblyStatistics:
             self.num_functions = len(disassembly_result.functions)
             self.num_recursive_functions = len(disassembly_result.recursive_functions)
             self.num_leaf_functions = len(disassembly_result.leaf_functions)
+            self.num_thunk_functions = len(disassembly_result.thunk_functions)
             self.num_basic_blocks = self._countBlocks(disassembly_result)
             self.num_instructions = self._countInstructions(disassembly_result)
             self.num_api_calls = self._countApiCalls(disassembly_result)
@@ -61,6 +64,7 @@ class DisassemblyStatistics:
         statistics.num_functions = statistics_dict["num_functions"]
         statistics.num_recursive_functions = statistics_dict["num_recursive_functions"]
         statistics.num_leaf_functions = statistics_dict["num_leaf_functions"]
+        statistics.num_thunk_functions = statistics_dict.get("num_thunk_functions")
         statistics.num_basic_blocks = statistics_dict["num_basic_blocks"]
         statistics.num_instructions = statistics_dict["num_instructions"]
         statistics.num_api_calls = statistics_dict["num_api_calls"]
@@ -74,6 +78,7 @@ class DisassemblyStatistics:
             "num_functions": self.num_functions,
             "num_recursive_functions": self.num_recursive_functions,
             "num_leaf_functions": self.num_leaf_functions,
+            "num_thunk_functions": self.num_thunk_functions,
             "num_basic_blocks": self.num_basic_blocks,
             "num_instructions": self.num_instructions,
             "num_api_calls": self.num_api_calls,

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -236,10 +236,7 @@ class X86Backend(ArchBackend):
             state.addCodeRef(i_address, jump_destination, by_jump=True)
             d.tailcall_analyzer.addJump(i_address, jump_destination)
             if dereferenced is not None:
-                resolved_api = d._handleApiTarget(i_address, jump_destination, dereferenced)
-                if resolved_api and state.isFirstInstruction():
-                    # the entire function body is this one jmp-to-import: a thunk, not a real routine
-                    state.setThunkCall(True)
+                self._handleApiJumpTarget(d, state, i_address, jump_destination, dereferenced)
         elif i_op_str.startswith("qword ptr [rip"):
             # case = "QWORD-PTR, RIP-relative"
             # Handles mostly jmp-to-api, stubs or tailcalls, all should be handled sanely this way.
@@ -249,9 +246,7 @@ class X86Backend(ArchBackend):
             state.addCodeRef(i_address, jump_destination, by_jump=True)
             d.tailcall_analyzer.addJump(i_address, jump_destination)
             if dereferenced is not None:
-                resolved_api = d._handleApiTarget(i_address, jump_destination, dereferenced)
-                if resolved_api and state.isFirstInstruction():
-                    state.setThunkCall(True)
+                self._handleApiJumpTarget(d, state, i_address, jump_destination, dereferenced)
         elif i_op_str.startswith("0x"):
             jump_destination = d.getReferencedAddr(i_op_str)
             d.tailcall_analyzer.addJump(i_address, jump_destination)
@@ -263,7 +258,7 @@ class X86Backend(ArchBackend):
                 pass
             else:
                 import_slot = self._resolveImportSlot(d, jump_destination)
-                if import_slot is not None and d._handleApiTarget(i_address, import_slot, import_slot):
+                if import_slot is not None and self._handleApiJumpTarget(d, state, i_address, import_slot, import_slot):
                     # case = "STUB-TAILCALL-API!"
                     state.setSanelyEnding(True)
                 elif state.isFirstInstruction():
@@ -281,6 +276,14 @@ class X86Backend(ArchBackend):
                     state.addCodeRef(i_address, target, by_jump=True)
         state.setNextInstructionReachable(False)
         state.setBlockEndingInstruction(True)
+
+    @staticmethod
+    def _handleApiJumpTarget(d, state, instruction_addr, import_slot, dereferenced):
+        resolved_api = d._handleApiTarget(instruction_addr, import_slot, dereferenced)
+        if resolved_api and state.isFirstInstruction():
+            # the entire function body is this one jmp-to-import: a thunk, not a real routine
+            state.setThunkCall(True)
+        return resolved_api
 
     def _analyzeEndInstruction(self, state):
         state.setSanelyEnding(True)

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -236,7 +236,10 @@ class X86Backend(ArchBackend):
             state.addCodeRef(i_address, jump_destination, by_jump=True)
             d.tailcall_analyzer.addJump(i_address, jump_destination)
             if dereferenced is not None:
-                d._handleApiTarget(i_address, jump_destination, dereferenced)
+                resolved_api = d._handleApiTarget(i_address, jump_destination, dereferenced)
+                if resolved_api and state.isFirstInstruction():
+                    # the entire function body is this one jmp-to-import: a thunk, not a real routine
+                    state.setThunkCall(True)
         elif i_op_str.startswith("qword ptr [rip"):
             # case = "QWORD-PTR, RIP-relative"
             # Handles mostly jmp-to-api, stubs or tailcalls, all should be handled sanely this way.
@@ -246,7 +249,9 @@ class X86Backend(ArchBackend):
             state.addCodeRef(i_address, jump_destination, by_jump=True)
             d.tailcall_analyzer.addJump(i_address, jump_destination)
             if dereferenced is not None:
-                d._handleApiTarget(i_address, jump_destination, dereferenced)
+                resolved_api = d._handleApiTarget(i_address, jump_destination, dereferenced)
+                if resolved_api and state.isFirstInstruction():
+                    state.setThunkCall(True)
         elif i_op_str.startswith("0x"):
             jump_destination = d.getReferencedAddr(i_op_str)
             d.tailcall_analyzer.addJump(i_address, jump_destination)

--- a/tests/testIntegration.py
+++ b/tests/testIntegration.py
@@ -9,6 +9,7 @@ from smda.common.SmdaBasicBlock import SmdaBasicBlock
 from smda.common.SmdaFunction import SmdaFunction
 from smda.common.SmdaReport import SmdaReport
 from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
 from smda.DisassemblyStatistics import DisassemblyStatistics
 from smda.utility.FileLoader import FileLoader
 
@@ -191,6 +192,35 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         self.assertEqual(total.num_functions, 11)
         left += right
         self.assertEqual(left.num_failed_instructions, 99)
+
+    def test_statistics_num_thunk_functions_roundtrip(self):
+        result = DisassemblyResult()
+        result.thunk_functions.add(0x401000)
+        result.thunk_functions.add(0x402000)
+
+        stats = DisassemblyStatistics(result)
+        self.assertEqual(stats.num_thunk_functions, 2)
+
+        restored = DisassemblyStatistics.fromDict(stats.toDict())
+        self.assertEqual(restored.num_thunk_functions, 2)
+        self.assertEqual((restored + stats).num_thunk_functions, 4)
+
+    def test_statistics_from_dict_tolerates_missing_num_thunk_functions(self):
+        stats = DisassemblyStatistics.fromDict(
+            {
+                "num_functions": 1,
+                "num_recursive_functions": 0,
+                "num_leaf_functions": 1,
+                "num_basic_blocks": 1,
+                "num_instructions": 2,
+                "num_api_calls": 0,
+                "num_function_calls": 1,
+                "num_failed_functions": 0,
+                "num_failed_instructions": 0,
+            }
+        )
+        self.assertIsNone(stats.num_thunk_functions)
+        self.assertIsNone(stats.toDict()["num_thunk_functions"])
 
 
 if __name__ == "__main__":

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -506,6 +506,49 @@ class TestIntelDisassembler(unittest.TestCase):
         manager.bitness = 64
         self.assertFalse(manager.isHotpatchPrologue(b"\x8b\xff\x55\x8b\xec"))
 
+    def test_jmp_to_resolved_import_as_first_instruction_marks_thunk_call(self):
+        # A single "jmp dword ptr [import_slot]" that is the function's very first
+        # instruction is a textbook single-instruction import-thunk stub: the entire
+        # function body is the jmp, so it must be flagged as a thunk call.
+        disassembler = self._create_disassembler()
+        disassembler._registerLabelProvider(ImportSlotProvider(0x1020, "kernel32.dll", "ExitProcess"))
+        disassembler.disassembly = SimpleNamespace(
+            apis={},
+            dereferenceDword=lambda addr: 0x9999 if addr == 0x1020 else None,
+            isAddrWithinMemoryImage=lambda addr: True,
+        )
+        disassembler.tailcall_analyzer = SimpleNamespace(addJump=lambda *a, **kw: None)
+        backend = X86Backend.__new__(X86Backend)
+
+        state = FunctionAnalysisState(0x1000, disassembler.disassembly)
+        instruction = (0x1000, 6, "jmp", "dword ptr [0x1020]")
+
+        backend._analyzeJmpInstruction(disassembler, instruction, state)
+
+        self.assertTrue(state.is_thunk_call)
+
+    def test_jmp_to_resolved_import_deep_in_function_does_not_mark_thunk_call(self):
+        # The identical jmp-to-resolved-API shape, but reached only after a preceding
+        # instruction inside the same function, is a thunk-shaped tailcall INSIDE a
+        # larger routine, not a whole-function thunk -- it must not be flagged.
+        disassembler = self._create_disassembler()
+        disassembler._registerLabelProvider(ImportSlotProvider(0x1020, "kernel32.dll", "ExitProcess"))
+        disassembler.disassembly = SimpleNamespace(
+            apis={},
+            dereferenceDword=lambda addr: 0x9999 if addr == 0x1020 else None,
+            isAddrWithinMemoryImage=lambda addr: True,
+        )
+        disassembler.tailcall_analyzer = SimpleNamespace(addJump=lambda *a, **kw: None)
+        backend = X86Backend.__new__(X86Backend)
+
+        state = FunctionAnalysisState(0x1010, disassembler.disassembly)
+        state.addInstruction(0x1010, 1, "push", "ebp", b"\x55")
+        instruction = (0x1013, 6, "jmp", "dword ptr [0x1020]")
+
+        backend._analyzeJmpInstruction(disassembler, instruction, state)
+
+        self.assertFalse(state.is_thunk_call)
+
     def test_function_gaps_cover_head_and_tail_without_code_areas(self):
         # Raw memory dumps are loaded without section info (_code_areas is empty). The gap scan
         # must still cover the head (before the first instruction) and tail (after the last

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -549,6 +549,45 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertFalse(state.is_thunk_call)
 
+    def test_direct_jmp_to_resolved_import_as_first_instruction_marks_thunk_call(self):
+        disassembler = self._create_disassembler()
+        disassembler._registerLabelProvider(ImportSlotProvider(0x1020, "kernel32.dll", "ExitProcess"))
+        disassembler.disassembly = SimpleNamespace(
+            apis={},
+            functions={},
+            isAddrWithinMemoryImage=lambda addr: True,
+        )
+        disassembler.fc_manager = SimpleNamespace(getFunctionStartCandidates=lambda: set())
+        disassembler.tailcall_analyzer = SimpleNamespace(addJump=lambda *a, **kw: None)
+        backend = X86Backend.__new__(X86Backend)
+        backend._resolveImportSlot = lambda d, target: 0x1020
+
+        state = FunctionAnalysisState(0x1000, disassembler.disassembly)
+        backend._analyzeJmpInstruction(disassembler, (0x1000, 5, "jmp", "0x1100"), state)
+
+        self.assertTrue(state.is_thunk_call)
+        self.assertTrue(state.is_sanely_ending)
+
+    def test_direct_jmp_to_resolved_import_deep_in_function_does_not_mark_thunk_call(self):
+        disassembler = self._create_disassembler()
+        disassembler._registerLabelProvider(ImportSlotProvider(0x1020, "kernel32.dll", "ExitProcess"))
+        disassembler.disassembly = SimpleNamespace(
+            apis={},
+            functions={},
+            isAddrWithinMemoryImage=lambda addr: True,
+        )
+        disassembler.fc_manager = SimpleNamespace(getFunctionStartCandidates=lambda: set())
+        disassembler.tailcall_analyzer = SimpleNamespace(addJump=lambda *a, **kw: None)
+        backend = X86Backend.__new__(X86Backend)
+        backend._resolveImportSlot = lambda d, target: 0x1020
+
+        state = FunctionAnalysisState(0x1000, disassembler.disassembly)
+        state.addInstruction(0x1000, 1, "push", "rbp", b"\x55")
+        backend._analyzeJmpInstruction(disassembler, (0x1001, 5, "jmp", "0x1100"), state)
+
+        self.assertFalse(state.is_thunk_call)
+        self.assertTrue(state.is_sanely_ending)
+
     def test_function_gaps_cover_head_and_tail_without_code_areas(self):
         # Raw memory dumps are loaded without section info (_code_areas is empty). The gap scan
         # must still cover the head (before the first instruction) and tail (after the last


### PR DESCRIPTION
## Summary
- `DisassemblyStatistics` gained a `num_thunk_functions` field, but `X86Backend` never called `setThunkCall`, so the count was always 0 for every x86/x64 report even when real import thunks existed.
- `X86Backend._analyzeJmpInstruction` now flags a function as a thunk when its entire body is a single `jmp` through a resolved IAT/GOT slot (`jmp dword ptr [...]` / `jmp qword ptr [rip+...]`), mirroring the existing AArch64 GOT-thunk detection (`AArch64Backend._walkGotThunk`).

## Root cause
`is_thunk_call` / `setThunkCall()` exists identically across the intel/dalvik/cil `FunctionAnalysisState` classes and each backend's finalize step already adds to `disassembly.thunk_functions` when the flag is set — but only `AArch64Backend` ever called `setThunkCall(True)`. Verified against a real x86 PE sample: 10 genuine single-instruction `jmp dword ptr [iat_slot]` thunk stubs were present but `num_thunk_functions` reported 0 before this fix.

## Validation
- `make lint` (ruff check + format) — clean
- `make test` — 533 passed, 1 skipped
- New regression tests in `tests/testIntelDisassembler.py` cover both the positive case (jmp-to-resolved-import as a function's sole instruction marks it a thunk) and the negative case (same shape deeper inside a function does not mark it a thunk)
- Manually confirmed against a real x86 PE malware sample: `num_thunk_functions` went from 0 to the correct count of 10

## Scope note
Dalvik and CIL backends still never populate `thunk_functions` (no PLT/IAT-equivalent concept to detect against) — left out of scope for this fix, tracked as a follow-up.
