### PR TITLE
fix(cil): filter non-disassemblable method labels

### DIFF
--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -222,7 +222,9 @@ class CilDisassembler:
                     if isinstance(operand, dnfile.mdtable.MethodDefRow):
                         # override operand string with "address" of the method
                         method_name = self.cil_label_provider.decodeSymbolName(operand.Name.value)
-                        i_op_str = f"0x{self.cil_label_provider.getAddress(method_name):x}"
+                        method_addr = self.cil_label_provider.getAddress(method_name)
+                        if method_addr is not None:
+                            i_op_str = f"0x{method_addr:x}"
             if i_mnemonic in ["throw", "rethrow"]:
                 state.setNextInstructionReachable(False)
             if i_mnemonic in ["switch"]:

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -48,6 +48,8 @@ class CilSymbolProvider(AbstractLabelProvider):
         if not method_defs:
             return
         for row in method_defs:
+            if not row.Rva or not row.ImplFlags.miIL or any((row.Flags.mdAbstract, row.Flags.mdPinvokeImpl)):
+                continue
             addr = pe.get_offset_from_rva(row.Rva)
             func_name = self.decodeSymbolName(row.Name.value)
             self._addr_to_func_symbols[addr] = func_name

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -386,6 +386,32 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
 
         self.assertFalse(state.isNextInstructionReachable())
 
+    def test_cil_call_to_method_without_disassembled_body_keeps_symbol_operand(self):
+        class FakeInstruction:
+            offset = 0x1000
+            opcode = "call"
+            operand = object()
+
+            def get_bytes(self):
+                return b"\x28\x01\x00\x00\x06"
+
+        class FakeMethodDef:
+            Name = SimpleNamespace(value="AbstractMethod")
+
+        disassembler = CilDisassembler(SmdaConfig())
+        disassembler.disassembly = DisassemblyResult()
+        method_body = SimpleNamespace(offset=0x1000, instructions=[FakeInstruction()])
+
+        with (
+            mock.patch("smda.cil.CilDisassembler.format_operand", return_value="AbstractMethod"),
+            mock.patch("smda.cil.CilDisassembler.resolve_token", return_value=FakeMethodDef()),
+            mock.patch("smda.cil.CilDisassembler.dnfile.mdtable.MethodDefRow", FakeMethodDef),
+        ):
+            state = disassembler.analyzeFunction(None, method_body.offset, method_body)
+
+        self.assertEqual(state.instructions[0][3], "AbstractMethod")
+        self.assertIn(0x1000, disassembler.disassembly.functions)
+
     def test_elf_api_resolver_uses_relocation_slot_address(self):
         resolver = ElfApiResolver(None)
         resolver._api_map["lief"][0x4018] = ("GLIBC_2.2.5", "puts")
@@ -404,6 +430,40 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
 
         self.assertEqual(provider.getFunctionSymbols(), {})
         self.assertIsNone(provider.getAddress("stale"))
+
+    def test_cil_symbol_provider_only_returns_managed_methods_with_il_bodies(self):
+        def method_def(name, rva, *, is_il=True, is_abstract=False, is_pinvoke=False):
+            return SimpleNamespace(
+                Rva=rva,
+                ImplFlags=SimpleNamespace(miIL=is_il),
+                Flags=SimpleNamespace(mdAbstract=is_abstract, mdPinvokeImpl=is_pinvoke),
+                Name=SimpleNamespace(value=name),
+            )
+
+        method_defs = [
+            method_def("ManagedBody", 0x2000),
+            method_def("AbstractMethod", 0x2100, is_abstract=True),
+            method_def("PInvokeMethod", 0x2200, is_pinvoke=True),
+            method_def("NoBody", 0),
+            method_def("RuntimeMethod", 0x2300, is_il=False),
+        ]
+        get_offset_from_rva = mock.Mock(side_effect=lambda rva: rva + 0x100)
+        fake_pe = SimpleNamespace(
+            net=SimpleNamespace(mdtables=SimpleNamespace(MethodDef=method_defs)),
+            get_offset_from_rva=get_offset_from_rva,
+        )
+        provider = CilSymbolProvider(None)
+
+        with mock.patch("smda.common.labelprovider.CilSymbolProvider.dnfile.dnPE", return_value=fake_pe):
+            provider.update(BinaryInfo(b"MZ"))
+
+        self.assertEqual(provider.getFunctionSymbols(), {0x2100: "ManagedBody"})
+        self.assertEqual(provider.getAddress("ManagedBody"), 0x2100)
+        self.assertIsNone(provider.getAddress("AbstractMethod"))
+        self.assertIsNone(provider.getAddress("PInvokeMethod"))
+        self.assertIsNone(provider.getAddress("NoBody"))
+        self.assertIsNone(provider.getAddress("RuntimeMethod"))
+        get_offset_from_rva.assert_called_once_with(0x2000)
 
     @staticmethod
     def _fake_macho(cpu_type):


### PR DESCRIPTION
## What was going on

A `MethodDef` row does not always mean there is real IL code behind it. Abstract methods, P/Invoke declarations, non-IL implementations, and rows without an RVA were still being added to `CilSymbolProvider` as function labels, even though SMDA would never disassemble them as functions.

## What changed

- only keep CIL function labels for MethodDef rows that are eligible to carry an IL body
- keep the readable symbol operand when a call points at a filtered method instead of trying to format a missing address
- add focused coverage for valid managed methods, abstract/P/Invoke/runtime methods, zero-RVA rows, and the call-operand fallback

The bug-class sweep found one provider instance in the label path and one CIL consumer that needed the missing-address guard. No report schema or CFG recovery behavior changed.

This stays intentionally metadata-only: malformed body parsing still belongs to the CIL disassembler, so the symbol provider does not duplicate method-body decoding.

## Checks

- `python -m pytest tests/testFileFormatParsers.py tests/testCommonModels.py tests/testCilEscaperVerification.py -q` — 75 passed, 86 subtests passed
- `make lint` — passed
- `make test` — 717 passed, 1 skipped
- `git diff --check` — passed