### PR TITLE
feat(common): surface Rust detection in the language-guess heuristic

### DIFF
--- a/src/smda/common/LanguageAnalyzer.py
+++ b/src/smda/common/LanguageAnalyzer.py
@@ -7,6 +7,7 @@ from smda.common.labelprovider.DelphiKbSymbolProvider import DelphiKbSymbolProvi
 from smda.common.labelprovider.DelphiPythiaProvider import DelphiPythiaProvider
 from smda.common.labelprovider.DelphiReSymProvider import DelphiReSymProvider
 from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
+from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,6 +16,7 @@ class LanguageAnalyzer:
     def __init__(self, disassembly):
         self.disassembly = disassembly
         self.go_resolver = GoSymbolProvider(None)
+        self.rust_resolver = RustSymbolProvider(None)
         self.delphi_kb_resolver = DelphiKbSymbolProvider(None)
         self.delphi_pythia_resolver = DelphiPythiaProvider(None)
         self.delphi_resym_resolver = DelphiReSymProvider(None)
@@ -112,6 +114,15 @@ class LanguageAnalyzer:
     def checkGo(self):
         return self.getGoScore() > 0.5
 
+    def getRustScore(self):
+        rust_score = 0.0
+        if self.rust_resolver.is_rust_binary(self.disassembly.binary_info):
+            rust_score = 0.6
+        return rust_score
+
+    def checkRust(self):
+        return self.getRustScore() > 0.5
+
     def parseDelphiString(self, buffer):
         parsed_string = ""
         if len(buffer) > 0:
@@ -174,6 +185,8 @@ class LanguageAnalyzer:
         result["visualbasic"] = self.getVisualBasicScore()
         # GO
         result["go"] = self.getGoScore()
+        # RUST
+        result["rust"] = self.getRustScore()
         # C++
         # check if there is a high number of the following patterns
         # in relation to the number off all functions (->the size of the sample)
@@ -206,6 +219,10 @@ class LanguageAnalyzer:
             # here (identify()) before any function exists, so it always divides by 1 and can
             # spuriously outscore a real Go binary (see rescore()).
             guess = "go"
+        if result.get("rust", 0) > 0.5:
+            # same rationale as the Go override above: a Rust mangled-symbol/signature match
+            # is unambiguous evidence that must win over the c++ thiscall score.
+            guess = "rust"
         return guess
 
     def rescore(self, result, function_count):

--- a/src/smda/common/labelprovider/RustSymbolProvider.py
+++ b/src/smda/common/labelprovider/RustSymbolProvider.py
@@ -118,8 +118,9 @@ class RustSymbolProvider(AbstractLabelProvider):
 
     def _get_binary_data(self, binary_info):
         """Safely retrieves binary data from either raw_data or a file path."""
-        data = binary_info.raw_data
-        if not data and binary_info.file_path:
+        data = getattr(binary_info, "raw_data", None)
+        file_path = getattr(binary_info, "file_path", None)
+        if not data and file_path:
             try:
                 with open(binary_info.file_path, "rb") as fin:
                     data = fin.read()

--- a/tests/testLanguageAnalyzer.py
+++ b/tests/testLanguageAnalyzer.py
@@ -50,6 +50,19 @@ class TestLanguageAnalyzer(unittest.TestCase):
         self.assertEqual(result["c++"], 1)  # the pre-disassembly zero-function artifact
         self.assertEqual(result["_guess"], "go")
 
+    def test_identify_prefers_rust_signature_over_zero_function_cpp_artifact(self):
+        # same rationale as the Go case above: an unambiguous Rust marker string must win the
+        # guess over the inflated pre-disassembly c++ score, or a real Rust binary gets
+        # misclassified as c++.
+        binary = b"RUST_MIN_STACK" + b"\x8b\x4d\x04\xe8\x01\x02\x03\x00" * 3
+        analyzer = LanguageAnalyzer(_DummyDisassembly(binary, functions={}))
+
+        result = analyzer.identify()
+
+        self.assertGreater(result["rust"], 0.5)
+        self.assertEqual(result["c++"], 1)  # the pre-disassembly zero-function artifact
+        self.assertEqual(result["_guess"], "rust")
+
     def test_rescore_renormalizes_cpp_score_and_guess_with_real_function_count(self):
         binary = b'Go build ID: "abc123def456"' + b"\x8b\x4d\x04\xe8\x01\x02\x03\x00" * 3
         analyzer = LanguageAnalyzer(_DummyDisassembly(binary, functions={}))

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -141,6 +141,22 @@ class TestRustDemangler(unittest.TestCase):
         with self.assertRaises(UnableTov0Demangle):
             printer.print_lifetime_from_index(2)
 
+    def test_v0_demangles_impl_path_generic_args(self):
+        """Impl-block/generic-instantiation ("I" tag) paths must demangle correctly.
+
+        Per RFC 2603's v0 grammar, path-generic-args = "I" path {generic-arg} "E" -- the
+        terminating E is mandatory even for an empty generic-arg list, so every legitimate
+        rustc-emitted "I" path already carries it.
+        """
+        self.assertEqual(demangle("_RINvNtC3std3env3varE"), "std::env::var::<>")
+
+    def test_v0_truncated_generic_args_raises_demangle_error_not_uncaught_exception(self):
+        """A truncated "I" path (missing the mandatory terminal E) is undecodable input;
+        it must raise the caught UnableTov0Demangle, not leak some other exception type
+        that RustSymbolProvider's except clause does not catch."""
+        with self.assertRaises(UnableTov0Demangle):
+            demangle("_RINvNtC3std3env3var")
+
     def test_demangle_thread_safety(self):
         """Demangling should be safe when run concurrently."""
 


### PR DESCRIPTION
## Summary

- `LanguageAnalyzer.identify()` scored `c/asm`, Delphi (3 variants), `.net`, `visualbasic`, `go`, and `c++`, but had **no Rust candidate at all**. A Rust binary's `report.language["_guess"]` therefore always fell through to a spurious `"c++"` guess (the thiscall-pattern heuristic), even though `RustSymbolProvider.is_rust_binary()` already detects Rust reliably for its own demangling path (mangled-symbol prefixes, or `RUST_BACKTRACE`/`RUST_MIN_STACK`/`/rustc/` signature strings) — that signal just never reached the report.
- Wires `is_rust_binary()` into `identify()`/`_deriveGuess()`, giving it the same "unambiguous evidence overrides the c++ artifact" treatment already used for the Go build-ID check.
- Hardens `RustSymbolProvider._get_binary_data()`, which assumed `binary_info.raw_data`/`.file_path` always exist as real attributes — this is now reachable via `LanguageAnalyzer` with lightweight `BinaryInfo`-like test doubles that don't carry those attributes, and previously raised an uncaught `AttributeError` instead of degrading gracefully.
- Adds test coverage for the `"I"` (impl-path/generic-args) v0 demangling tag, which previously had none. Verified against RFC 2603's grammar (`path-generic-args = "I" path {generic-arg} "E"`) that a well-formed instance always carries the terminal `E`, even for an empty generic-arg list, and confirmed a truncated/malformed instance fails via the already-caught `UnableTov0Demangle` rather than leaking an unhandled exception type.

## Changed behavior

- `report.language` now includes a `"rust"` score and can guess `"rust"` instead of `"c++"` for Rust binaries.
- `RustSymbolProvider._get_binary_data()` no longer raises `AttributeError` on a `binary_info` without `raw_data`/`file_path`; it returns `None` instead.

## Validation

```
ruff check .
ruff format --check .
make test
```
All green locally (612 passed, 1 skipped).

Manually verified on a real 32-bit Rust-compiled PE (tokio + rustls networking stack): `report.language["_guess"]` changed from `"c++"` to `"rust"` after this change.
