### PR TITLE
feat(intel): split merged functions at x64 pdata ends

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -36,6 +36,13 @@ class SmdaConfig:
     # system binaries (wermgr/ping/robocopy/bcrypt) show equal-or-better boundary accuracy
     # with the directory enabled, so it is on by default
     USE_PE_ARM64_PDATA_CANDIDATES = True
+    # force function-end splits at x64 PE .pdata RUNTIME_FUNCTION EndAddresses so that
+    # SMDA functions align with the compiler's exception-table boundaries; off by default
+    # because MSVC fragments single control-flow functions across many .pdata ranges
+    # (cold/hot splitting), so naive splitting fragments real functions. When on, splits
+    # are only performed where the interior .pdata start has a non-fall-through inbound
+    # jmp/call from another recovered function, never from candidate membership alone.
+    USE_PE_X64_PDATA_ENDS = False
     # promote unclaimed ELF .eh_frame FDE starts as late AArch64 candidates (after the primary
     # pass, before gap analysis); off until validated against ground-truth function boundaries
     USE_ELF_EH_FRAME_CANDIDATES = False

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 import re
+from bisect import bisect_right
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.labelprovider.DelphiKbSymbolProvider import DelphiKbSymbolProvider
@@ -465,6 +466,8 @@ class RecursiveDisassembler:
                 if cbAnalysisTimeout and cbAnalysisTimeout():
                     break
                 state = self.analyzeFunction(candidate.addr)
+        if self.config.USE_PE_X64_PDATA_ENDS:
+            self._splitMergedFunctionsAtPdataEnds(cbAnalysisTimeout)
         self.disassembly.failed_analysis_addr = self.fc_manager.getAbortedCandidates()
         # package up and finish
         for addr, candidate in self.fc_manager.candidates.items():
@@ -478,3 +481,125 @@ class RecursiveDisassembler:
         if cbAnalysisTimeout and cbAnalysisTimeout():
             self.disassembly.analysis_timeout = True
         return self.disassembly
+
+    def _splitMergedFunctionsAtPdataEnds(self, cbAnalysisTimeout=None):
+        if not self.config.USE_PE_X64_PDATA_ENDS:
+            return 0
+        if self.backend.name != "intel":
+            return 0
+        pdata_ends = self.fc_manager.pdata_end_addresses
+        if not pdata_ends:
+            return 0
+        if self._pdataSplitTimeoutTripped(cbAnalysisTimeout):
+            return 0
+        split_points_by_owner = {}
+        for index, end_addr in enumerate(sorted(pdata_ends)):
+            if index and index % 4096 == 0 and self._pdataSplitTimeoutTripped(cbAnalysisTimeout):
+                return 0
+            fn_start = self.disassembly.ins2fn.get(end_addr)
+            if (
+                fn_start is None
+                or end_addr == fn_start
+                or end_addr not in self.disassembly.instructions
+                or fn_start not in self.disassembly.functions
+            ):
+                continue
+            fn_min, fn_max = self.disassembly.function_borders[fn_start]
+            if not fn_min < end_addr < fn_max:
+                continue
+            if self._hasNonFallthroughCodeRef(end_addr, fn_start):
+                split_points_by_owner.setdefault(fn_start, []).append(end_addr)
+        splits_performed = 0
+        for fn_start, genuine_splits in sorted(split_points_by_owner.items()):
+            if self._pdataSplitTimeoutTripped(cbAnalysisTimeout):
+                break
+            splits_performed += self._partitionFunctionAtPdataEnds(fn_start, genuine_splits)
+        return splits_performed
+
+    def _pdataSplitTimeoutTripped(self, cbAnalysisTimeout):
+        if self.disassembly.analysis_timeout:
+            return True
+        if cbAnalysisTimeout is not None and cbAnalysisTimeout():
+            self.disassembly.analysis_timeout = True
+            return True
+        return False
+
+    def _hasNonFallthroughCodeRef(self, target_addr, owner_fn):
+        for source_addr in self.disassembly.code_refs_to.get(target_addr, ()):
+            instruction = self.disassembly.instructions.get(source_addr)
+            source_owner = self.disassembly.ins2fn.get(source_addr)
+            if instruction is not None and source_addr + instruction[1] != target_addr and source_owner is not None:
+                return True
+        return False
+
+    def _partitionFunctionAtPdataEnds(self, fn_start, split_points):
+        split_points = sorted(set(split_points))
+        segment_starts = [fn_start, *split_points]
+        partitioned_blocks = {start: [] for start in segment_starts}
+
+        for block in self.disassembly.functions[fn_start]:
+            current_segment = None
+            block_fragment = []
+            for instruction in block:
+                segment = segment_starts[bisect_right(split_points, instruction[0])]
+                if segment != current_segment and block_fragment:
+                    partitioned_blocks[current_segment].append(block_fragment)
+                    block_fragment = []
+                current_segment = segment
+                block_fragment.append(instruction)
+            if block_fragment:
+                partitioned_blocks[current_segment].append(block_fragment)
+
+        if any(not blocks for blocks in partitioned_blocks.values()):
+            return 0
+
+        self.disassembly.recursive_functions.discard(fn_start)
+        self.disassembly.leaf_functions.discard(fn_start)
+        self.disassembly.thunk_functions.discard(fn_start)
+
+        for segment_start, blocks in partitioned_blocks.items():
+            instructions = [instruction for block in blocks for instruction in block]
+            self.disassembly.functions[segment_start] = blocks
+            self.disassembly.function_borders[segment_start] = (
+                min(instruction[0] for instruction in instructions),
+                max(instruction[0] + instruction[1] for instruction in instructions),
+            )
+            for instruction in instructions:
+                for byte_addr in range(instruction[0], instruction[0] + instruction[1]):
+                    self.disassembly.ins2fn[byte_addr] = segment_start
+
+            self.disassembly.function_symbols[segment_start] = self.resolveSymbol(segment_start)
+            if not any(instruction[2].split(" ")[-1] == "call" for instruction in instructions):
+                self.disassembly.leaf_functions.add(segment_start)
+            if any(
+                instruction[2].split(" ")[-1] == "call"
+                and segment_start in self.disassembly.code_refs_from.get(instruction[0], ())
+                for instruction in instructions
+            ):
+                self.disassembly.recursive_functions.add(segment_start)
+            if self._isApiJumpThunk(instructions):
+                self.disassembly.thunk_functions.add(segment_start)
+
+            candidate = self.fc_manager.candidates.get(segment_start)
+            if candidate is not None:
+                candidate.analysis_aborted = False
+                candidate.abortion_reason = ""
+                candidate.setAnalysisCompleted()
+
+        for split_point in split_points:
+            for source_addr in tuple(self.disassembly.code_refs_to.get(split_point, ())):
+                instruction = self.disassembly.instructions.get(source_addr)
+                if (
+                    instruction is not None
+                    and source_addr + instruction[1] == split_point
+                    and self.disassembly.ins2fn.get(source_addr) != split_point
+                ):
+                    self.disassembly.removeCodeRefs(source_addr, split_point)
+
+        return len(split_points)
+
+    def _isApiJumpThunk(self, instructions):
+        if len(instructions) != 1 or instructions[0][2].split(" ")[-1] != "jmp":
+            return False
+        instruction_addr = instructions[0][0]
+        return any(instruction_addr in api.get("referencing_addr", ()) for api in self.disassembly.apis.values())

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -41,6 +41,11 @@ _ENTRY_SHAPE_MIN_SCORE = 30
 class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
 
+    def __init__(self, config):
+        super().__init__(config)
+        self.pdata_start_addresses = set()
+        self.pdata_end_addresses = set()
+
     def init(self, disassembly, cbAnalysisTimeout=None):
         # the gap scan decodes potential NOP instructions, so it needs an x86 capstone
         # matching the binary's bitness; build it before the base init runs discovery
@@ -542,6 +547,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
     def locateExceptionHandlerCandidates(self):
         # 64bit only - if we have a .pdata section describing exception handlers, we extract entries of guaranteed function starts from it.
         if self.disassembly.binary_info.bitness == 64:
+            self.pdata_start_addresses = set()
+            self.pdata_end_addresses = set()
+            record_pdata_ends = self.config.USE_PE_X64_PDATA_ENDS
+            base_addr = self.disassembly.binary_info.base_addr
             for section_info in self.disassembly.binary_info.getSections():
                 section_name, section_va_start, section_va_end = section_info
                 if section_name == ".pdata":
@@ -560,7 +569,12 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                             # split-off cold/epilogue chunk) chained to another function's
                             # primary RUNTIME_FUNCTION entry, not an independent function start.
                             continue
-                        self.addExceptionCandidate(self.disassembly.binary_info.base_addr + rva_function_candidate)
+                        self.addExceptionCandidate(base_addr + rva_function_candidate)
+                        if record_pdata_ends and _rva_function_end > rva_function_candidate:
+                            # record .pdata EndAddresses as candidate split points; skip degenerate
+                            # (EndAddress <= BeginAddress) entries and keep them as VAs.
+                            self.pdata_start_addresses.add(base_addr + rva_function_candidate)
+                            self.pdata_end_addresses.add(base_addr + _rva_function_end)
 
     def _isChainedUnwindInfo(self, rva_unwind_info):
         # x64 UNWIND_INFO header byte 0 packs Version (bits 0-2) and Flags (bits 3-7);

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -1,6 +1,8 @@
 import struct
 import unittest
+from types import SimpleNamespace
 
+from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
@@ -8,6 +10,87 @@ from smda.SmdaConfig import SmdaConfig
 BASE_ADDR = 0x140000000
 BINARY_SIZE = 0x4000
 PDATA_OFFSET = 0x1000
+TEXT_RVA = 0x1000
+PDATA_RVA = 0x2000
+XDATA_RVA = 0x3000
+FILE_ALIGNMENT = 0x200
+SECTION_ALIGNMENT = 0x1000
+
+
+def build_x64_pe(text_bytes, pdata_entries):
+    pdata_bytes = b"".join(struct.pack("<III", *entry) for entry in pdata_entries)
+    dos = bytearray(0x40)
+    dos[0:2] = b"MZ"
+    dos[0x3C:0x40] = struct.pack("<I", 0x40)
+    coff = struct.pack("<HHIIIHH", 0x8664, 3, 0, 0, 0, 240, 0x0022)
+    data_directories = [(0, 0)] * 16
+    data_directories[3] = (PDATA_RVA, len(pdata_bytes))
+    optional_header = struct.pack(
+        "<HBBIIIIIQIIHHHHHHIIIIHHQQQQII",
+        0x20B,
+        14,
+        0,
+        len(text_bytes),
+        0,
+        0,
+        TEXT_RVA,
+        TEXT_RVA,
+        BASE_ADDR,
+        SECTION_ALIGNMENT,
+        FILE_ALIGNMENT,
+        6,
+        0,
+        0,
+        0,
+        6,
+        0,
+        0,
+        0x4000,
+        FILE_ALIGNMENT,
+        0,
+        3,
+        0,
+        0x100000,
+        0x1000,
+        0x100000,
+        0x1000,
+        0,
+        16,
+    ) + b"".join(struct.pack("<II", rva, size) for rva, size in data_directories)
+
+    def section_header(name, rva, virtual_size, raw_offset, characteristics):
+        return struct.pack(
+            "<8sIIIIIIHHI",
+            name,
+            virtual_size,
+            rva,
+            FILE_ALIGNMENT,
+            raw_offset,
+            0,
+            0,
+            0,
+            0,
+            characteristics,
+        )
+
+    sections = (
+        section_header(b".text", TEXT_RVA, len(text_bytes), 0x200, 0x60000020)
+        + section_header(b".pdata", PDATA_RVA, len(pdata_bytes), 0x400, 0x40000040)
+        + section_header(b".xdata", XDATA_RVA, 0x40, 0x600, 0x40000040)
+    )
+    headers = bytes(dos) + b"PE\x00\x00" + coff + optional_header + sections
+    image = bytearray(0x800)
+    image[: len(headers)] = headers
+    image[0x200 : 0x200 + len(text_bytes)] = text_bytes
+    image[0x400 : 0x400 + len(pdata_bytes)] = pdata_bytes
+    return bytes(image)
+
+
+def disassemble_x64_pe(text_bytes, pdata_entries):
+    config = SmdaConfig()
+    config.WITH_STRINGS = False
+    config.USE_PE_X64_PDATA_ENDS = True
+    return Disassembler(config).disassembleUnmappedBuffer(build_x64_pe(text_bytes, pdata_entries))
 
 
 class MockBinaryInfo:
@@ -131,6 +214,156 @@ class PdataExtractionTestSuite(unittest.TestCase):
         candidates = fcm.candidates
         self.assertIn(BASE_ADDR + 0x2000, candidates)
         self.assertEqual(len(candidates), 1)
+
+
+class PdataEndSplitTestSuite(unittest.TestCase):
+    def test_non_fallthrough_entry_ref_splits_at_pdata_end(self):
+        text = bytearray(b"\x90" * 0x40)
+        text[0x10] = 0xC3
+        text[0x20:0x25] = b"\xe9" + struct.pack("<i", -0x15)
+        report = disassemble_x64_pe(
+            bytes(text),
+            [
+                (TEXT_RVA, TEXT_RVA + 0x10, XDATA_RVA),
+                (TEXT_RVA + 0x10, TEXT_RVA + 0x11, XDATA_RVA + 0x10),
+                (TEXT_RVA + 0x20, TEXT_RVA + 0x25, XDATA_RVA + 0x20),
+            ],
+        )
+
+        self.assertEqual(report.status, "ok")
+        starts = {function.offset for function in report.getFunctions()}
+        self.assertIn(BASE_ADDR + TEXT_RVA, starts)
+        self.assertIn(BASE_ADDR + TEXT_RVA + 0x10, starts)
+        self.assertIn(BASE_ADDR + TEXT_RVA + 0x20, starts)
+        first = report.getFunction(BASE_ADDR + TEXT_RVA)
+        second = report.getFunction(BASE_ADDR + TEXT_RVA + 0x10)
+        self.assertEqual([instruction.mnemonic for instruction in first.getInstructions()], ["nop"] * 16)
+        self.assertEqual([instruction.mnemonic for instruction in second.getInstructions()], ["ret"])
+        self.assertEqual(first.outrefs, {})
+        self.assertIn(BASE_ADDR + TEXT_RVA + 0x20, second.inrefs)
+
+    def test_pdata_candidate_with_only_fallthrough_ref_is_not_split(self):
+        text = bytearray(b"\x90" * 0x20)
+        text[0x10] = 0xC3
+        report = disassemble_x64_pe(
+            bytes(text),
+            [
+                (TEXT_RVA, TEXT_RVA + 0x10, XDATA_RVA),
+                (TEXT_RVA + 0x10, TEXT_RVA + 0x11, XDATA_RVA + 0x10),
+            ],
+        )
+
+        self.assertEqual(report.status, "ok")
+        starts = {function.offset for function in report.getFunctions()}
+        self.assertIn(BASE_ADDR + TEXT_RVA, starts)
+        self.assertNotIn(BASE_ADDR + TEXT_RVA + 0x10, starts)
+        merged = report.getFunction(BASE_ADDR + TEXT_RVA)
+        self.assertEqual(
+            [instruction.mnemonic for instruction in merged.getInstructions()],
+            ["nop"] * 16 + ["ret"],
+        )
+
+    def test_existing_function_start_with_backward_block_is_not_resplit(self):
+        text = bytearray(b"\x90" * 0x30)
+        text[0] = 0xC3
+        text[8] = 0xC3
+        text[0x10:0x13] = b"\x75\xf6\xc3"
+        text[0x20:0x25] = b"\xe9" + struct.pack("<i", -0x15)
+        pdata_entries = [
+            (TEXT_RVA, TEXT_RVA + 0x10, XDATA_RVA),
+            (TEXT_RVA + 0x10, TEXT_RVA + 0x13, XDATA_RVA + 0x10),
+            (TEXT_RVA + 0x20, TEXT_RVA + 0x25, XDATA_RVA + 0x20),
+        ]
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        config.USE_PE_X64_PDATA_ENDS = True
+        disassembler = Disassembler(config)
+        report = disassembler.disassembleUnmappedBuffer(build_x64_pe(bytes(text), pdata_entries))
+
+        self.assertEqual(report.status, "ok")
+        starts = {function.offset for function in report.getFunctions()}
+        self.assertIn(BASE_ADDR + TEXT_RVA + 0x10, starts)
+        existing = report.getFunction(BASE_ADDR + TEXT_RVA + 0x10)
+        self.assertEqual(
+            [instruction.offset for instruction in existing.getInstructions()],
+            [BASE_ADDR + TEXT_RVA + 8, BASE_ADDR + TEXT_RVA + 0x10, BASE_ADDR + TEXT_RVA + 0x12],
+        )
+
+    def test_internal_jump_to_split_interior_preserves_disjoint_ownership(self):
+        text = bytearray(b"\x90" * 0x40)
+        text[0:2] = b"\x75\x0f"
+        text[0x10:0x12] = b"\x90\xc3"
+        text[0x20:0x25] = b"\xe9" + struct.pack("<i", 0x10 - (0x20 + 5))
+        report = disassemble_x64_pe(
+            bytes(text),
+            [
+                (TEXT_RVA, TEXT_RVA + 0x10, XDATA_RVA),
+                (TEXT_RVA + 0x10, TEXT_RVA + 0x12, XDATA_RVA + 0x10),
+                (TEXT_RVA + 0x20, TEXT_RVA + 0x25, XDATA_RVA + 0x20),
+            ],
+        )
+
+        self.assertEqual(report.status, "ok")
+        owner = report.getFunction(BASE_ADDR + TEXT_RVA)
+        split = report.getFunction(BASE_ADDR + TEXT_RVA + 0x10)
+        owner_addresses = {instruction.offset for instruction in owner.getInstructions()}
+        split_addresses = {instruction.offset for instruction in split.getInstructions()}
+        self.assertIn(BASE_ADDR + TEXT_RVA + 0x11, split_addresses)
+        self.assertNotIn(BASE_ADDR + TEXT_RVA + 0x11, owner_addresses)
+        self.assertTrue(owner_addresses.isdisjoint(split_addresses))
+
+    def test_unowned_non_fallthrough_ref_does_not_authorize_split(self):
+        config = SmdaConfig()
+        config.USE_PE_X64_PDATA_ENDS = True
+        disassembler = Disassembler(config, backend="intel").disassembler
+        disassembler.disassembly.instructions = {0x1000: ("jmp", 5)}
+        disassembler.disassembly.code_refs_to = {0x1010: {0x1000}}
+        disassembler.disassembly.ins2fn = {}
+
+        self.assertFalse(disassembler._hasNonFallthroughCodeRef(0x1010, 0x2000))
+
+    def test_partition_does_not_consult_stale_data_map_bytes(self):
+        text = bytearray(b"\x90" * 0x40)
+        text[0x10] = 0xC3
+        text[0x20:0x25] = b"\xe9" + struct.pack("<i", -0x15)
+        entries = [
+            (TEXT_RVA, TEXT_RVA + 0x10, XDATA_RVA),
+            (TEXT_RVA + 0x10, TEXT_RVA + 0x11, XDATA_RVA + 0x10),
+            (TEXT_RVA + 0x20, TEXT_RVA + 0x25, XDATA_RVA + 0x20),
+        ]
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        disassembler = Disassembler(config)
+        report = disassembler.disassembleUnmappedBuffer(build_x64_pe(bytes(text), entries))
+        self.assertEqual(report.status, "ok")
+
+        engine = disassembler.disassembler
+        split_addr = BASE_ADDR + TEXT_RVA + 0x10
+        engine.config.USE_PE_X64_PDATA_ENDS = True
+        engine.fc_manager.pdata_start_addresses = {split_addr}
+        engine.fc_manager.pdata_end_addresses = {split_addr}
+        engine.disassembly.data_map.add(split_addr)
+
+        self.assertEqual(engine._splitMergedFunctionsAtPdataEnds(), 1)
+        self.assertIn(split_addr, engine.disassembly.instructions)
+        self.assertEqual(engine.disassembly.ins2fn[split_addr], split_addr)
+        self.assertIn(split_addr, engine.disassembly.data_map)
+
+    def test_timeout_skips_pdata_split_pass(self):
+        config = SmdaConfig()
+        config.USE_PE_X64_PDATA_ENDS = True
+        disassembler = Disassembler(config, backend="intel").disassembler
+        disassembler.fc_manager = SimpleNamespace(pdata_start_addresses={0x1010}, pdata_end_addresses={0x1010})
+        callback_calls = 0
+
+        def timeout():
+            nonlocal callback_calls
+            callback_calls += 1
+            return True
+
+        self.assertEqual(disassembler._splitMergedFunctionsAtPdataEnds(timeout), 0)
+        self.assertEqual(callback_calls, 1)
+        self.assertTrue(disassembler.disassembly.analysis_timeout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds a default-off x64 PE boundary pass, `USE_PE_X64_PDATA_ENDS`, that splits already-recovered
functions at exact `.pdata` RUNTIME_FUNCTION `EndAddress`/`BeginAddress` boundaries, but only when
the interior boundary has an external, non-fall-through code reference (a real `jmp`/`call` target
from another recovered function) — never from candidate membership alone.

## Motivation
MSVC frequently fragments a single logical function's `.pdata` into multiple RUNTIME_FUNCTION
entries (hot/cold splitting, epilogue chunks). SMDA's existing recursive disassembly can end up
merging control flow across an interior `.pdata` end when a genuinely separate function begins
right there. Naively splitting at every `.pdata` boundary regresses accuracy (splits real
cold/hot fragments apart), so this pass only splits where there's independent evidence — a
non-fall-through inbound reference — that the boundary is a real function start.

## Changed behavior
- `FunctionCandidateManager.locateExceptionHandlerCandidates` now optionally records
  `pdata_start_addresses` / `pdata_end_addresses` alongside its existing candidate extraction
  (recording is gated on the new flag; no behavior change when off).
- `RecursiveDisassembler` gains a post-pass, `_splitMergedFunctionsAtPdataEnds`, that partitions
  blocks at genuine boundaries while preserving instruction ownership (no re-disassembly, no
  candidate loss, no stale data-map state) and respects the existing analysis-timeout callback.
- Flag defaults to `False`; behavior is unchanged unless explicitly enabled.

## Validation
- `python -m pytest tests/testPdataExtraction.py tests/testAnalysisTimeoutCallback.py -q` — pass
- `make lint` (ruff check + ruff format --check) — clean
- `make test` (full suite) — pass
- Validated against a 61-pair MSVC PE/PDB corpus for boundary parity
