### PR TITLE
refactor(intel): width-correct two's complement in escapeBinaryPtrRef

### DIFF
--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -2250,16 +2250,23 @@ class IntelInstructionEscaper:
         addr_match = re.search(r"\[(rip (\+|\-) )?(?P<dword_offset>0x[a-fA-F0-9]+)\]", ins.operands)
         if addr_match:
             offset = int(addr_match.group("dword_offset"), 16)
-            if "rip -" in ins.operands:
-                offset = 0x100000000 - offset
-            pack_format = "<I"
+            disp_size = 4
             try:
                 if ins.getDetailed().disp_size == 8:
-                    pack_format = "<Q"
+                    disp_size = 8
             except (AttributeError, AssertionError, NotImplementedError, ValueError):
                 # ValueError: getDetailed() raises it when the stored bytes do not decode;
-                # fall back to the default 32-bit pack_format rather than crash here.
+                # fall back to the default 32-bit displacement rather than crash here.
                 pass
+            pack_format = "<Q" if disp_size == 8 else "<I"
+            if "rip -" in ins.operands:
+                # two's complement must use the displacement's own width; hardcoding
+                # 0x100000000 here would produce a value that cannot be packed with "<Q".
+                # Not currently reachable: x86-64 RIP-relative addressing is always
+                # ModRM mod=00/rm=101 with a disp32, while disp_size == 8 occurs only for
+                # moffs64 forms (movabs), whose operand string contains no "rip". Kept
+                # width-correct so the two branches cannot disagree if either changes.
+                offset = (1 << (disp_size * 8)) - offset
             try:
                 packed_hex = str(codecs.encode(struct.pack(pack_format, offset), "hex").decode("ascii"))
             except struct.error:


### PR DESCRIPTION
> **This is not a bug fix.** Nothing changes at runtime. Please read the reachability note before treating it as one — I'd rather over-explain that than have it land in a changelog as a correctness fix.

## What's wrong with the current code

`escapeBinaryPtrRef` negates a `rip -` displacement with a hardcoded 32-bit modulus, and only afterwards decides how wide to pack it:

```python
if "rip -" in ins.operands:
    offset = 0x100000000 - offset      # always 32-bit two's complement
pack_format = "<I"
try:
    if ins.getDetailed().disp_size == 8:
        pack_format = "<Q"             # ...but the width can be 64-bit
```

If both branches ever applied to the same instruction, the encoded bytes would be `2**64 - offset` while `packed_hex` was computed from a 32-bit complement. `packed_hex` would then never occur in `ins.bytes`, and the reference would silently go unescaped — no error, just a pointer reference that quietly stops being wildcarded.

## Why it can't actually happen

That combination isn't reachable on x86-64:

- RIP-relative addressing is always ModRM `mod=00` / `rm=101`, which carries a **disp32**. Capstone reports `disp_size == 4` for every `[rip +/- N]` form.
- `disp_size == 8` only shows up for `moffs64` encodings (`movabs rax, [0x1122334455667788]`), whose operand string contains no `rip`, so it never enters the negation branch.
- x86 allows at most one memory operand per instruction, so a single operand string can't carry both shapes at once.

So the two conditions are mutually exclusive by encoding.

## Why there's no test

**No regression test can be written that fails on the pre-fix code**, because no input reaches the broken path. Every other fix I've sent recently ships with a test verified to fail before the change — this one can't, and I didn't want to paper over that with a test that passes identically before and after and looks like verification.

Instead I measured the equivalence directly. I ran `escapeBinaryPtrRef` over every recovered instruction of six intel fixtures with both the old and new implementations:

```
cutwail_xored              1611 instructions, 0 differing
mirai_x64_xored           12564 instructions, 0 differing
mirai_i386_xored          14758 instructions, 0 differing
bashlite_xored             8767 instructions, 0 differing
komplex_xored              4914 instructions, 0 differing
njrat_xored                8454 instructions, 0 differing

TOTAL: 51068 instructions compared, 905 rip-relative, 0 escaping differences
```

Plus a synthetic sweep over positive and negative disp32 forms in both 32- and 64-bit mode (including a displacement containing `0x0a`, and `-0x7fffffff`) and a `movabs` moffs64 form — all escape identically.

## The change

Derive the width once, before the negation, and negate using that width:

```python
offset = (1 << (disp_size * 8)) - offset
```

The inline comment records the reachability argument so the next person doesn't either mistake this for dead defensive code and rip it out, or mistake it for a live bug and go looking for the sample that triggers it.

## Validation

`make lint` clean, `make test` 715 passed / 1 skipped.

Entirely reasonable to close this as not-worth-it — it's hygiene, and the argument for leaving the code alone (it demonstrably cannot misbehave) is about as strong as the argument for changing it (the two branches shouldn't be able to disagree if either is ever touched). Kept on its own branch so it doesn't ride along with anything that matters.
