### PR TITLE
feat: continuous fuzzing, report determinism fixes, and parallel batch disassembly

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -12,6 +12,8 @@ on:
       - "src/smda/**"
       - ".github/workflows/fuzzing.yml"
   schedule:
+    # Scheduled workflows do not run in forks unless explicitly re-enabled, so
+    # no repository guard is needed here.
     - cron: "0 3 * * 1"
   workflow_dispatch:
     inputs:
@@ -31,6 +33,11 @@ defaults:
   run:
     shell: bash
 
+env:
+  # atheris ships manylinux x86_64 wheels only; pinned so a release cannot
+  # silently change instrumentation or drop the Python version used here.
+  ATHERIS_VERSION: "3.1.0"
+
 jobs:
   fuzz:
     name: Fuzz (${{ matrix.target }})
@@ -41,9 +48,20 @@ jobs:
       matrix:
         include:
           - target: fuzz_loaders
+            seed_profile: binary
+            max_len: 262144
+          - target: fuzz_formats
+            seed_profile: formats
             max_len: 262144
           - target: fuzz_disassembler
+            seed_profile: binary
             max_len: 65536
+          - target: fuzz_buffer
+            seed_profile: buffer
+            max_len: 65536
+          - target: fuzz_report
+            seed_profile: report
+            max_len: 1048576
 
     steps:
       - name: Checkout code
@@ -62,32 +80,90 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .
-          python -m pip install atheris
+          python -m pip install "atheris==${ATHERIS_VERSION}"
+
+      - name: Restore accumulated corpus
+        id: corpus-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: corpus
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
 
       - name: Generate seed corpus
-        run: python fuzzing/generate_seeds.py corpus
+        run: python fuzzing/generate_seeds.py corpus --profile ${{ matrix.seed_profile }}
 
       - name: Determine fuzzing duration
         id: duration
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_SECONDS: ${{ inputs.max_total_time }}
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "seconds=900" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "seconds=${{ inputs.max_total_time }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "seconds=120" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            schedule) seconds=900 ;;
+            workflow_dispatch)
+              # Validate rather than interpolating a dispatch input into a shell
+              # command, and keep it inside the job timeout.
+              if [[ ! "$REQUESTED_SECONDS" =~ ^[0-9]{1,4}$ ]] || [ "$REQUESTED_SECONDS" -lt 10 ]; then
+                echo "max_total_time must be an integer between 10 and 9999" >&2
+                exit 1
+              fi
+              seconds="$REQUESTED_SECONDS"
+              ;;
+            *) seconds=120 ;;
+          esac
+          echo "seconds=$seconds" >> "$GITHUB_OUTPUT"
 
       - name: Run fuzz target
+        env:
+          MAX_TOTAL_TIME: ${{ steps.duration.outputs.seconds }}
+          MAX_LEN: ${{ matrix.max_len }}
+          TARGET: ${{ matrix.target }}
         run: |
+          set -euo pipefail
           mkdir -p artifacts
-          python fuzzing/${{ matrix.target }}.py corpus \
-            -max_total_time=${{ steps.duration.outputs.seconds }} \
-            -max_len=${{ matrix.max_len }} \
+          python "fuzzing/${TARGET}.py" corpus \
+            -dict=fuzzing/smda.dict \
+            -max_total_time="${MAX_TOTAL_TIME}" \
+            -max_len="${MAX_LEN}" \
             -timeout=60 \
             -rss_limit_mb=4096 \
+            -malloc_limit_mb=2048 \
             -artifact_prefix=artifacts/ \
             -print_final_stats=1
+
+      - name: Minimize corpus before caching
+        # Success only: on a crash, -merge would re-execute the crashing input
+        # and abort partway, leaving a truncated corpus behind.
+        if: success()
+        continue-on-error: true
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          # Keep the cached corpus bounded: -merge keeps only inputs that add
+          # coverage, so it does not grow without limit across weekly runs.
+          mkdir -p corpus-merged
+          python "fuzzing/${TARGET}.py" -merge=1 -max_total_time=120 corpus-merged corpus
+          if [ -n "$(ls -A corpus-merged)" ]; then
+            rm -rf corpus
+            mv corpus-merged corpus
+          fi
+
+      - name: Minimize crash artifacts
+        if: failure()
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          # Best effort: a smaller reproducer is what gets pinned as a
+          # regression test. Never mask the original failure.
+          shopt -s nullglob
+          for artifact in artifacts/crash-* artifacts/oom-* artifacts/timeout-*; do
+            python "fuzzing/${TARGET}.py" -minimize_crash=1 -runs=20000 \
+              -artifact_prefix=artifacts/minimized- "$artifact" || true
+          done
 
       - name: Upload crash artifacts
         if: failure()
@@ -96,3 +172,22 @@ jobs:
           name: fuzz-artifacts-${{ matrix.target }}
           path: artifacts/
           if-no-files-found: ignore
+
+      - name: Upload corpus for reproduction
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-corpus-${{ matrix.target }}
+          path: corpus/
+          if-no-files-found: ignore
+
+      - name: Save accumulated corpus
+        # Persist coverage progress even when the run failed, so the inputs that
+        # led to a crash are not lost, and the next run starts warm. Cache
+        # writes are unavailable to fork pull requests, which must not fail the job.
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: corpus
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -82,6 +82,12 @@ jobs:
           python -m pip install -e .
           python -m pip install "atheris==${ATHERIS_VERSION}"
 
+      - name: Record dependency versions
+        # `pip install -e .` resolves the newest allowed capstone/lief, which can
+        # differ from a developer's pinned environment; a finding must be
+        # attributable to the versions that produced it.
+        run: python -c "import capstone, lief; print('capstone', capstone.__version__); print('lief', lief.__version__)"
+
       - name: Restore accumulated corpus
         id: corpus-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -134,23 +134,9 @@ jobs:
             -artifact_prefix=artifacts/ \
             -print_final_stats=1
 
-      - name: Minimize corpus before caching
-        # Success only: on a crash, -merge would re-execute the crashing input
-        # and abort partway, leaving a truncated corpus behind.
-        if: success()
-        continue-on-error: true
-        env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          set -euo pipefail
-          # Keep the cached corpus bounded: -merge keeps only inputs that add
-          # coverage, so it does not grow without limit across weekly runs.
-          mkdir -p corpus-merged
-          python "fuzzing/${TARGET}.py" -merge=1 -max_total_time=120 corpus-merged corpus
-          if [ -n "$(ls -A corpus-merged)" ]; then
-            rm -rf corpus
-            mv corpus-merged corpus
-          fi
+      - name: Bound the cached corpus
+        if: always()
+        run: python fuzzing/prune_corpus.py corpus
 
       - name: Minimize crash artifacts
         if: failure()
@@ -161,8 +147,7 @@ jobs:
           # regression test. Never mask the original failure.
           shopt -s nullglob
           for artifact in artifacts/crash-* artifacts/oom-* artifacts/timeout-*; do
-            python "fuzzing/${TARGET}.py" -minimize_crash=1 -runs=20000 \
-              -artifact_prefix=artifacts/minimized- "$artifact" || true
+            python fuzzing/minimize.py "${TARGET#fuzz_}" "$artifact" || true
           done
 
       - name: Upload crash artifacts

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,98 @@
+name: Fuzzing
+
+on:
+  push:
+    paths:
+      - "fuzzing/**"
+      - "src/smda/**"
+      - ".github/workflows/fuzzing.yml"
+  pull_request:
+    paths:
+      - "fuzzing/**"
+      - "src/smda/**"
+      - ".github/workflows/fuzzing.yml"
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      max_total_time:
+        description: "Seconds of fuzzing per target"
+        required: false
+        default: "300"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: fuzz_loaders
+            max_len: 262144
+          - target: fuzz_disassembler
+            max_len: 65536
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install SMDA and atheris
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install atheris
+
+      - name: Generate seed corpus
+        run: python fuzzing/generate_seeds.py corpus
+
+      - name: Determine fuzzing duration
+        id: duration
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "seconds=900" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "seconds=${{ inputs.max_total_time }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "seconds=120" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run fuzz target
+        run: |
+          mkdir -p artifacts
+          python fuzzing/${{ matrix.target }}.py corpus \
+            -max_total_time=${{ steps.duration.outputs.seconds }} \
+            -max_len=${{ matrix.max_len }} \
+            -timeout=60 \
+            -rss_limit_mb=4096 \
+            -artifact_prefix=artifacts/ \
+            -print_final_stats=1
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: artifacts/
+          if-no-files-found: ignore

--- a/.github/workflows/scripts/compare_perf.py
+++ b/.github/workflows/scripts/compare_perf.py
@@ -14,6 +14,12 @@ def main():
     parser.add_argument(
         "--threshold-fail", type=float, default=0.50, help="Slowdown failure threshold (e.g. 0.50 for 50%)"
     )
+    parser.add_argument(
+        "--fail-on-call-count-change",
+        action="store_true",
+        help="Treat any call-count delta as a failure (useful when bisecting, off by default because "
+        "a legitimate optimization changes it on purpose)",
+    )
     args = parser.parse_args()
 
     try:
@@ -43,6 +49,9 @@ def main():
 
     overall_base_time = 0
     overall_pr_time = 0
+    call_count_rows = []
+    call_count_changed = False
+    skipped_call_counts = []
 
     all_fixtures = set(base_data.keys()).union(pr_data.keys())
     for name in sorted(all_fixtures):
@@ -80,6 +89,11 @@ def main():
         # Check correctness
         corr_status = "MATCH"
         mismatches = []
+
+        base_hash = base.get("report_hash", "")
+        pr_hash = pr.get("report_hash", "")
+        if base_hash and pr_hash and base_hash != pr_hash:
+            mismatches.append(f"Report identity hash mismatch: base={base_hash[:16]}, pr={pr_hash[:16]}")
 
         if base["num_functions"] != pr["num_functions"]:
             mismatches.append(f"Function count mismatch: base={base['num_functions']}, pr={pr['num_functions']}")
@@ -122,6 +136,19 @@ def main():
             if len(mismatches) > 10:
                 print(f"  - ... and {len(mismatches) - 10} more mismatches")
 
+        base_calls = base.get("total_calls")
+        pr_calls = pr.get("total_calls")
+        if base_calls is not None and pr_calls is not None:
+            if base.get("python_version") != pr.get("python_version"):
+                # call counts are only comparable within one interpreter version
+                skipped_call_counts.append(name)
+            else:
+                delta = pr_calls - base_calls
+                pct = (delta / base_calls) * 100 if base_calls else 0
+                call_count_rows.append((name, base_calls, pr_calls, delta, pct))
+                if delta:
+                    call_count_changed = True
+
         print(
             row_fmt.format(
                 name,
@@ -158,9 +185,23 @@ def main():
     )
     print()
 
+    if call_count_rows:
+        print("=== PYTHON CALL COUNTS (informational) ===")
+        cc_fmt = "{:<12} | {:>14} | {:>14} | {:>14} | {:>9}"
+        print(cc_fmt.format("Fixture", "Base Calls", "PR Calls", "Delta", "Change"))
+        print("-" * 74)
+        for cc_name, base_calls, pr_calls, delta, pct in call_count_rows:
+            print(cc_fmt.format(cc_name, base_calls, pr_calls, f"{delta:+d}", f"{pct:+.2f}%"))
+        print()
+    if skipped_call_counts:
+        print(f"Call-count comparison skipped (python version differs): {', '.join(skipped_call_counts)}\n")
+
     # Exit codes
     if correctness_failed:
         print("❌ Correctness checks failed! Output results do not match.", file=sys.stderr)
+        sys.exit(1)
+    if call_count_changed and args.fail_on_call_count_change:
+        print("❌ Call counts changed and --fail-on-call-count-change was requested.", file=sys.stderr)
         sys.exit(1)
     if perf_failed:
         print("❌ Performance checks failed! Severe performance regression detected.", file=sys.stderr)

--- a/.github/workflows/scripts/compare_perf.py
+++ b/.github/workflows/scripts/compare_perf.py
@@ -9,10 +9,10 @@ def main():
     parser.add_argument("pr_results", type=str, help="Path to PR results JSON")
     parser.add_argument("base_results", type=str, help="Path to base results JSON")
     parser.add_argument(
-        "--threshold-warn", type=float, default=0.20, help="Slowdown warning threshold (e.g. 0.20 for 20%)"
+        "--threshold-warn", type=float, default=0.20, help="Slowdown warning threshold (e.g. 0.20 for 20%%)"
     )
     parser.add_argument(
-        "--threshold-fail", type=float, default=0.50, help="Slowdown failure threshold (e.g. 0.50 for 50%)"
+        "--threshold-fail", type=float, default=0.50, help="Slowdown failure threshold (e.g. 0.50 for 50%%)"
     )
     parser.add_argument(
         "--fail-on-call-count-change",

--- a/.github/workflows/scripts/run_perf_check.py
+++ b/.github/workflows/scripts/run_perf_check.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 import argparse
+import cProfile
 import json
 import logging
 import os
+import platform
+import pstats
 import statistics
 import sys
 import time
@@ -13,6 +16,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 try:
     from smda.Disassembler import Disassembler
     from smda.SmdaConfig import SmdaConfig
+    from smda.utility.common import computeReportIdentityHash
 except ImportError as e:
     print(f"Error importing SMDA. Make sure you run this script from the repository root: {e}", file=sys.stderr)
     sys.exit(1)
@@ -50,7 +54,34 @@ def merge_results(existing_results, new_results):
     return merged_results
 
 
-def run_benchmark(iterations, output_file, append=False):
+def disassemble_fixture(config, fixture, binary_bytes):
+    disasm = Disassembler(config, backend=fixture["backend"])
+    if fixture["backend"] in ("dalvik", "cil"):
+        return disasm.disassembleUnmappedBuffer(binary_bytes)
+    if fixture["base_addr"] != 0:
+        return disasm.disassembleBuffer(binary_bytes, fixture["base_addr"])
+    return disasm.disassembleUnmappedBuffer(binary_bytes)
+
+
+def count_calls(config, fixture, binary_bytes):
+    """Total/primitive call counts from a dedicated pass, strictly outside the timed loop.
+
+    The first pass of a process carries ~200k one-time calls (ApiScout DB parse, regex
+    compilation, demangler caches), so it is discarded: only the warm pass is reported. Two
+    separate processes then agree to the digit, which is what makes this metric usable at all.
+    """
+    disassemble_fixture(config, fixture, binary_bytes)
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        disassemble_fixture(config, fixture, binary_bytes)
+    finally:
+        profiler.disable()
+    stats = pstats.Stats(profiler)
+    return stats.total_calls, stats.prim_calls
+
+
+def run_benchmark(iterations, output_file, append=False, with_call_counts=False):
     # Disable logging during benchmark to avoid stdout/file write overhead in the timed region
     logging.disable(logging.CRITICAL)
     config = SmdaConfig()
@@ -82,18 +113,23 @@ def run_benchmark(iterations, output_file, append=False):
 
         times = []
         report = None
+        report_hashes = set()
         for _ in range(iterations):
-            disasm = Disassembler(config, backend=fixture["backend"])
             start = time.perf_counter()
-            if fixture["backend"] in ("dalvik", "cil"):
-                report = disasm.disassembleUnmappedBuffer(binary_bytes)
-            else:
-                if fixture["base_addr"] != 0:
-                    report = disasm.disassembleBuffer(binary_bytes, fixture["base_addr"])
-                else:
-                    report = disasm.disassembleUnmappedBuffer(binary_bytes)
+            report = disassemble_fixture(config, fixture, binary_bytes)
             end = time.perf_counter()
             times.append(end - start)
+            # hashed outside the timed region: identical input must yield an identical report,
+            # and a side that disagrees with itself makes any cross-side comparison meaningless
+            report_hashes.add(computeReportIdentityHash(report))
+
+        if len(report_hashes) > 1:
+            print(
+                f"Error: '{fixture['name']}' produced {len(report_hashes)} different report hashes "
+                f"across {iterations} iterations of the same input - the output is non-deterministic.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         num_functions = report.num_functions if report else 0
         num_instructions = report.num_instructions if report else 0
@@ -116,7 +152,14 @@ def run_benchmark(iterations, output_file, append=False):
             "num_instructions": num_instructions,
             "num_blocks": num_blocks,
             "functions": functions_meta,
+            "report_hash": report_hashes.pop() if report_hashes else "",
+            "python_version": platform.python_version(),
         }
+
+        if with_call_counts:
+            total_calls, prim_calls = count_calls(config, fixture, binary_bytes)
+            results[fixture["name"]]["total_calls"] = total_calls
+            results[fixture["name"]]["prim_calls"] = prim_calls
 
     if output_file:
         if append and os.path.exists(output_file):
@@ -142,8 +185,13 @@ if __name__ == "__main__":
         action="store_true",
         help="Merge this pass's timing samples into an existing output file instead of replacing it",
     )
+    parser.add_argument(
+        "--call-counts",
+        action="store_true",
+        help="Also record cProfile call counts (two extra untimed passes per fixture)",
+    )
     args = parser.parse_args()
 
     if args.iterations < 1:
         parser.error("--iterations must be >= 1")
-    run_benchmark(args.iterations, args.output, append=args.append)
+    run_benchmark(args.iterations, args.output, append=args.append, with_call_counts=args.call_counts)

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ profiling/output/
 
 # Fuzzing artifacts
 /corpus/
-/corpus-merged/
 /artifacts/
 crash-*
 oom-*

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ profiling/output/
 .dockerignore
 # Validation scripts and data
 /validation
+
+# Fuzzing artifacts
+/corpus/
+crash-*
+oom-*
+timeout-*

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ profiling/output/
 
 # Fuzzing artifacts
 /corpus/
+/corpus-merged/
+/artifacts/
 crash-*
 oom-*
 timeout-*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python3
 
-.PHONY: init package publish ruff-check ruff-format ruff-fix lint format test test-coverage clean benchmark profile-cpu profile-mem profile-flame
+.PHONY: init package publish ruff-check ruff-format ruff-fix lint format test test-coverage clean benchmark benchmark-determinism profile-cpu profile-mem profile-flame
 
 # Default profiling target fixture; override e.g. `make profile-cpu TARGET=komplex`
 TARGET ?= asprox
@@ -28,6 +28,8 @@ test-coverage:
 	$(PYTHON) -m pytest --cov=smda --cov-report=html:coverage-html tests/
 benchmark:
 	$(PYTHON) .github/workflows/scripts/run_perf_check.py --output benchmark_results.json
+benchmark-determinism:
+	$(PYTHON) .github/workflows/scripts/run_perf_check.py --iterations 2 --call-counts --output benchmark_determinism.json
 profile-cpu:
 	$(PYTHON) -m profiling.profile_smda cpu --target $(TARGET) --line
 profile-mem:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,44 @@ There is also a demo script:
 
 * analyze.py -- example usage: perform disassembly on a file or memory dump and optionally store results in JSON to a given output path.
 
+### Batch mode
+
+Disassembly is CPU-bound and every input file is independent, so corpora are processed in parallel:
+
+```
+$ python batch_analyze.py /path/to/corpus -o /path/to/reports
+```
+
+* `-w/--workers` defaults to all usable cores; `-w 1` is the serial reference.
+* `-c/--resume` skips inputs whose report already exists in the output directory.
+* `-m/--max_tasks_per_child` recycles workers to bound memory growth on very large corpora, at the cost of re-paying process warm-up.
+* `-t/--timeout` sets the per-file analysis timeout; `0` disables it.
+
+Reports are named after the input's path-relative stem, so identically-named samples in different
+subdirectories cannot overwrite each other. Batch mode uses `disassembleFile`, so raw memory dumps
+that need an explicit base address still belong in `analyze.py -a <base_addr>`.
+
+The same thing is available as a library helper, which yields one summary dict per completed file:
+
+```
+>>> from smda.utility.BatchProcessor import disassembleParallel
+>>> for summary in disassembleParallel(["/path/to/corpus"], output_dir="/path/to/reports"):
+...     print(summary["path"], summary["status"], summary["num_functions"])
+```
+
+Output does not depend on the number of workers, with one exception: `SmdaConfig.TIMEOUT` is
+wall-clock, so under heavy oversubscription a slow sample can time out where a serial run
+finished. Pass `--timeout 0` when output must be reproducible regardless of machine load.
+
+### Tuning analysis cost
+
+The largest built-in performance lever is the optional per-function metadata in `SmdaConfig`:
+`CALCULATE_HASHING` (PIC hashes), `CALCULATE_NESTING` (nesting depth) and `CALCULATE_SCC`
+(strongly connected components). Measured on the bundled cutwail fixture, in Python calls per
+run (a stable metric, unlike wall-clock on a loaded machine): hashing accounts for 10.0%,
+nesting 4.6% and SCC 3.2% of all calls, and disabling all three removes 17.8%. Turn off whatever
+a downstream consumer does not read.
+
 ### IDA Pro integration
 
 SMDA can also turn an IDA-analyzed database into a SMDA report instead of running its own disassembly. Inside the IDA GUI, SMDA supports IDA Pro 8.4 and newer via the existing IDAPython integrations; older SDK generations are rejected. On IDA 9.1 or newer, it prefers the higher-level [IDA Domain API](https://ida-domain.docs.hex-rays.com/) when the optional package is installed and otherwise falls back to IDAPython.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ python batch_analyze.py /path/to/corpus -o /path/to/reports
 
 * `-w/--workers` defaults to all usable cores; `-w 1` is the serial reference.
 * `-c/--resume` skips inputs whose report already exists in the output directory.
-* `-m/--max_tasks_per_child` recycles workers to bound memory growth on very large corpora, at the cost of re-paying process warm-up.
+* `-m/--max_tasks_per_child` recycles workers after N files. It defaults to off, and measurement says that is usually right (see memory notes below).
 * `-t/--timeout` sets the per-file analysis timeout; `0` disables it.
 
 Reports are named after the input's path-relative stem, so identically-named samples in different
@@ -67,11 +67,31 @@ that need an explicit base address still belong in `analyze.py -a <base_addr>`.
 
 The same thing is available as a library helper, which yields one summary dict per completed file:
 
+```python
+from smda.utility.BatchProcessor import disassembleParallel
+
+if __name__ == "__main__":  # required: workers are spawned, so they re-import your module
+    for summary in disassembleParallel(["/path/to/corpus"], output_dir="/path/to/reports"):
+        print(summary["path"], summary["status"], summary["num_functions"])
 ```
->>> from smda.utility.BatchProcessor import disassembleParallel
->>> for summary in disassembleParallel(["/path/to/corpus"], output_dir="/path/to/reports"):
-...     print(summary["path"], summary["status"], summary["num_functions"])
-```
+
+Workers use the `spawn` start method, which re-imports the calling module in each child. Calling
+`disassembleParallel` at import time therefore fails with a `multiprocessing` traceback - keep the
+call under a `__main__` guard (or inside a function that a guard invokes).
+
+#### Memory
+
+Peak memory is dominated by the single largest binary in flight, not by how many files a worker has
+already processed. Measured over 136 distinct real PE binaries in one worker: live Python objects
+grew by 9 across 105 files, and resident memory oscillated inside a stable band instead of trending
+up, so there is no per-file accumulation to bound. What is large is the per-file peak - one 3 MB
+binary reached roughly 1.8 GB resident on its own.
+
+Size the run by `workers x per-file peak`: on the same corpus, four workers peaked at about 5.3 GB
+combined. Reduce `--workers` on a memory-constrained machine. Recycling every file
+(`--max_tasks_per_child 1`) cost 30% wall clock (86.6s to 112.3s) while cutting the single-worker
+peak by only 8%, because it reclaims allocator high-water rather than a leak - so leave it off
+unless a specific corpus shows otherwise.
 
 Output does not depend on the number of workers, with one exception: `SmdaConfig.TIMEOUT` is
 wall-clock, so under heavy oversubscription a slow sample can time out where a serial run

--- a/batch_analyze.py
+++ b/batch_analyze.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.BatchProcessor import collectInputFiles, disassembleParallel, getDefaultWorkerCount
+
+try:
+    import tqdm
+
+    HAVE_TQDM = True
+except ImportError:
+    HAVE_TQDM = False
+
+LOGGER = logging.getLogger("batch_analyze")
+
+
+def _iterateWithProgress(results, total):
+    if HAVE_TQDM:
+        yield from tqdm.tqdm(results, total=total, unit="file")
+        return
+    last_report = 0.0
+    for index, result in enumerate(results, start=1):
+        now = time.time()
+        if now - last_report > 2.0 or index == total:
+            print(f"  {index}/{total} files processed", file=sys.stderr)
+            last_report = now
+        yield result
+
+
+if __name__ == "__main__":
+    PARSER = argparse.ArgumentParser(
+        description="Disassemble many files in parallel, writing one SMDA report per input file."
+    )
+    PARSER.add_argument("input_paths", type=str, nargs="+", help="Files and/or directories to disassemble.")
+    PARSER.add_argument(
+        "-o",
+        "--output_path",
+        type=str,
+        required=True,
+        help="Directory to write reports to. Created if it does not exist.",
+    )
+    PARSER.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=0,
+        help="Number of worker processes (default: all usable cores).",
+    )
+    PARSER.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=None,
+        help="Per-file analysis timeout in seconds; 0 disables it. A nonzero timeout is wall-clock, "
+        "so under oversubscription it makes output load-dependent (default: SmdaConfig.TIMEOUT).",
+    )
+    PARSER.add_argument(
+        "-c",
+        "--resume",
+        action="store_true",
+        default=False,
+        help="Skip inputs whose report already exists in the output directory.",
+    )
+    PARSER.add_argument(
+        "-m",
+        "--max_tasks_per_child",
+        type=int,
+        default=None,
+        help="Recycle each worker after this many files, bounding per-worker memory growth "
+        "at the cost of re-paying ~175ms of warm-up per recycle.",
+    )
+    PARSER.add_argument("-v", "--verbose", action="store_true", default=False, help="Enable debug logging.")
+    ARGS = PARSER.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)-15s %(message)s",
+        level=logging.DEBUG if ARGS.verbose else logging.WARNING,
+    )
+
+    if ARGS.workers < 0:
+        PARSER.error("--workers must be >= 0")
+    if ARGS.timeout is not None and ARGS.timeout < 0:
+        PARSER.error("--timeout must be >= 0")
+    if ARGS.max_tasks_per_child is not None and ARGS.max_tasks_per_child < 1:
+        PARSER.error("--max_tasks_per_child must be >= 1")
+    for input_path in ARGS.input_paths:
+        if not os.path.exists(input_path):
+            PARSER.error(f"input path does not exist: {input_path}")
+
+    os.makedirs(ARGS.output_path, exist_ok=True)
+
+    TOTAL = len(collectInputFiles(ARGS.input_paths))
+    WORKERS = ARGS.workers if ARGS.workers > 0 else getDefaultWorkerCount()
+    print(f"Disassembling {TOTAL} file(s) with {WORKERS} worker(s) into {ARGS.output_path}")
+    if ARGS.timeout is None:
+        print(f"Per-file timeout: {SmdaConfig.TIMEOUT}s (wall-clock; pass --timeout 0 to disable)")
+
+    RESULTS = disassembleParallel(
+        ARGS.input_paths,
+        output_dir=ARGS.output_path,
+        workers=ARGS.workers,
+        timeout=ARGS.timeout,
+        resume=ARGS.resume,
+        max_tasks_per_child=ARGS.max_tasks_per_child,
+    )
+
+    START = time.time()
+    COUNTS = {"ok": 0, "timeout": 0, "error": 0, "other": 0}
+    FAILURES = []
+    for RESULT in _iterateWithProgress(RESULTS, TOTAL):
+        status = RESULT["status"]
+        COUNTS[status if status in COUNTS else "other"] += 1
+        if RESULT["error"]:
+            FAILURES.append((RESULT["path"], RESULT["error"]))
+
+    DURATION = time.time() - START
+    print(
+        f"\nDone in {DURATION:.2f}s - ok: {COUNTS['ok']}, timeout: {COUNTS['timeout']}, "
+        f"error: {COUNTS['error']}, other: {COUNTS['other']}"
+    )
+    for path, error in FAILURES[:20]:
+        print(f"  FAILED {path}: {error}")
+    if len(FAILURES) > 20:
+        print(f"  ... and {len(FAILURES) - 20} more failures")
+    sys.exit(1 if FAILURES else 0)

--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -16,6 +16,8 @@ works anywhere without atheris.
 | `generate_seeds.py` | builds a per-target seed corpus from the test fixtures |
 | `smda.dict` | libFuzzer dictionary of magics, section names, report keys |
 | `replay.py` | runs a target over files on disk, no atheris needed |
+| `minimize.py` | delta-debugs a crashing input to a small reproducer |
+| `prune_corpus.py` | bounds the cached corpus by file count and total size |
 
 ## Targets
 
@@ -51,8 +53,19 @@ Download the `fuzz-artifacts-<target>` artifact from the failed run, then:
 python fuzzing/replay.py <target> artifacts/crash-*
 ```
 
-Once confirmed, minimize it and pin it as a regression test — see
-`tests/fuzz_regressions/README.md`.
+Once confirmed, minimize it and pin it as a regression test:
+
+```
+python fuzzing/minimize.py <target> artifacts/crash-<hash>
+```
+
+See `tests/fuzz_regressions/README.md` for how to commit the reproducer.
+
+Note that libFuzzer's own `-merge=1` and `-minimize_crash=1` are unusable under
+atheris: both re-execute `argv[0]` to run their inner passes, which here is the
+bare Python interpreter without the harness script, so they process nothing and
+report zero results. `minimize.py` and `prune_corpus.py` replace them and work
+on every platform.
 
 ## Running locally (Linux x86_64 only)
 

--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -1,0 +1,70 @@
+# Fuzzing
+
+Coverage-guided fuzzing of SMDA's untrusted-input surfaces with
+[atheris](https://github.com/google/atheris) / libFuzzer. atheris publishes no
+arm64 or macOS wheels, so the fuzzers run on Linux CI only
+(`.github/workflows/fuzzing.yml`); everything needed to *reproduce* a finding
+works anywhere without atheris.
+
+## Layout
+
+| File | Role |
+| --- | --- |
+| `targets.py` | the actual target bodies — plain Python, no atheris import |
+| `harness.py` | atheris/libFuzzer plumbing, instruments `targets.py` |
+| `fuzz_<target>.py` | one entry point per target, for libFuzzer to run |
+| `generate_seeds.py` | builds a per-target seed corpus from the test fixtures |
+| `smda.dict` | libFuzzer dictionary of magics, section names, report keys |
+| `replay.py` | runs a target over files on disk, no atheris needed |
+
+## Targets
+
+| Target | Surface |
+| --- | --- |
+| `loaders` | `MemoryFileLoader(..., map_file=True)` and every accessor |
+| `formats` | one format loader per input with `isCompatible()` bypassed |
+| `disassembler` | `disassembleUnmappedBuffer()`, the full pipeline |
+| `buffer` | `disassembleBuffer()` with fuzzer-chosen architecture/bitness/base |
+| `report` | `SmdaReport.fromDict()` over fuzzer-generated JSON, plus round-trip |
+
+## What counts as a finding
+
+SMDA's public contract is that malformed input yields an error *report*, not an
+exception: `disassembleUnmappedBuffer()` catches broadly and the loaders funnel
+through `reraise_non_operational_exception`. The harnesses mirror that, so
+ordinary parse failures are not findings. What fails a run:
+
+- a segfault, abort, or uncaught native error in capstone/lief
+- a hang (libFuzzer `-timeout`) or memory blow-up (`-rss_limit_mb`,
+  `-malloc_limit_mb`)
+- an exception the contract classes as non-operational (`AssertionError`,
+  `MemoryError`, `ImportError`, `NameError`, `ReferenceError`, `SyntaxError`)
+- `RecursionError` — operational by type, but a latent stack overflow in
+  practice, so the harnesses promote it (`FATAL_EXCEPTION_TYPES`)
+- a report that is `None` or carries a status outside `{ok, timeout, error}`
+
+## Reproducing a CI finding
+
+Download the `fuzz-artifacts-<target>` artifact from the failed run, then:
+
+```
+python fuzzing/replay.py <target> artifacts/crash-*
+```
+
+Once confirmed, minimize it and pin it as a regression test — see
+`tests/fuzz_regressions/README.md`.
+
+## Running locally (Linux x86_64 only)
+
+```
+pip install -e . && pip install atheris
+python fuzzing/generate_seeds.py corpus_loaders --profile binary
+python fuzzing/fuzz_loaders.py corpus_loaders -max_total_time=120 -dict=fuzzing/smda.dict
+```
+
+Use `--profile formats` / `--profile buffer` / `--profile report` for the
+corresponding targets: those targets consume selector bytes from the front of
+the input, and the profile prepends them.
+
+The corpus is cached per target in CI, so coverage accumulates across runs
+instead of restarting from the seeds every time.

--- a/fuzzing/fuzz_buffer.py
+++ b/fuzzing/fuzz_buffer.py
@@ -1,0 +1,6 @@
+"""Fuzz entry point for the buffer target; body lives in targets.py."""
+
+from harness import run
+
+if __name__ == "__main__":
+    run("buffer")

--- a/fuzzing/fuzz_disassembler.py
+++ b/fuzzing/fuzz_disassembler.py
@@ -1,0 +1,33 @@
+import logging
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from smda.Disassembler import Disassembler
+    from smda.SmdaConfig import SmdaConfig
+
+logging.disable(logging.CRITICAL)
+
+VALID_STATUS = {"ok", "timeout", "error"}
+
+CONFIG = SmdaConfig()
+CONFIG.TIMEOUT = 5
+DISASSEMBLER = Disassembler(CONFIG)
+
+
+def TestOneInput(data):
+    report = DISASSEMBLER.disassembleUnmappedBuffer(data)
+    if report is None:
+        raise AssertionError("disassembleUnmappedBuffer returned None")
+    if report.status not in VALID_STATUS:
+        raise AssertionError(f"invalid report status: {report.status}")
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzing/fuzz_disassembler.py
+++ b/fuzzing/fuzz_disassembler.py
@@ -1,33 +1,6 @@
-import logging
-import sys
+"""Fuzz entry point for the disassembler target; body lives in targets.py."""
 
-import atheris
-
-with atheris.instrument_imports():
-    from smda.Disassembler import Disassembler
-    from smda.SmdaConfig import SmdaConfig
-
-logging.disable(logging.CRITICAL)
-
-VALID_STATUS = {"ok", "timeout", "error"}
-
-CONFIG = SmdaConfig()
-CONFIG.TIMEOUT = 5
-DISASSEMBLER = Disassembler(CONFIG)
-
-
-def TestOneInput(data):
-    report = DISASSEMBLER.disassembleUnmappedBuffer(data)
-    if report is None:
-        raise AssertionError("disassembleUnmappedBuffer returned None")
-    if report.status not in VALID_STATUS:
-        raise AssertionError(f"invalid report status: {report.status}")
-
-
-def main():
-    atheris.Setup(sys.argv, TestOneInput)
-    atheris.Fuzz()
-
+from harness import run
 
 if __name__ == "__main__":
-    main()
+    run("disassembler")

--- a/fuzzing/fuzz_formats.py
+++ b/fuzzing/fuzz_formats.py
@@ -1,0 +1,6 @@
+"""Fuzz entry point for the formats target; body lives in targets.py."""
+
+from harness import run
+
+if __name__ == "__main__":
+    run("formats")

--- a/fuzzing/fuzz_loaders.py
+++ b/fuzzing/fuzz_loaders.py
@@ -1,0 +1,34 @@
+import logging
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from smda.common.ExceptionHandling import reraise_non_operational_exception
+    from smda.utility.MemoryFileLoader import MemoryFileLoader
+
+logging.disable(logging.CRITICAL)
+
+
+def TestOneInput(data):
+    try:
+        loader = MemoryFileLoader(data, map_file=True)
+        loader.getData()
+        loader.getRawData()
+        loader.getBaseAddress()
+        loader.getBitness()
+        loader.getArchitecture()
+        loader.getAbi()
+        loader.getCodeAreas()
+        loader.getHasBackend()
+    except Exception as exc:
+        reraise_non_operational_exception(exc)
+
+
+def main():
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzing/fuzz_loaders.py
+++ b/fuzzing/fuzz_loaders.py
@@ -1,34 +1,6 @@
-import logging
-import sys
+"""Fuzz entry point for the loaders target; body lives in targets.py."""
 
-import atheris
-
-with atheris.instrument_imports():
-    from smda.common.ExceptionHandling import reraise_non_operational_exception
-    from smda.utility.MemoryFileLoader import MemoryFileLoader
-
-logging.disable(logging.CRITICAL)
-
-
-def TestOneInput(data):
-    try:
-        loader = MemoryFileLoader(data, map_file=True)
-        loader.getData()
-        loader.getRawData()
-        loader.getBaseAddress()
-        loader.getBitness()
-        loader.getArchitecture()
-        loader.getAbi()
-        loader.getCodeAreas()
-        loader.getHasBackend()
-    except Exception as exc:
-        reraise_non_operational_exception(exc)
-
-
-def main():
-    atheris.Setup(sys.argv, TestOneInput)
-    atheris.Fuzz()
-
+from harness import run
 
 if __name__ == "__main__":
-    main()
+    run("loaders")

--- a/fuzzing/fuzz_report.py
+++ b/fuzzing/fuzz_report.py
@@ -1,0 +1,6 @@
+"""Fuzz entry point for the report target; body lives in targets.py."""
+
+from harness import run
+
+if __name__ == "__main__":
+    run("report")

--- a/fuzzing/generate_seeds.py
+++ b/fuzzing/generate_seeds.py
@@ -1,0 +1,53 @@
+import hashlib
+import sys
+from pathlib import Path
+
+FIXTURE_SEEDS = [
+    "cutwail_xored",
+    "bashlite_xored",
+    "komplex_xored",
+    "njrat_xored",
+    "blockblast_classes_xored",
+    "mirai_x64_xored",
+    "mirai_i386_xored",
+    "aarch64_static_xored",
+    "pe_export_label_test_xored",
+]
+
+MAGIC_SEEDS = [
+    b"MZ" + b"\x00" * 62,
+    b"\x7fELF\x02\x01\x01" + b"\x00" * 57,
+    b"\x7fELF\x01\x01\x01" + b"\x00" * 57,
+    b"\xcf\xfa\xed\xfe" + b"\x00" * 60,
+    b"\xce\xfa\xed\xfe" + b"\x00" * 60,
+    b"dex\n035\x00" + b"\x00" * 104,
+]
+
+
+def decode_fixture(path):
+    data = path.read_bytes()
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
+
+
+def main():
+    corpus_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("corpus")
+    head_size = int(sys.argv[2]) if len(sys.argv) > 2 else 8192
+    corpus_dir.mkdir(parents=True, exist_ok=True)
+    tests_dir = Path(__file__).resolve().parent.parent / "tests"
+    written = 0
+    for fixture_name in FIXTURE_SEEDS:
+        fixture_path = tests_dir / fixture_name
+        if not fixture_path.is_file():
+            continue
+        seed = decode_fixture(fixture_path)[:head_size]
+        (corpus_dir / f"{fixture_name}_head").write_bytes(seed)
+        written += 1
+    for seed in MAGIC_SEEDS:
+        digest = hashlib.sha256(seed).hexdigest()[:16]
+        (corpus_dir / f"magic_{digest}").write_bytes(seed)
+        written += 1
+    print(f"wrote {written} seeds to {corpus_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzing/generate_seeds.py
+++ b/fuzzing/generate_seeds.py
@@ -1,6 +1,23 @@
+"""Build a seed corpus for one fuzz target from the committed test fixtures.
+
+Fixtures live in the repository's XOR-obfuscated form only; they are decoded in
+memory and truncated to a header-sized prefix, which is where the interesting
+parsing decisions are made. Missing fixtures are a hard error: a silently
+degraded corpus would leave the fuzzer exploring almost nothing while CI stayed
+green.
+
+Profiles mirror the per-target input encodings in targets.py, prefixing the
+selector bytes that pick a loader or an architecture.
+"""
+
+import argparse
 import hashlib
+import json
 import sys
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
 
 FIXTURE_SEEDS = [
     "cutwail_xored",
@@ -23,31 +40,88 @@ MAGIC_SEEDS = [
     b"dex\n035\x00" + b"\x00" * 104,
 ]
 
+# Fixture used to produce a realistic report-JSON seed; smallest of the set.
+REPORT_SEED_FIXTURE = "bashlite_xored"
+
+# Selector-byte counts consumed by the parameter-carrying targets.
+SELECTOR_BYTES = {"binary": 0, "formats": 1, "buffer": 4}
+
 
 def decode_fixture(path):
     data = path.read_bytes()
     return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
 
 
-def main():
-    corpus_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("corpus")
-    head_size = int(sys.argv[2]) if len(sys.argv) > 2 else 8192
-    corpus_dir.mkdir(parents=True, exist_ok=True)
-    tests_dir = Path(__file__).resolve().parent.parent / "tests"
-    written = 0
+def _write(corpus_dir, name, payload):
+    (corpus_dir / name).write_bytes(payload)
+
+
+def _binary_seeds(head_size):
+    seeds = []
+    missing = []
     for fixture_name in FIXTURE_SEEDS:
-        fixture_path = tests_dir / fixture_name
+        fixture_path = TESTS_DIR / fixture_name
         if not fixture_path.is_file():
+            missing.append(fixture_name)
             continue
-        seed = decode_fixture(fixture_path)[:head_size]
-        (corpus_dir / f"{fixture_name}_head").write_bytes(seed)
-        written += 1
-    for seed in MAGIC_SEEDS:
-        digest = hashlib.sha256(seed).hexdigest()[:16]
-        (corpus_dir / f"magic_{digest}").write_bytes(seed)
-        written += 1
-    print(f"wrote {written} seeds to {corpus_dir}")
+        seeds.append((f"{fixture_name}_head", decode_fixture(fixture_path)[:head_size]))
+    if missing:
+        raise SystemExit(f"missing fixtures, corpus would be degraded: {', '.join(missing)}")
+    for payload in MAGIC_SEEDS:
+        seeds.append((f"magic_{hashlib.sha256(payload).hexdigest()[:16]}", payload))
+    return seeds
+
+
+def _prefixed_seeds(seeds, selector_count):
+    """Emit one variant per selector value so every backend/loader gets a seed."""
+    if not selector_count:
+        return seeds
+    prefixed = []
+    for selector in range(6):
+        prefix = bytes([selector]) + bytes(selector_count - 1)
+        for name, payload in seeds:
+            prefixed.append((f"sel{selector}_{name}", prefix + payload))
+    return prefixed
+
+
+def _report_seeds():
+    """Disassemble one fixture and dump the report as JSON.
+
+    A hand-written skeleton would only reach the first few field lookups in
+    fromDict(); a real report reaches the function/block/instruction rebuild.
+    """
+    from smda.Disassembler import Disassembler
+    from smda.SmdaConfig import SmdaConfig
+
+    fixture_path = TESTS_DIR / REPORT_SEED_FIXTURE
+    if not fixture_path.is_file():
+        raise SystemExit(f"missing fixture for report seed: {REPORT_SEED_FIXTURE}")
+    config = SmdaConfig()
+    config.TIMEOUT = 60
+    report = Disassembler(config).disassembleUnmappedBuffer(decode_fixture(fixture_path))
+    if report is None or report.status == "error":
+        raise SystemExit("could not produce a report seed from the fixture")
+    payload = json.dumps(report.toDict()).encode()
+    return [("report_full", payload), ("report_minimal", json.dumps({"architecture": "intel"}).encode())]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("corpus_dir", nargs="?", default="corpus", type=Path)
+    parser.add_argument("--profile", choices=(*SELECTOR_BYTES, "report"), default="binary")
+    parser.add_argument("--head-size", type=int, default=8192)
+    args = parser.parse_args()
+
+    args.corpus_dir.mkdir(parents=True, exist_ok=True)
+    if args.profile == "report":
+        seeds = _report_seeds()
+    else:
+        seeds = _prefixed_seeds(_binary_seeds(args.head_size), SELECTOR_BYTES[args.profile])
+    for name, payload in seeds:
+        _write(args.corpus_dir, name, payload)
+    print(f"wrote {len(seeds)} {args.profile} seeds to {args.corpus_dir}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/fuzzing/harness.py
+++ b/fuzzing/harness.py
@@ -1,0 +1,24 @@
+"""atheris plumbing shared by the fuzz_*.py entry points.
+
+The target bodies live in targets.py, which imports no atheris; this module is
+what instruments them and hands them to libFuzzer.
+"""
+
+import logging
+import sys
+
+import atheris
+
+
+def instrumented_target(name):
+    """Import the target bodies under atheris instrumentation and return one."""
+    with atheris.instrument_imports():
+        import targets
+
+    return targets.TARGETS[name]
+
+
+def run(name):
+    logging.disable(logging.CRITICAL)
+    atheris.Setup(sys.argv, instrumented_target(name))
+    atheris.Fuzz()

--- a/fuzzing/minimize.py
+++ b/fuzzing/minimize.py
@@ -1,0 +1,81 @@
+"""Shrink a crashing input to a smaller input that fails the same way.
+
+libFuzzer's ``-minimize_crash=1`` is unusable with atheris (it re-executes
+argv[0], which is the interpreter rather than the harness), and it would only
+work on Linux CI anyway. This is a plain delta-debugging loop over the target
+bodies in targets.py, so it runs anywhere and produces the small reproducer that
+gets pinned under tests/fuzz_regressions/.
+
+    python fuzzing/minimize.py loaders artifacts/crash-abc -o crash-min
+
+"Fails the same way" means the same exception type, deliberately ignoring the
+message and traceback: a shrunken input often reports different offsets while
+hitting the identical defect.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from targets import TARGETS  # noqa: E402
+
+
+def failure_type(target, data):
+    """Return the exception type a target raises for data, or None if it passes."""
+    try:
+        target(data)
+    except BaseException as exc:  # noqa: BLE001 - classifying, not handling
+        return type(exc)
+    return None
+
+
+def shrink(data, predicate, max_rounds=64):
+    """Delta-debug data down while predicate(candidate) stays True.
+
+    Removes shrinking-sized chunks, then trims single bytes from both ends, and
+    repeats until a full round makes no progress.
+    """
+    best = data
+    for _ in range(max_rounds):
+        progressed = False
+        chunk = max(len(best) // 2, 1)
+        while chunk >= 1:
+            offset = 0
+            while offset < len(best):
+                candidate = best[:offset] + best[offset + chunk :]
+                if candidate != best and predicate(candidate):
+                    best = candidate
+                    progressed = True
+                else:
+                    offset += chunk
+            chunk //= 2
+        if not progressed:
+            break
+    return best
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", choices=sorted(TARGETS))
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("-o", "--output", type=Path, help="defaults to <artifact>.min")
+    args = parser.parse_args()
+
+    target = TARGETS[args.target]
+    data = args.artifact.read_bytes()
+    expected = failure_type(target, data)
+    if expected is None:
+        print(f"{args.artifact} does not fail the {args.target} target; nothing to minimize")
+        return 1
+
+    minimized = shrink(data, lambda candidate: failure_type(target, candidate) is expected)
+    output = args.output or args.artifact.with_suffix(args.artifact.suffix + ".min")
+    output.write_bytes(minimized)
+    print(f"{expected.__name__}: {len(data)} -> {len(minimized)} bytes, wrote {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fuzzing/prune_corpus.py
+++ b/fuzzing/prune_corpus.py
@@ -1,0 +1,54 @@
+"""Bound a cached corpus directory by file count and total size.
+
+libFuzzer's own ``-merge=1`` cannot be used here: the merge driver re-executes
+argv[0] to run its inner passes, which under atheris is the bare Python
+interpreter without the harness script, so the merge processes nothing and
+reports zero new files. Pruning by size instead is deterministic, needs no
+instrumentation, and keeps the cache from growing without limit across weekly
+runs.
+
+Smaller inputs are kept first: they reach the same code faster, and libFuzzer
+already prefers short inputs when it reduces the corpus in-process.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+DEFAULT_MAX_FILES = 5000
+DEFAULT_MAX_BYTES = 64 * 1024 * 1024
+
+
+def prune(corpus_dir, max_files, max_bytes):
+    entries = sorted(
+        ((path.stat().st_size, path.name, path) for path in corpus_dir.iterdir() if path.is_file()),
+    )
+    kept_bytes = 0
+    kept = 0
+    removed = 0
+    for size, _name, path in entries:
+        if kept < max_files and kept_bytes + size <= max_bytes:
+            kept += 1
+            kept_bytes += size
+            continue
+        path.unlink()
+        removed += 1
+    return kept, kept_bytes, removed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("corpus_dir", type=Path)
+    parser.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    args = parser.parse_args()
+    if not args.corpus_dir.is_dir():
+        print(f"no corpus at {args.corpus_dir}, nothing to prune")
+        return 0
+    kept, kept_bytes, removed = prune(args.corpus_dir, args.max_files, args.max_bytes)
+    print(f"kept {kept} files ({kept_bytes} bytes), removed {removed}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fuzzing/replay.py
+++ b/fuzzing/replay.py
@@ -1,0 +1,55 @@
+"""Replay crash artifacts against a fuzz target without atheris.
+
+atheris publishes no arm64/macOS wheels, so a crash found in CI would otherwise
+be undebuggable on a developer machine. This runs the identical target body over
+files on disk:
+
+    python fuzzing/replay.py loaders artifacts/crash-*
+
+Files whose name ends in ``_xored`` are decoded with the repository fixture XOR
+scheme first, which is how a reproducer is committed under
+tests/fuzz_regressions/ (raw samples are never stored in the tree).
+"""
+
+import argparse
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from targets import TARGETS  # noqa: E402
+
+
+def decode(path):
+    data = path.read_bytes()
+    if path.name.endswith("_xored"):
+        return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("target", choices=sorted(TARGETS))
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    target = TARGETS[args.target]
+    failures = 0
+    for path in args.paths:
+        if not path.is_file():
+            print(f"SKIP {path} (not a file)")
+            continue
+        try:
+            target(decode(path))
+        except Exception:
+            failures += 1
+            print(f"FAIL {path}")
+            traceback.print_exc()
+        else:
+            print(f"OK   {path}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fuzzing/smda.dict
+++ b/fuzzing/smda.dict
@@ -10,8 +10,8 @@ macho_magic_64="\xcf\xfa\xed\xfe"
 macho_magic_32="\xce\xfa\xed\xfe"
 macho_cigam_64="\xfe\xed\xfa\xcf"
 macho_fat="\xca\xfe\xba\xbe"
-dex_magic="dex\n035\x00"
-dex_magic_038="dex\n038\x00"
+dex_magic="dex\x0a035\x00"
+dex_magic_038="dex\x0a038\x00"
 delphi_kb="\x14\x00\x00\x00Delphi"
 
 # PE optional-header magics and machine types

--- a/fuzzing/smda.dict
+++ b/fuzzing/smda.dict
@@ -1,0 +1,79 @@
+# libFuzzer dictionary for the SMDA binary-format targets. Mutation almost never
+# invents a valid magic or section name on its own, so the deeper parsing paths
+# are unreachable without these tokens.
+
+# Container magics
+pe_mz="MZ"
+pe_signature="PE\x00\x00"
+elf_magic="\x7fELF"
+macho_magic_64="\xcf\xfa\xed\xfe"
+macho_magic_32="\xce\xfa\xed\xfe"
+macho_cigam_64="\xfe\xed\xfa\xcf"
+macho_fat="\xca\xfe\xba\xbe"
+dex_magic="dex\n035\x00"
+dex_magic_038="dex\n038\x00"
+delphi_kb="\x14\x00\x00\x00Delphi"
+
+# PE optional-header magics and machine types
+pe_opt_pe32="\x0b\x01"
+pe_opt_pe32plus="\x0b\x02"
+machine_i386="\x4c\x01"
+machine_amd64="\x64\x86"
+machine_arm64="\xaa\x64"
+
+# PE/ELF section and directory names
+sec_text=".text"
+sec_data=".data"
+sec_rdata=".rdata"
+sec_pdata=".pdata"
+sec_xdata=".xdata"
+sec_reloc=".reloc"
+sec_rsrc=".rsrc"
+sec_edata=".edata"
+sec_idata=".idata"
+sec_bss=".bss"
+sec_ehframe=".eh_frame"
+sec_ehframehdr=".eh_frame_hdr"
+sec_gopclntab=".gopclntab"
+sec_dynsym=".dynsym"
+sec_symtab=".symtab"
+sec_cil=".cormeta"
+
+# Mach-O load commands / segments
+seg_text="__TEXT"
+seg_data="__DATA"
+sec_macho_text="__text"
+sec_unwind="__unwind_info"
+
+# Go / .NET markers
+go_pclntab_magic="\xfb\xff\xff\xff"
+go_pclntab_magic_118="\xf0\xff\xff\xff"
+go_buildid="Go build ID:"
+cli_header="BSJB"
+
+# ELF program/section header type values
+elf_pt_load="\x01\x00\x00\x00"
+elf_class_64="\x02"
+elf_class_32="\x01"
+
+# Report-JSON keys (report target)
+json_architecture="\"architecture\""
+json_base_addr="\"base_addr\""
+json_binary_size="\"binary_size\""
+json_bitness="\"bitness\""
+json_code_areas="\"code_areas\""
+json_code_sections="\"code_sections\""
+json_confidence="\"confidence_threshold\""
+json_disasm_errors="\"disassembly_errors\""
+json_execution_time="\"execution_time\""
+json_alignment="\"identified_alignment\""
+json_metadata="\"metadata\""
+json_status="\"status\""
+json_summary="\"summary\""
+json_xcfg="\"xcfg\""
+json_blocks="\"blocks\""
+json_instructions="\"instructions\""
+json_apirefs="\"apirefs\""
+json_blockrefs="\"blockrefs\""
+json_inrefs="\"inrefs\""
+json_outrefs="\"outrefs\""

--- a/fuzzing/targets.py
+++ b/fuzzing/targets.py
@@ -1,0 +1,172 @@
+"""Fuzz target bodies, free of any atheris dependency.
+
+Every function here takes a single ``bytes`` input and returns None, raising only
+when the input revealed a genuine defect. Keeping the bodies importable without
+atheris is what allows crash artifacts to be replayed (``replay.py``) and pinned
+as regression tests on platforms where no atheris wheel exists.
+
+Parameter-carrying targets consume a small fixed-size header from the front of
+the input to pick their arguments instead of using a fuzzer-provided data
+provider; the mutation engine explores those bytes like any other, and replay
+stays byte-exact.
+"""
+
+import json
+
+from smda.common.ExceptionHandling import reraise_non_operational_exception
+from smda.common.SmdaReport import SmdaReport
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.DelphiKbFileLoader import DelphiKbFileLoader
+from smda.utility.DexFileLoader import DexFileLoader
+from smda.utility.ElfFileLoader import ElfFileLoader
+from smda.utility.MachoFileLoader import MachoFileLoader
+from smda.utility.MemoryFileLoader import MemoryFileLoader
+from smda.utility.PeFileLoader import PeFileLoader
+
+# Exceptions that the public contract treats as operational (i.e. any malformed
+# input may legitimately produce them) but which still indicate a real defect
+# when a fuzzer triggers them: unbounded recursion is a crash on CPython builds
+# with a raised recursion limit and a latent stack overflow either way.
+FATAL_EXCEPTION_TYPES = (RecursionError,)
+
+VALID_STATUS = frozenset({"ok", "timeout", "error"})
+
+ARCHITECTURES = ("intel", "aarch64", "cil", "dalvik", "unsupported")
+BITNESSES = (None, 16, 32, 64)
+
+FORMAT_LOADERS = (
+    PeFileLoader,
+    ElfFileLoader,
+    MachoFileLoader,
+    DelphiKbFileLoader,
+    DexFileLoader,
+)
+
+# Analysis budget per input. The engine's own -timeout is the backstop for hangs
+# inside native code; this keeps the cooperative timeout well below it.
+ANALYSIS_TIMEOUT = 5
+
+
+def _config():
+    config = SmdaConfig()
+    config.TIMEOUT = ANALYSIS_TIMEOUT
+    return config
+
+
+def _reraise_real_defect(exception):
+    """Swallow operational exceptions, propagate everything that is a defect."""
+    if isinstance(exception, FATAL_EXCEPTION_TYPES):
+        raise
+    reraise_non_operational_exception(exception)
+
+
+def _check_report(report):
+    if report is None:
+        raise AssertionError("disassembly returned None instead of a report")
+    if report.status not in VALID_STATUS:
+        raise AssertionError(f"invalid report status: {report.status}")
+
+
+def loaders(data):
+    """MemoryFileLoader mapping path, mirroring the public loader contract."""
+    try:
+        loader = MemoryFileLoader(data, map_file=True)
+        loader.getData()
+        loader.getRawData()
+        loader.getBaseAddress()
+        loader.getBitness()
+        loader.getArchitecture()
+        loader.getAbi()
+        loader.getCodeAreas()
+        loader.getHasBackend()
+    except Exception as exc:
+        _reraise_real_defect(exc)
+
+
+def formats(data):
+    """A single format loader, invoked with isCompatible() deliberately bypassed.
+
+    Mutation rarely preserves a magic header, so the generic path above spends
+    most of its budget in the unrecognized-format branch. Pinning one loader per
+    input reaches the header-parsing code of every format instead.
+    """
+    if not data:
+        return
+    loader = FORMAT_LOADERS[data[0] % len(FORMAT_LOADERS)]
+    payload = data[1:]
+    try:
+        kw = {"parsed": loader.parseBinary(payload)} if hasattr(loader, "parseBinary") else {}
+        loader.mapBinary(payload, **kw)
+        loader.getBaseAddress(payload, **kw)
+        loader.getBitness(payload, **kw)
+        loader.getCodeAreas(payload, **kw)
+        loader.getArchitecture(payload, **kw)
+        loader.getAbi(payload, **kw)
+        if hasattr(loader, "getHasBackend"):
+            loader.getHasBackend(payload, **kw)
+    except Exception as exc:
+        _reraise_real_defect(exc)
+
+
+def disassembler(data):
+    """Full unmapped-buffer pipeline: detection, mapping, CFG recovery, report.
+
+    A fresh Disassembler per input: the instance caches a backend and the last
+    DisassemblyResult, so reusing one would make a crash depend on the preceding
+    input and defeat replay of the artifact on its own.
+    """
+    report = Disassembler(_config()).disassembleUnmappedBuffer(data)
+    _check_report(report)
+
+
+def buffer(data):
+    """disassembleBuffer() with caller-supplied architecture/bitness/addresses.
+
+    This is the API path that skips format detection, so the fuzzer — not a
+    header — chooses the backend. It is also the only way to feed foreign-ISA
+    bytes to a pinned backend, which is what exercises the instruction escapers
+    and candidate filters of each architecture directly.
+    """
+    if len(data) < 4:
+        return
+    architecture = ARCHITECTURES[data[0] % len(ARCHITECTURES)]
+    bitness = BITNESSES[data[1] % len(BITNESSES)]
+    base_addr = int.from_bytes(data[2:4], "little") << 12
+    payload = data[4:]
+    try:
+        report = Disassembler(_config()).disassembleBuffer(
+            payload,
+            base_addr,
+            bitness=bitness,
+            architecture=architecture,
+        )
+    except Exception as exc:
+        _reraise_real_defect(exc)
+        return
+    _check_report(report)
+
+
+def report(data):
+    """SmdaReport JSON deserialization, the surface consumers ingest reports on."""
+    try:
+        parsed = json.loads(data)
+    except Exception:
+        return
+    if not isinstance(parsed, dict):
+        return
+    try:
+        smda_report = SmdaReport.fromDict(parsed)
+        if smda_report is not None:
+            smda_report.toDict()
+    except Exception as exc:
+        _reraise_real_defect(exc)
+
+
+TARGETS = {
+    "loaders": loaders,
+    "formats": formats,
+    "disassembler": disassembler,
+    "buffer": buffer,
+    "report": report,
+}

--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -37,6 +37,7 @@ class DisassemblyResult:
         # key: address of API in target DLL, value: {referencing_addr, api_name, dll_name}
         self.apis = {}
         self._api_ref_sources = {}
+        self._api_refs_initialized = False
         self.addr_to_api = {}
         # address:name
         self.function_symbols = {}
@@ -342,6 +343,7 @@ class DisassemblyResult:
         return len(out_refs.difference(ins_addrs)) == 0
 
     def _initApiRefs(self):
+        self._api_refs_initialized = True
         for api_offset in self.apis:
             api = self.apis[api_offset]
             for ref in api["referencing_addr"]:
@@ -362,6 +364,7 @@ class DisassemblyResult:
             ref_sources.add(referencing_addr)
             api_entry["referencing_addr"].append(referencing_addr)
         self.apis[api_addr] = api_entry
+        self._api_refs_initialized = False
 
     def getAllApiRefs(self):
         all_api_refs = {}
@@ -370,7 +373,9 @@ class DisassemblyResult:
         return all_api_refs
 
     def getApiRefs(self, func_addr):
-        if not self.addr_to_api:
+        # an explicit flag, not a truthiness test: the old guard re-walked every API on every
+        # call for a binary with zero APIs, and never refreshed once the map was non-empty
+        if not self._api_refs_initialized:
             self._initApiRefs()
         api_refs = {}
         for block in self.functions[func_addr]:

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -60,7 +60,9 @@ class SmdaConfig:
     MAX_CALL_REFS_PER_CANDIDATE = 2000
     HIGH_ACCURACY = True
     RESOLVE_TAILCALLS = False
-    # optional metadata generation options
+    # optional metadata generation options; the largest built-in performance lever.
+    # Measured on the cutwail fixture, as a share of all Python calls per run: hashing 10.0%,
+    # nesting 4.6%, SCC 3.2%, all three together 17.8%.
     CALCULATE_SCC = True
     CALCULATE_NESTING = True
     CALCULATE_HASHING = True

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -80,14 +80,21 @@ def format_operand(pe, operand: Any) -> str:
             return f"{str(operand.TypeNamespace)}.{operand.TypeName}::{operand.Name}"
         else:
             return f"{operand.Name}"
-    elif isinstance(operand, dnfile.mdtable.TypeRefRow):
+    elif isinstance(operand, (dnfile.mdtable.TypeRefRow, dnfile.mdtable.TypeDefRow)):
         return f"{str(operand.TypeNamespace)}.{operand.TypeName}"
+    elif isinstance(operand, dnfile.mdtable.TypeSpecRow):
+        # a TypeSpec has no name, only a signature blob; render the blob so distinct
+        # instantiations stay distinguishable without serializing a memory address
+        signature = getattr(operand.Signature, "value", None)
+        return f"TypeSpec({signature.hex()})" if signature else "TypeSpec()"
     elif isinstance(operand, (dnfile.mdtable.FieldRow, dnfile.mdtable.MethodDefRow)):
         return f"{operand.Name}"
     elif operand is None:
         return ""
 
-    return str(operand)
+    # never fall through to str(operand): the default object repr embeds a memory address,
+    # which made every report of the same input serialize differently
+    return f"<{type(operand).__name__}>"
 
 
 class DnfileMethodBodyReader(CilMethodBodyReaderBase):
@@ -149,7 +156,8 @@ class CilDisassembler:
 
     def _updateApiInformation(self, from_addr, ins_bytes, api_function):
         if ins_bytes.endswith(b"\x0a"):
-            if api_function.startswith("<dnfile.mdtable.MemberRefRow"):
+            if api_function.startswith("<"):
+                # format_operand could not resolve the row to a name, so there is no API here
                 return
             self.disassembly.addr_to_api[from_addr] = api_function
 

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -207,6 +207,8 @@ class RecursiveDisassembler:
         if binary_info is None:
             return b""
         relative_start = addr - binary_info.base_addr
+        if relative_start < 0 or relative_start >= len(binary_info.binary):
+            return b""
         relative_end = relative_start + self.backend.max_instruction_size
         return binary_info.binary[relative_start:relative_end]
 

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -703,7 +703,6 @@ class SmdaFunction:
                 and version < DALVIK_PIC_HASH_ESCAPE_VERSION
             ):
                 recalculate_pic_hash = True
-                recalculate_pic_hash = True
             if recalculate_pic_hash:
                 smda_function.nesting_depth = smda_function._calculateNestingDepth()
                 if smda_function._escaper and hash_context:
@@ -751,4 +750,8 @@ class SmdaFunction:
         return self.offset
 
     def __str__(self):
-        return f"0x{self.offset:08x}: (->{self.num_inrefs:>4d}, {self.num_outrefs:>4d}->) {self.num_blocks:>3d} blocks, {self.num_instructions:>4d} instructions."
+        offset = f"0x{self.offset:08x}" if self.offset is not None else "0x????????"
+        return (
+            f"{offset}: (->{self.num_inrefs:>4d}, {self.num_outrefs:>4d}->) "
+            f"{self.num_blocks:>3d} blocks, {self.num_instructions:>4d} instructions."
+        )

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -461,11 +461,12 @@ class SmdaFunction:
         self.blocks = {}
         for block in disasm_blocks:
             instructions = []
+            block_start = block[0][0]
             for ins_addr, _, ins_mnem, ins_ops, ins_raw_bytes in block:
                 instructions.append(
                     SmdaInstruction([ins_addr, ins_raw_bytes.hex(), str(ins_mnem), str(ins_ops)], smda_function=self)
                 )
-            self.blocks[instructions[0].offset] = instructions
+            self.blocks[block_start] = instructions
             self.binweight += sum(len(ins.bytes or "") / 2 for ins in instructions)
         self._sorted_block_keys = sorted(self.blocks.keys())
         # invalidate any cached SmdaBasicBlock objects built from a previous block set

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -190,7 +190,7 @@ class SmdaFunction:
             architecture = binary_info.architecture if binary_info is not None else None
             self._escaper = self.getInstructionEscaper(architecture)
             self.offset = function_offset
-            self._parseBlocks(disassembly.getBlocksAsDict(function_offset))
+            self._parseBlocksFromTuples(disassembly.functions.get(function_offset, []))
             self.apirefs = disassembly.getApiRefs(function_offset)
             self.blockrefs = disassembly.getBlockRefs(function_offset)
             self.inrefs = disassembly.getInRefs(function_offset)
@@ -449,11 +449,23 @@ class SmdaFunction:
                 escaped_binary_seqs.append(instruction.getEscapedToOpcodeOnly(self._escaper))
         return "".join(escaped_binary_seqs).encode("ascii")
 
-    def _parseBlocks(self, block_dict):
+    def _parseBlocksFromTuples(self, disasm_blocks):
+        """Build SmdaInstructions straight from the raw disassembly tuples.
+
+        getBlocksAsDict() allocates one intermediate 4-element list per instruction plus a list
+        and dict entry per block, only to have them consumed immediately here. The transform is
+        inlined rather than removed - the stored bytes remain the same hex string and the str()
+        coercions are preserved, because the IDA path may hand back non-str mnemonics/operands.
+        Precedent for bypassing it: the TF-IDF scoring pass in RecursiveDisassembler.
+        """
         self.blocks = {}
-        for offset, block in block_dict.items():
-            instructions = [SmdaInstruction(ins, smda_function=self) for ins in block]
-            self.blocks[int(offset)] = instructions
+        for block in disasm_blocks:
+            instructions = []
+            for ins_addr, _, ins_mnem, ins_ops, ins_raw_bytes in block:
+                instructions.append(
+                    SmdaInstruction([ins_addr, ins_raw_bytes.hex(), str(ins_mnem), str(ins_ops)], smda_function=self)
+                )
+            self.blocks[instructions[0].offset] = instructions
             self.binweight += sum(len(ins.bytes or "") / 2 for ins in instructions)
         self._sorted_block_keys = sorted(self.blocks.keys())
         # invalidate any cached SmdaBasicBlock objects built from a previous block set

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -106,6 +106,14 @@ class SmdaInstruction:
         self._data_refs = data_refs
         yield from self._data_refs
 
+    def __getstate__(self):
+        # the cached capstone CsInsn holds ctypes pointers and cannot be pickled; the class-level
+        # default makes attribute lookup fall through to None after unpickling, so getDetailed()
+        # simply re-creates it on demand
+        state = self.__dict__.copy()
+        state.pop("detailed", None)
+        return state
+
     def getDetailed(self):
         if self.smda_function is None or self.smda_function.smda_report is None:
             raise ValueError("SmdaFunction or SmdaReport not set on instruction")

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -202,4 +202,5 @@ class SmdaInstruction:
         return self.offset
 
     def __str__(self):
-        return f"0x{self.offset:08x}: ({self.bytes:>14s}) - {self.mnemonic} {self.operands}"
+        offset = f"0x{self.offset:08x}" if self.offset is not None else "0x????????"
+        return f"{offset}: ({self.bytes or '':>14s}) - {self.mnemonic} {self.operands}"

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -464,7 +464,9 @@ class SmdaReport:
             LOGGER.info(f"SmdaReport saved to: {output_filepath}")
 
     def __str__(self):
+        duration = f"{self.execution_time:>6.3f}s" if self.execution_time is not None else "     ?s"
         if self.status == "error":
-            return f"{self.execution_time:>6.3f}s -> {self.message}"
+            return f"{duration} -> {self.message}"
         arch_str = f"{self.architecture}.{self.bitness}bit" if self.bitness else self.architecture
-        return f"{self.execution_time:>6.3f}s -> (architecture: {arch_str}, base_addr: 0x{self.base_addr:08x}): {len(self.xcfg)} functions"
+        base_addr = f"0x{self.base_addr:08x}" if self.base_addr is not None else "0x????????"
+        return f"{duration} -> (architecture: {arch_str}, base_addr: {base_addr}): {len(self.xcfg)} functions"

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -197,6 +197,14 @@ class SmdaReport:
         block = self.block_locator.findBlockByContainedAddress(inner_address)
         return block
 
+    def __getstate__(self):
+        # the capstone singleton holds ctypes pointers and cannot be pickled; the class-level
+        # default makes attribute lookup fall through to None after unpickling, so getCapstone()
+        # simply re-creates it on demand
+        state = self.__dict__.copy()
+        state.pop("capstone", None)
+        return state
+
     def getCapstone(self):
         if self.capstone is None:
             if self.architecture is not None and self.architecture not in ("intel", "aarch64"):

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -16,6 +16,7 @@ from smda.dalvik.DalvikOpcodeDecoder import (
 )
 from smda.DisassemblyResult import DisassemblyResult
 from smda.utility.DexFileLoader import DexFileLoader
+from smda.utility.lief_helper import safe_lief_parse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1545,7 +1546,7 @@ class DalvikDisassembler:
         dex_file = None
         if getattr(binary_info, "file_path", "") and not getattr(binary_info, "is_buffer", False):
             with contextlib.suppress(Exception):
-                dex_file = lief.DEX.parse(binary_info.file_path)
+                dex_file = safe_lief_parse(binary_info.file_path, parser=lief.DEX.parse)
         if dex_file is None:
             # Prefer bytes/memoryview: list(raw_data) allocates a PyLong per byte
             # (~30x memory blowup on large DEX). Older LIEF builds only accept
@@ -1554,11 +1555,11 @@ class DalvikDisassembler:
             if not isinstance(raw_data, (bytes, bytearray)):
                 raw_data = bytes(raw_data)
             try:
-                dex_file = lief.DEX.parse(raw_data)
+                dex_file = safe_lief_parse(raw_data, parser=lief.DEX.parse)
             except TypeError:
                 dex_file = None
             if dex_file is None:
-                dex_file = lief.DEX.parse(list(raw_data))
+                dex_file = safe_lief_parse(list(raw_data), parser=lief.DEX.parse)
         if dex_file is None:
             raise ValueError("Failed to parse DEX file")
 

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -11,6 +11,8 @@ from .BitnessAnalyzer import BitnessAnalyzer
 from .definitions import (
     CALL_INS,
     CJMP_INS,
+    GAP_SEQUENCE_FIRST_BYTES,
+    GAP_SEQUENCES,
     JMP_INS,
     LOOP_INS,
     REGS_32BIT,
@@ -427,8 +429,20 @@ class X86Backend(ArchBackend):
                     )
         elif previous_address is not None and i_address != start_addr and previous_mnemonic == "call":
             instruction_bytes = d._getDisasmWindowBuffer(i_address)
-            instruction_sequence = list(d.capstone.disasm_lite(instruction_bytes, i_address))
-            has_alignment_sequence = d.fc_manager.isAlignmentSequence(instruction_sequence, instruction_bytes)
+            # isAlignmentSequence can only return True when the FIRST decoded instruction's bytes
+            # are in GAP_SEQUENCES (otherwise it breaks with instructions_analyzed == 0, and the
+            # trailing-mnemonic check can only force False), so this byte-level test is a
+            # necessary condition and rejecting on its negation cannot change any outcome.
+            # Measured on the bundled fixtures: rejects 99.0% of 3616 calls with zero false rejects.
+            has_alignment_sequence = False
+            if instruction_bytes[:1] in GAP_SEQUENCE_FIRST_BYTES:
+                for size, sequences in GAP_SEQUENCES.items():
+                    if instruction_bytes[:size] in sequences:
+                        instruction_sequence = list(d.capstone.disasm_lite(instruction_bytes, i_address))
+                        has_alignment_sequence = d.fc_manager.isAlignmentSequence(
+                            instruction_sequence, instruction_bytes
+                        )
+                        break
             is_alignment_evidence = getattr(d.disassembly, "language_guess", None) != "go" and has_alignment_sequence
             is_candidate_evidence = d.fc_manager.isFunctionCandidate(i_address)
             if is_alignment_evidence and not is_candidate_evidence and d.disassembly.binary_info._getLiefType() == "PE":

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -167,90 +167,120 @@ COMMON_PROLOGUES = {
 
 # https://stackoverflow.com/questions/25545470/long-multi-byte-nops-commonly-understood-macros-or-other-notation
 GAP_SEQUENCES = {
-    1: [
-        b"\x90",  # NOP1_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\xcc",  # int3
-        b"\xf4",  # hlt - trap filler, a function never opens with it
-        b"\x00",  # pass over sequences of null bytes
-    ],
-    2: [
-        b"\x66\x90",  # NOP2_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x0f\x0b",  # ud2 - trap filler, a function never opens with it
-        b"\x8b\xc0",  # mov eax, eax
-        b"\x89\xc0",  # mov eax, eax
-        b"\x8b\xff",  # mov edi, edi
-        b"\x89\xff",  # mov edi, edi
-        b"\x8d\x00",  # lea eax, dword ptr [eax]
-        b"\x86\xc0",  # xchg al, al
-        b"\x66\x2e",  # NOP2_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\xeb\x00",  # jmp $+2 (jumps to next instruction; used as padding by some MSVC versions)
-        b"\x8b\xc9",  # mov ecx, ecx
-        b"\x8b\xd2",  # mov edx, edx
-        b"\x8b\xdb",  # mov ebx, ebx
-        b"\x8b\xf6",  # mov esi, esi
-    ],
-    3: [
-        b"\x0f\x1f\x00",  # NOP3_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x8d\x40\x00",  # lea eax, dword ptr [eax]
-        b"\x8d\x00\x00",  # lea eax, dword ptr [eax]
-        b"\x8d\x49\x00",  # lea ecx, dword ptr [ecx]
-        b"\x8d\x24\x24",  # lea esp, dword ptr [esp]
-        b"\x8d\x76\x00",
-        b"\x66\x66\x90",
-    ],
-    4: [
-        b"\x0f\x1f\x40\x00",  # NOP4_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x8d\x74\x26\x00",
-        b"\x66\x66\x66\x90",
-        b"\x8d\x64\x24\x00",  # lea esp, [esp+0]
-    ],
-    5: [
-        b"\x0f\x1f\x44\x00\x00",  # NOP5_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x90\x8d\x74\x26\x00",
-        b"\x66\x0f\x1f\x40\x00",
-    ],
-    6: [
-        b"\x66\x0f\x1f\x44\x00\x00",  # NOP6_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x8d\xb6\x00\x00\x00\x00",
-        b"\x8d\xbf\x00\x00\x00\x00",  # lea edi, [edi]
-    ],
-    7: [
-        b"\x0f\x1f\x80\x00\x00\x00\x00",  # NOP7_OVERRIDE_NOP - AMD / nop - INTEL,
-        b"\x8d\xb4\x26\x00\x00\x00\x00",
-        b"\x8d\xbc\x27\x00\x00\x00\x00",
-    ],
-    8: [
-        b"\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP8_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x90\x8d\xb4\x26\x00\x00\x00\x00",
-    ],
-    9: [
-        b"\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP9_OVERRIDE_NOP - AMD / nop - INTEL
-        b"\x89\xf6\x8d\xbc\x27\x00\x00\x00\x00",
-    ],
-    10: [
-        b"\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP10_OVERRIDE_NOP - AMD
-        b"\x8d\x76\x00\x8d\xbc\x27\x00\x00\x00\x00",
-        b"\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
-    ],
-    11: [
-        b"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP11_OVERRIDE_NOP - AMD
-        b"\x8d\x74\x26\x00\x8d\xbc\x27\x00\x00\x00\x00",
-        b"\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
-    ],
-    12: [
-        b"\x8d\xb6\x00\x00\x00\x00\x8d\xbf\x00\x00\x00\x00",
-        b"\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
-    ],
-    13: [
-        b"\x8d\xb6\x00\x00\x00\x00\x8d\xbc\x27\x00\x00\x00\x00",
-        b"\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
-    ],
-    14: [
-        b"\x8d\xb4\x26\x00\x00\x00\x00\x8d\xbc\x27\x00\x00\x00\x00",
-        b"\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
-    ],
-    15: [b"\x66\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00"],
+    1: frozenset(
+        {
+            b"\x90",  # NOP1_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\xcc",  # int3
+            b"\xf4",  # hlt - trap filler, a function never opens with it
+            b"\x00",  # pass over sequences of null bytes
+        }
+    ),
+    2: frozenset(
+        {
+            b"\x66\x90",  # NOP2_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x0f\x0b",  # ud2 - trap filler, a function never opens with it
+            b"\x8b\xc0",  # mov eax, eax
+            b"\x89\xc0",  # mov eax, eax
+            b"\x8b\xff",  # mov edi, edi
+            b"\x89\xff",  # mov edi, edi
+            b"\x8d\x00",  # lea eax, dword ptr [eax]
+            b"\x86\xc0",  # xchg al, al
+            b"\x66\x2e",  # NOP2_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\xeb\x00",  # jmp $+2 (jumps to next instruction; used as padding by some MSVC versions)
+            b"\x8b\xc9",  # mov ecx, ecx
+            b"\x8b\xd2",  # mov edx, edx
+            b"\x8b\xdb",  # mov ebx, ebx
+            b"\x8b\xf6",  # mov esi, esi
+        }
+    ),
+    3: frozenset(
+        {
+            b"\x0f\x1f\x00",  # NOP3_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x8d\x40\x00",  # lea eax, dword ptr [eax]
+            b"\x8d\x00\x00",  # lea eax, dword ptr [eax]
+            b"\x8d\x49\x00",  # lea ecx, dword ptr [ecx]
+            b"\x8d\x24\x24",  # lea esp, dword ptr [esp]
+            b"\x8d\x76\x00",
+            b"\x66\x66\x90",
+        }
+    ),
+    4: frozenset(
+        {
+            b"\x0f\x1f\x40\x00",  # NOP4_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x8d\x74\x26\x00",
+            b"\x66\x66\x66\x90",
+            b"\x8d\x64\x24\x00",  # lea esp, [esp+0]
+        }
+    ),
+    5: frozenset(
+        {
+            b"\x0f\x1f\x44\x00\x00",  # NOP5_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x90\x8d\x74\x26\x00",
+            b"\x66\x0f\x1f\x40\x00",
+        }
+    ),
+    6: frozenset(
+        {
+            b"\x66\x0f\x1f\x44\x00\x00",  # NOP6_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x8d\xb6\x00\x00\x00\x00",
+            b"\x8d\xbf\x00\x00\x00\x00",  # lea edi, [edi]
+        }
+    ),
+    7: frozenset(
+        {
+            b"\x0f\x1f\x80\x00\x00\x00\x00",  # NOP7_OVERRIDE_NOP - AMD / nop - INTEL,
+            b"\x8d\xb4\x26\x00\x00\x00\x00",
+            b"\x8d\xbc\x27\x00\x00\x00\x00",
+        }
+    ),
+    8: frozenset(
+        {
+            b"\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP8_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x90\x8d\xb4\x26\x00\x00\x00\x00",
+        }
+    ),
+    9: frozenset(
+        {
+            b"\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP9_OVERRIDE_NOP - AMD / nop - INTEL
+            b"\x89\xf6\x8d\xbc\x27\x00\x00\x00\x00",
+        }
+    ),
+    10: frozenset(
+        {
+            b"\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP10_OVERRIDE_NOP - AMD
+            b"\x8d\x76\x00\x8d\xbc\x27\x00\x00\x00\x00",
+            b"\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
+        }
+    ),
+    11: frozenset(
+        {
+            b"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP11_OVERRIDE_NOP - AMD
+            b"\x8d\x74\x26\x00\x8d\xbc\x27\x00\x00\x00\x00",
+            b"\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
+        }
+    ),
+    12: frozenset(
+        {
+            b"\x8d\xb6\x00\x00\x00\x00\x8d\xbf\x00\x00\x00\x00",
+            b"\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
+        }
+    ),
+    13: frozenset(
+        {
+            b"\x8d\xb6\x00\x00\x00\x00\x8d\xbc\x27\x00\x00\x00\x00",
+            b"\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
+        }
+    ),
+    14: frozenset(
+        {
+            b"\x8d\xb4\x26\x00\x00\x00\x00\x8d\xbc\x27\x00\x00\x00\x00",
+            b"\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00",
+        }
+    ),
+    15: frozenset({b"\x66\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00"}),
 }
+
+GAP_SEQUENCE_FIRST_BYTES = frozenset(sequence[:1] for sequences in GAP_SEQUENCES.values() for sequence in sequences)
 
 
 COMMON_START_BYTES = {

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -4,6 +4,7 @@ import lief
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.synthesis.BinarySynthesizer import BinarySynthesizer, align_down, align_up
+from smda.utility.lief_helper import safe_lief_parse
 
 IMAGE_SCN_CNT_CODE = 0x00000020
 IMAGE_SCN_CNT_INITIALIZED_DATA = 0x00000040
@@ -251,7 +252,7 @@ class PeSynthesizer(BinarySynthesizer):
 
     def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
         base = self.report.base_addr
-        pe_src = lief.parse(bytes(self.report.xheader))
+        pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
             raise ValueError("xheader does not parse as PE")
         optional = pe_src.optional_header

--- a/src/smda/utility/BatchProcessor.py
+++ b/src/smda/utility/BatchProcessor.py
@@ -1,0 +1,180 @@
+import json
+import logging
+import os
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from multiprocessing import get_context
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.common import computeReportIdentityHash
+
+LOGGER = logging.getLogger(__name__)
+
+
+def getDefaultWorkerCount():
+    """Number of usable cores, honouring CPU affinity where the platform exposes it."""
+    process_cpu_count = getattr(os, "process_cpu_count", None)
+    if process_cpu_count is not None:
+        return max(1, process_cpu_count())
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        return max(1, len(sched_getaffinity(0)))
+    return max(1, os.cpu_count() or 1)
+
+
+def deriveReportStem(path, input_root):
+    """Path-relative stem, so same-named samples in different folders cannot collide."""
+    relative = os.path.relpath(os.path.abspath(path), os.path.abspath(input_root))
+    return relative.replace(os.sep, "_")
+
+
+def _initWorker(log_level):
+    logging.getLogger().setLevel(log_level)
+
+
+def _analyzeOneFile(task):
+    """Runs in a worker process. Writes the report and returns a small summary.
+
+    The Disassembler is constructed here rather than in a pool initializer: reusing one
+    instance across files would reintroduce instance-scoped id()-keyed caches and per-call
+    scratch state that are only valid for a single binary.
+    """
+    path = task["path"]
+    summary = {
+        "path": path,
+        "report_stem": task["report_stem"],
+        "status": "error",
+        "output_path": None,
+        "num_functions": 0,
+        "num_instructions": 0,
+        "report_hash": "",
+        "execution_time": 0.0,
+        "error": None,
+        "report": None,
+    }
+    try:
+        config = SmdaConfig()
+        if task["timeout"] is not None:
+            config.TIMEOUT = task["timeout"]
+        disassembler = Disassembler(config)
+        report = disassembler.disassembleFile(path)
+        summary["status"] = report.status
+        summary["num_functions"] = report.num_functions
+        summary["num_instructions"] = report.num_instructions
+        summary["execution_time"] = report.execution_time
+        summary["report_hash"] = computeReportIdentityHash(report)
+        if task["output_dir"]:
+            output_path = os.path.join(task["output_dir"], task["report_stem"] + ".smda")
+            with open(output_path, "w") as f_out:
+                json.dump(report.toDict(), f_out, indent=1, sort_keys=True)
+            summary["output_path"] = output_path
+        if task["return_reports"]:
+            summary["report"] = report
+    except Exception as exc:
+        summary["error"] = f"{type(exc).__name__}: {exc}"
+        summary["traceback"] = traceback.format_exc()
+    return summary
+
+
+def collectInputFiles(paths, input_root=None):
+    """Expand files and directories into a sorted list of (path, report_stem) pairs."""
+    collected = []
+    for path in paths:
+        if os.path.isdir(path):
+            root = input_root or path
+            for dirpath, _, filenames in os.walk(path):
+                for filename in sorted(filenames):
+                    file_path = os.path.join(dirpath, filename)
+                    collected.append((file_path, deriveReportStem(file_path, root)))
+        elif os.path.isfile(path):
+            root = input_root or os.path.dirname(os.path.abspath(path)) or os.sep
+            collected.append((path, deriveReportStem(path, root)))
+        else:
+            raise FileNotFoundError(path)
+    return sorted(collected)
+
+
+def disassembleParallel(
+    paths,
+    output_dir=None,
+    workers=0,
+    timeout=None,
+    resume=False,
+    max_tasks_per_child=None,
+    return_reports=False,
+    input_root=None,
+):
+    """Disassemble many files across processes, yielding one summary dict per completed file.
+
+    Each binary is independent, so results do not depend on the number of workers, with one
+    exception: a nonzero SmdaConfig.TIMEOUT is wall-clock, so under oversubscription a slow
+    sample can time out where a serial run finished. Pass timeout=0 for load-independent
+    output.
+
+    Reports are written in the worker and only a small summary is returned, because shipping
+    whole reports back through the parent makes deserialization the bottleneck. Pass
+    return_reports=True to receive the report objects as well.
+
+    This is a library helper: it never configures logging and never adds a handler.
+    """
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    collected = collectInputFiles(paths, input_root=input_root)
+    tasks = []
+    for path, report_stem in collected:
+        # resume is decided here, in the parent, so the set of finished reports is never
+        # embedded into every task payload
+        if resume and output_dir and os.path.exists(os.path.join(output_dir, report_stem + ".smda")):
+            LOGGER.debug("Skipping %s, report already exists", path)
+            continue
+        tasks.append(
+            {
+                "path": path,
+                "report_stem": report_stem,
+                "output_dir": output_dir,
+                "timeout": timeout,
+                "return_reports": return_reports,
+            }
+        )
+
+    if not tasks:
+        return
+
+    worker_count = workers if workers > 0 else getDefaultWorkerCount()
+    worker_count = max(1, min(worker_count, len(tasks)))
+
+    executor_kwargs = {
+        "max_workers": worker_count,
+        # spawn is the strictest context: it re-imports, which proves the task function is
+        # importable and the payload picklable instead of relying on a forked address space
+        "mp_context": get_context("spawn"),
+        "initializer": _initWorker,
+        "initargs": (logging.getLogger().level,),
+    }
+    if max_tasks_per_child is not None:
+        executor_kwargs["max_tasks_per_child"] = max_tasks_per_child
+
+    with ProcessPoolExecutor(**executor_kwargs) as executor:
+        futures = {executor.submit(_analyzeOneFile, task): task for task in tasks}
+        for future in as_completed(futures):
+            task = futures[future]
+            try:
+                yield future.result()
+            except Exception as exc:
+                # a worker that was OOM-killed or died inside capstone/LIEF surfaces here as
+                # BrokenProcessPool instead of hanging the run
+                LOGGER.error("Worker failed for %s: %r", task["path"], exc)
+                yield {
+                    "path": task["path"],
+                    "report_stem": task["report_stem"],
+                    "status": "error",
+                    "output_path": None,
+                    "num_functions": 0,
+                    "num_instructions": 0,
+                    "report_hash": "",
+                    "execution_time": 0.0,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "report": None,
+                }

--- a/src/smda/utility/BatchProcessor.py
+++ b/src/smda/utility/BatchProcessor.py
@@ -145,18 +145,16 @@ def disassembleParallel(
     worker_count = workers if workers > 0 else getDefaultWorkerCount()
     worker_count = max(1, min(worker_count, len(tasks)))
 
-    executor_kwargs = {
-        "max_workers": worker_count,
+    with ProcessPoolExecutor(
+        max_workers=worker_count,
         # spawn is the strictest context: it re-imports, which proves the task function is
         # importable and the payload picklable instead of relying on a forked address space
-        "mp_context": get_context("spawn"),
-        "initializer": _initWorker,
-        "initargs": (logging.getLogger().level,),
-    }
-    if max_tasks_per_child is not None:
-        executor_kwargs["max_tasks_per_child"] = max_tasks_per_child
-
-    with ProcessPoolExecutor(**executor_kwargs) as executor:
+        mp_context=get_context("spawn"),
+        initializer=_initWorker,
+        initargs=(logging.getLogger().level,),
+        # None is the ProcessPoolExecutor default: a worker lives as long as the executor
+        max_tasks_per_child=max_tasks_per_child,
+    ) as executor:
         futures = {executor.submit(_analyzeOneFile, task): task for task in tasks}
         for future in as_completed(futures):
             task = futures[future]

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -201,7 +201,7 @@ class MachoFileLoader:
         # Preserve the FatBinary container so every accessor and provider can
         # select the same active slice instead of accepting lief.parse()'s
         # implicit first-slice conversion.
-        return lief.MachO.parse(binary)
+        return safe_lief_parse(binary, parser=lief.MachO.parse)
 
     @staticmethod
     def getBaseAddress(binary, parsed=_NOT_PROVIDED):

--- a/src/smda/utility/common.py
+++ b/src/smda/utility/common.py
@@ -1,3 +1,20 @@
+import hashlib
+import json
+
+
+def computeReportIdentityHash(report, exclude=("timestamp", "execution_time")):
+    """Canonical content hash of a SmdaReport, ignoring fields that legitimately vary per run.
+
+    Covers the CFG, per-function hashes, statistics, xrefs and xmetadata in one number, because
+    all of them are serialized inside toDict().
+    """
+    as_dict = report.toDict()
+    for field in exclude:
+        as_dict.pop(field, None)
+    serialized = json.dumps(as_dict, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
 def mergeCodeAreas(code_areas):
     if not code_areas:
         return []

--- a/src/smda/utility/lief_helper.py
+++ b/src/smda/utility/lief_helper.py
@@ -16,8 +16,16 @@ from __future__ import annotations
 import lief
 
 
-def safe_lief_parse(binary):
+def safe_lief_parse(binary, parser=None):
+    """Parse ``binary``, returning None when lief fails to allocate.
+
+    ``parser`` selects a format-specific entry point (``lief.MachO.parse``,
+    ``lief.DEX.parse``, ...) for callers that must keep the format container
+    rather than lief's generic result; it defaults to ``lief.parse``.
+    """
+    if parser is None:
+        parser = lief.parse
     try:
-        return lief.parse(binary)
+        return parser(binary)
     except MemoryError:
         return None

--- a/tests/fuzz_regressions/README.md
+++ b/tests/fuzz_regressions/README.md
@@ -1,0 +1,20 @@
+# Pinned fuzz crash reproducers
+
+Crash, OOM, and timeout artifacts found by the `Fuzzing` workflow are committed
+here so the defect they found can never regress silently.
+
+Rules:
+
+- Store the artifact XOR-obfuscated with the repository fixture scheme
+  (`byte ^ (index % 256)`), never as a raw sample.
+- Name it `<target>_<short-slug>_xored`, where `<target>` is one of the keys in
+  `fuzzing/targets.py` (`loaders`, `formats`, `disassembler`, `buffer`,
+  `report`) — `tests/testFuzzRegressions.py` dispatches on that prefix.
+- Keep it minimized (`-minimize_crash=1`) and small; these run on every test
+  invocation.
+
+To reproduce one locally, no atheris required:
+
+```
+python fuzzing/replay.py loaders tests/fuzz_regressions/loaders_example_xored
+```

--- a/tests/fuzz_regressions/README.md
+++ b/tests/fuzz_regressions/README.md
@@ -10,8 +10,8 @@ Rules:
 - Name it `<target>_<short-slug>_xored`, where `<target>` is one of the keys in
   `fuzzing/targets.py` (`loaders`, `formats`, `disassembler`, `buffer`,
   `report`) — `tests/testFuzzRegressions.py` dispatches on that prefix.
-- Keep it minimized (`-minimize_crash=1`) and small; these run on every test
-  invocation.
+- Keep it minimized (`python fuzzing/minimize.py <target> <artifact>`) and small;
+  these run on every test invocation.
 
 To reproduce one locally, no atheris required:
 

--- a/tests/testBatchProcessor.py
+++ b/tests/testBatchProcessor.py
@@ -1,0 +1,118 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.BatchProcessor import (
+    collectInputFiles,
+    deriveReportStem,
+    disassembleParallel,
+    getDefaultWorkerCount,
+)
+
+FIXTURES = [
+    "cutwail_xored",
+    "bashlite_xored",
+    "komplex_xored",
+    "njrat_xored",
+    "blockblast_classes_xored",
+    "pe_export_label_test_xored",
+]
+
+
+def _decrypt(path):
+    with open(path, "rb") as f_binary:
+        binary = f_binary.read()
+    return bytes(bytearray(byte ^ (index % 256) for index, byte in enumerate(binary)))
+
+
+class TestBatchProcessor(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # decrypted copies are written to a temp dir so the pool can read real files without
+        # ever executing them
+        config = SmdaConfig()
+        cls.tmp_dir = tempfile.mkdtemp(prefix="smda_batch_")
+        cls.input_dir = os.path.join(cls.tmp_dir, "inputs", "nested")
+        os.makedirs(cls.input_dir)
+        for name in FIXTURES:
+            source = os.path.join(config.PROJECT_ROOT, "tests", name)
+            with open(os.path.join(cls.input_dir, name), "wb") as f_out:
+                f_out.write(_decrypt(source))
+        cls.input_root = os.path.join(cls.tmp_dir, "inputs")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp_dir, ignore_errors=True)
+
+    def _run(self, **kwargs):
+        output_dir = tempfile.mkdtemp(dir=self.tmp_dir)
+        results = {}
+        for summary in disassembleParallel([self.input_root], output_dir=output_dir, timeout=0, **kwargs):
+            results[summary["report_stem"]] = summary
+        return output_dir, results
+
+    def test_pooled_output_matches_serial_output(self):
+        _, serial = self._run(workers=1)
+        _, pooled = self._run(workers=4)
+        self.assertEqual(len(FIXTURES), len(serial))
+        self.assertEqual(set(serial), set(pooled))
+        for stem in serial:
+            self.assertEqual(serial[stem]["report_hash"], pooled[stem]["report_hash"], stem)
+            self.assertNotEqual("", serial[stem]["report_hash"], stem)
+
+    def test_recycling_workers_does_not_change_output(self):
+        _, pooled = self._run(workers=4)
+        _, recycled = self._run(workers=4, max_tasks_per_child=1)
+        for stem in pooled:
+            self.assertEqual(pooled[stem]["report_hash"], recycled[stem]["report_hash"], stem)
+
+    def test_reports_are_written_per_input_file(self):
+        output_dir, results = self._run(workers=2)
+        for stem, summary in results.items():
+            expected = os.path.join(output_dir, stem + ".smda")
+            self.assertEqual(expected, summary["output_path"])
+            with open(expected) as f_in:
+                as_dict = json.load(f_in)
+            self.assertEqual(summary["num_functions"], as_dict["statistics"]["num_functions"])
+
+    def test_resume_skips_finished_reports(self):
+        output_dir = tempfile.mkdtemp(dir=self.tmp_dir)
+        first = list(disassembleParallel([self.input_root], output_dir=output_dir, workers=2, timeout=0))
+        self.assertEqual(len(FIXTURES), len(first))
+        second = list(disassembleParallel([self.input_root], output_dir=output_dir, workers=2, timeout=0, resume=True))
+        self.assertEqual([], second)
+
+    def test_return_reports_yields_picklable_reports(self):
+        summaries = list(
+            disassembleParallel(
+                [os.path.join(self.input_dir, "cutwail_xored")],
+                output_dir=None,
+                workers=1,
+                timeout=0,
+                return_reports=True,
+            )
+        )
+        self.assertEqual(1, len(summaries))
+        self.assertIsNotNone(summaries[0]["report"])
+        self.assertEqual(summaries[0]["num_functions"], summaries[0]["report"].num_functions)
+
+    def test_missing_input_path_is_reported(self):
+        with self.assertRaises(FileNotFoundError):
+            list(disassembleParallel([os.path.join(self.tmp_dir, "does_not_exist")], workers=1))
+
+    def test_report_stems_are_path_relative(self):
+        collected = collectInputFiles([self.input_root])
+        stems = [stem for _, stem in collected]
+        self.assertEqual(len(stems), len(set(stems)))
+        self.assertIn(os.path.join("nested", "cutwail_xored").replace(os.sep, "_"), stems)
+        self.assertEqual("a_b_c", deriveReportStem("/root/a/b/c", "/root"))
+
+    def test_default_worker_count_is_positive(self):
+        self.assertGreaterEqual(getDefaultWorkerCount(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testCilReportDeterminism.py
+++ b/tests/testCilReportDeterminism.py
@@ -1,0 +1,51 @@
+import hashlib
+import json
+import os
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+
+def _canonicalize(report):
+    as_dict = report.toDict()
+    as_dict.pop("timestamp", None)
+    as_dict.pop("execution_time", None)
+    return json.dumps(as_dict, sort_keys=True, separators=(",", ":"))
+
+
+class TestCilReportDeterminism(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        config = SmdaConfig()
+        fixture_path = os.path.join(config.PROJECT_ROOT, "tests", "njrat_xored")
+        with open(fixture_path, "rb") as f_binary:
+            binary = f_binary.read()
+        decrypted = bytearray()
+        for index, byte in enumerate(binary):
+            decrypted.append(byte ^ (index % 256))
+        cls.njrat_binary = bytes(decrypted)
+        cls.blobs = []
+        for _ in range(2):
+            report = Disassembler(SmdaConfig(), backend="cil").disassembleUnmappedBuffer(cls.njrat_binary)
+            cls.blobs.append(_canonicalize(report))
+
+    def test_repeated_disassembly_yields_identical_reports(self):
+        # unhandled dnfile row types fell through to str(operand), serializing the default object
+        # repr - including a memory address - so every run produced a different report
+        first, second = (hashlib.sha256(blob.encode()).hexdigest() for blob in self.blobs)
+        self.assertEqual(first, second)
+
+    def test_no_object_repr_leaks_into_operands(self):
+        for blob in self.blobs:
+            self.assertNotIn("object at 0x", blob)
+
+    def test_typespec_and_typedef_operands_are_named(self):
+        report = Disassembler(SmdaConfig(), backend="cil").disassembleUnmappedBuffer(self.njrat_binary)
+        operands = [ins.operands for fn in report.getFunctions() for ins in fn.getInstructions()]
+        self.assertTrue(any(op.startswith("TypeSpec(") for op in operands))
+        self.assertFalse(any("dnfile.mdtable" in op for op in operands))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testDisasmWindowBounds.py
+++ b/tests/testDisasmWindowBounds.py
@@ -1,0 +1,31 @@
+import types
+import unittest
+
+from smda.common.RecursiveDisassembler import RecursiveDisassembler
+
+
+def _stub(base_addr, binary, max_instruction_size=15):
+    return types.SimpleNamespace(
+        disassembly=types.SimpleNamespace(binary_info=types.SimpleNamespace(base_addr=base_addr, binary=binary)),
+        backend=types.SimpleNamespace(max_instruction_size=max_instruction_size),
+    )
+
+
+class TestDisasmWindowBounds(unittest.TestCase):
+    def test_target_below_base_addr_yields_no_bytes(self):
+        # a negative relative offset smaller than the image wrapped to the tail of the image, so
+        # bytes from an unrelated location were decoded and booked as if they lived at the target.
+        stub = _stub(0x400000, b"\x90" * 0x100 + b"\xcc" * 0x10)
+        self.assertEqual(RecursiveDisassembler._getDisasmWindowBuffer(stub, 0x3FFFF0), b"")
+
+    def test_target_past_image_end_yields_no_bytes(self):
+        stub = _stub(0x400000, b"\x90" * 0x100)
+        self.assertEqual(RecursiveDisassembler._getDisasmWindowBuffer(stub, 0x400100), b"")
+
+    def test_in_image_target_still_yields_the_window(self):
+        stub = _stub(0x400000, b"\x90" * 0x100)
+        self.assertEqual(RecursiveDisassembler._getDisasmWindowBuffer(stub, 0x400010), b"\x90" * 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testFuzzRegressions.py
+++ b/tests/testFuzzRegressions.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+"""Smoke-test the fuzz target bodies and replay any pinned crash reproducers.
+
+The fuzzers themselves only run on Linux CI (atheris ships no arm64/macOS
+wheels), which makes the target bodies easy to break unnoticed by an unrelated
+API change. These tests import them directly — no atheris needed — so a renamed
+loader accessor or a changed report field fails here instead of silently
+degrading every future fuzzing run.
+
+Crash artifacts found by CI are committed under tests/fuzz_regressions/ in the
+repository's XOR-obfuscated fixture form, named ``<target>_<slug>_xored``; each
+one is replayed here and must pass.
+"""
+
+import logging
+import os
+import sys
+import unittest
+from pathlib import Path
+
+logging.disable(logging.CRITICAL)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "fuzzing"))
+
+from targets import TARGETS  # noqa: E402
+
+REGRESSION_DIR = Path(__file__).resolve().parent / "fuzz_regressions"
+
+# Inputs that must not raise for any target: the empty buffer, a truncated
+# header, a plausible magic, and non-binary text.
+SMOKE_INPUTS = [
+    b"",
+    b"\x00",
+    b"MZ",
+    b"MZ" + b"\x00" * 4096,
+    b"\x7fELF\x02\x01\x01" + b"\x00" * 512,
+    b"dex\n035\x00" + b"\x00" * 512,
+    b'{"architecture": "intel"}',
+    b"not a binary at all",
+    bytes(range(256)) * 4,
+]
+
+
+def decode_fixture(data, name):
+    if not name.endswith("_xored"):
+        return data
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
+
+
+class SmdaFuzzTargetSmokeTest(unittest.TestCase):
+    def test_targets_tolerate_smoke_inputs(self):
+        for target_name, target in sorted(TARGETS.items()):
+            for payload in SMOKE_INPUTS:
+                with self.subTest(target=target_name, size=len(payload)):
+                    target(payload)
+
+    def test_every_target_has_an_entry_point(self):
+        fuzzing_dir = REPO_ROOT / "fuzzing"
+        for target_name in TARGETS:
+            self.assertTrue(
+                (fuzzing_dir / f"fuzz_{target_name}.py").is_file(),
+                f"missing fuzzing/fuzz_{target_name}.py entry point",
+            )
+
+    def test_workflow_covers_every_target(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "fuzzing.yml").read_text()
+        for target_name in TARGETS:
+            self.assertIn(f"fuzz_{target_name}", workflow, f"target {target_name} is not fuzzed in CI")
+
+
+class SmdaFuzzRegressionTest(unittest.TestCase):
+    def test_pinned_crash_artifacts_replay_cleanly(self):
+        if not REGRESSION_DIR.is_dir():
+            self.skipTest("no fuzz_regressions directory")
+        artifacts = sorted(path for path in REGRESSION_DIR.iterdir() if path.is_file() and path.suffix != ".md")
+        if not artifacts:
+            self.skipTest("no pinned fuzz crash artifacts")
+        for path in artifacts:
+            target_name = path.name.split("_", 1)[0]
+            with self.subTest(artifact=path.name):
+                self.assertIn(target_name, TARGETS, f"{path.name} does not name a known target")
+                TARGETS[target_name](decode_fixture(path.read_bytes(), path.name))
+
+
+if __name__ == "__main__":
+    if os.environ.get("SMDA_FUZZ_VERBOSE"):
+        logging.disable(logging.NOTSET)
+    unittest.main()

--- a/tests/testFuzzRegressions.py
+++ b/tests/testFuzzRegressions.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -24,6 +25,8 @@ logging.disable(logging.CRITICAL)
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "fuzzing"))
 
+from minimize import failure_type, shrink  # noqa: E402
+from prune_corpus import prune  # noqa: E402
 from targets import TARGETS  # noqa: E402
 
 REGRESSION_DIR = Path(__file__).resolve().parent / "fuzz_regressions"
@@ -95,6 +98,44 @@ class SmdaFuzzTargetSmokeTest(unittest.TestCase):
         workflow = (REPO_ROOT / ".github" / "workflows" / "fuzzing.yml").read_text()
         for target_name in TARGETS:
             self.assertIn(f"fuzz_{target_name}", workflow, f"target {target_name} is not fuzzed in CI")
+
+
+class SmdaFuzzToolingTest(unittest.TestCase):
+    """The atheris-free crash-handling tooling, which only ever runs on a finding."""
+
+    def test_shrink_reduces_to_the_failing_core(self):
+        def predicate(candidate):
+            return b"\xde\xad" in candidate
+
+        payload = bytes(64) + b"\xde\xad" + bytes(64)
+        self.assertEqual(shrink(payload, predicate), b"\xde\xad")
+
+    def test_shrink_keeps_input_when_nothing_can_be_removed(self):
+        self.assertEqual(shrink(b"\xde\xad", lambda candidate: b"\xde\xad" in candidate), b"\xde\xad")
+
+    def test_failure_type_classifies_by_exception_type(self):
+        def raiser(_data):
+            raise ValueError("boom")
+
+        self.assertIs(failure_type(raiser, b""), ValueError)
+        self.assertIsNone(failure_type(lambda _data: None, b""))
+
+    def test_prune_caps_file_count_keeping_smallest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp)
+            for size in (10, 20, 30, 40):
+                (corpus / f"input_{size}").write_bytes(bytes(size))
+            kept, kept_bytes, removed = prune(corpus, max_files=2, max_bytes=10**6)
+            self.assertEqual((kept, kept_bytes, removed), (2, 30, 2))
+            self.assertEqual(sorted(path.name for path in corpus.iterdir()), ["input_10", "input_20"])
+
+    def test_prune_caps_total_bytes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp)
+            for size in (10, 20, 30):
+                (corpus / f"input_{size}").write_bytes(bytes(size))
+            kept, kept_bytes, removed = prune(corpus, max_files=100, max_bytes=35)
+            self.assertEqual((kept, kept_bytes, removed), (2, 30, 1))
 
 
 class SmdaFuzzRegressionTest(unittest.TestCase):

--- a/tests/testFuzzRegressions.py
+++ b/tests/testFuzzRegressions.py
@@ -14,6 +14,7 @@ one is replayed here and must pass.
 
 import logging
 import os
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -62,6 +63,33 @@ class SmdaFuzzTargetSmokeTest(unittest.TestCase):
                 (fuzzing_dir / f"fuzz_{target_name}.py").is_file(),
                 f"missing fuzzing/fuzz_{target_name}.py entry point",
             )
+
+    def test_dictionary_uses_only_libfuzzer_escapes(self):
+        """libFuzzer accepts \\xAB, \\\\ and \\" only; anything else aborts the run at startup."""
+        dictionary = (REPO_ROOT / "fuzzing" / "smda.dict").read_text()
+        for number, line in enumerate(dictionary.splitlines(), 1):
+            entry = line.strip()
+            if not entry or entry.startswith("#"):
+                continue
+            match = re.fullmatch(r'[A-Za-z0-9_]+="(.*)"', entry)
+            self.assertIsNotNone(match, f'line {number} is not a name="token" entry: {entry}')
+            body = match.group(1)
+            index = 0
+            while index < len(body):
+                if body[index] != "\\":
+                    index += 1
+                    continue
+                following = body[index + 1 : index + 2]
+                if following == "x":
+                    self.assertRegex(
+                        body[index + 2 : index + 4],
+                        r"^[0-9a-fA-F]{2}$",
+                        f"line {number} has a malformed hex escape: {entry}",
+                    )
+                    index += 4
+                    continue
+                self.assertIn(following, ("\\", '"'), f"line {number} uses unsupported escape: {entry}")
+                index += 2
 
     def test_workflow_covers_every_target(self):
         workflow = (REPO_ROOT / ".github" / "workflows" / "fuzzing.yml").read_text()

--- a/tests/testLiefParseOom.py
+++ b/tests/testLiefParseOom.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+"""Every raw-bytes lief parse entry point must degrade on an allocation failure.
+
+lief is a C++ library: a crafted header makes it attempt an unbounded allocation
+that surfaces in Python as MemoryError (std::bad_alloc). MemoryError is
+non-operational, so it escapes SMDA's own error handling and aborts the whole
+run instead of producing an error report.
+
+Found by fuzzing: with lief 1.0.0, lief.MachO.parse(b".") raises
+MemoryError, and MachoFileLoader.parseBinary passed it straight through.
+"""
+
+import logging
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import lief
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.lief_helper import safe_lief_parse
+from smda.utility.MachoFileLoader import MachoFileLoader
+
+logging.disable(logging.CRITICAL)
+
+
+def _raise_bad_alloc(*_args, **_kwargs):
+    raise MemoryError("std::bad_alloc")
+
+
+class SmdaLiefParseOomTest(unittest.TestCase):
+    def test_safe_lief_parse_returns_none_on_allocation_failure(self):
+        with mock.patch.object(lief, "parse", _raise_bad_alloc):
+            self.assertIsNone(safe_lief_parse(b"MZ"))
+
+    def test_safe_lief_parse_honours_a_format_specific_parser(self):
+        self.assertIsNone(safe_lief_parse(b".", parser=_raise_bad_alloc))
+        self.assertEqual(safe_lief_parse(b".", parser=len), 1)
+
+    def test_macho_parse_binary_degrades_instead_of_raising(self):
+        with mock.patch.object(lief.MachO, "parse", _raise_bad_alloc):
+            self.assertIsNone(MachoFileLoader.parseBinary(b"\xcf\xfa\xed\xfe" + bytes(60)))
+
+    def test_macho_accessors_survive_an_allocation_failure(self):
+        crafted = b"\xcf\xfa\xed\xfe" + bytes(60)
+        with (
+            mock.patch.object(lief.MachO, "parse", _raise_bad_alloc),
+            mock.patch.object(lief, "parse", _raise_bad_alloc),
+        ):
+            self.assertEqual(MachoFileLoader.mapBinary(crafted, parsed=None), b"")
+            self.assertEqual(MachoFileLoader.getBaseAddress(crafted, parsed=None), 0)
+            self.assertEqual(MachoFileLoader.getCodeAreas(crafted, parsed=None), [])
+
+    def test_dex_allocation_failure_yields_an_error_report_not_a_crash(self):
+        """The Dalvik backend parses the DEX itself; a bad_alloc there must stay operational."""
+        fixture = Path(__file__).resolve().parent / "blockblast_classes_xored"
+        dex = bytes(byte ^ (index % 256) for index, byte in enumerate(fixture.read_bytes()))
+        with mock.patch.object(lief.DEX, "parse", _raise_bad_alloc):
+            report = Disassembler(SmdaConfig(), backend="dalvik").disassembleUnmappedBuffer(dex)
+        self.assertEqual(report.status, "error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testPartialObjectFormatting.py
+++ b/tests/testPartialObjectFormatting.py
@@ -1,0 +1,52 @@
+import unittest
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
+from smda.common.SmdaFunction import SmdaFunction
+from smda.common.SmdaInstruction import SmdaInstruction
+from smda.common.SmdaReport import SmdaReport
+from smda.DisassemblyResult import DisassemblyResult
+
+
+class TestPartialObjectFormatting(unittest.TestCase):
+    """Display helpers must not raise on partially-populated objects; every offset-like field
+    on these models is nullable, so formatting it as an integer crashed."""
+
+    def test_function_str(self):
+        self.assertIn("0x????????", str(SmdaFunction()))
+
+    def test_instruction_str(self):
+        self.assertIn("0x????????", str(SmdaInstruction()))
+
+    def test_basic_block_str(self):
+        self.assertIn("0x????????", str(SmdaBasicBlock([])))
+
+    def test_report_str(self):
+        self.assertIn("0x????????", str(SmdaReport()))
+
+    def test_report_str_for_error_status(self):
+        report = SmdaReport()
+        report.status = "error"
+        report.message = "boom"
+        self.assertIn("boom", str(report))
+
+    def test_pic_hash_helpers_tolerate_missing_hash(self):
+        function = SmdaFunction()
+        self.assertIsNone(function.getPicHashAsLong())
+        self.assertIsNone(function.getPicHashAsHex())
+
+
+class TestApiRefInitialization(unittest.TestCase):
+    def test_api_refs_are_initialized_once_and_invalidated_on_new_reference(self):
+        result = DisassemblyResult()
+        result.functions[0x1000] = [[(0x1000, 2, "call", "0x2000", b"\xff\xd0")]]
+        # a binary with zero APIs must not re-walk the (empty) API table on every call
+        self.assertEqual({}, result.getApiRefs(0x1000))
+        self.assertTrue(result._api_refs_initialized)
+
+        result.addApiReference(0x2000, 0x1000, "kernel32.dll", "Sleep")
+        self.assertFalse(result._api_refs_initialized)
+        self.assertEqual({0x1000: "kernel32.dll!Sleep"}, result.getApiRefs(0x1000))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testPerfBenchmark.py
+++ b/tests/testPerfBenchmark.py
@@ -1,4 +1,6 @@
-"""Aggregation tests for the counterbalanced fixture benchmark passes.
+"""Tests for the CI perf-gate scripts (`.github/workflows/scripts/run_perf_check.py` and
+`compare_perf.py`), the canonical report-identity hash they rely on, and the aggregation
+behind the counterbalanced fixture benchmark passes.
 
 The perf gate used to time base once and PR once, base first, so any slowdown that
 developed over the job landed entirely on the PR measurement. The workflow now runs
@@ -6,47 +8,59 @@ the passes base/PR/PR/base and merges each side's samples, which cancels drift t
 is linear in pass order while still surfacing a genuine regression.
 """
 
+import datetime
 import importlib.util
+import json
+import os
 import statistics
+import subprocess
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
-_SCRIPT = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "scripts" / "run_perf_check.py"
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.common import computeReportIdentityHash
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "scripts"
 
 
-def _load_module():
-    spec = importlib.util.spec_from_file_location("run_perf_check", _SCRIPT)
+def _load_module(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-run_perf_check = _load_module()
+run_perf_check = _load_module("run_perf_check")
 
 
-def _result(times):
+def _timing_result(times):
     return {"execution_times": times, "median_time": statistics.median(times)}
 
 
 class TestMergeResults(unittest.TestCase):
     def test_merge_accumulates_samples_and_recomputes_median(self):
-        merged = run_perf_check.merge_results({"k": _result([1.0, 1.0, 1.0])}, {"k": _result([3.0, 3.0, 3.0])})
+        merged = run_perf_check.merge_results(
+            {"k": _timing_result([1.0, 1.0, 1.0])}, {"k": _timing_result([3.0, 3.0, 3.0])}
+        )
         self.assertEqual([1.0, 1.0, 1.0, 3.0, 3.0, 3.0], merged["k"]["execution_times"])
         self.assertAlmostEqual(2.0, merged["k"]["median_time"])
 
     def test_merge_adds_fixtures_absent_from_the_first_pass(self):
-        merged = run_perf_check.merge_results({"a": _result([1.0])}, {"b": _result([2.0])})
+        merged = run_perf_check.merge_results({"a": _timing_result([1.0])}, {"b": _timing_result([2.0])})
         self.assertEqual({"a", "b"}, set(merged))
 
     def test_merge_carries_forward_keys_the_new_pass_did_not_produce(self):
-        first = {"k": dict(_result([1.0]), backend="intel", num_functions=7)}
-        merged = run_perf_check.merge_results(first, {"k": _result([2.0])})
+        first = {"k": dict(_timing_result([1.0]), backend="intel", num_functions=7)}
+        merged = run_perf_check.merge_results(first, {"k": _timing_result([2.0])})
         self.assertEqual("intel", merged["k"]["backend"])
         self.assertEqual(7, merged["k"]["num_functions"])
 
     def test_merge_does_not_mutate_its_inputs(self):
-        first = {"k": _result([1.0])}
-        second = {"k": _result([2.0])}
+        first = {"k": _timing_result([1.0])}
+        second = {"k": _timing_result([2.0])}
         run_perf_check.merge_results(first, second)
         self.assertEqual([1.0], first["k"]["execution_times"])
         self.assertEqual([2.0], second["k"]["execution_times"])
@@ -59,8 +73,12 @@ class TestCounterbalancedAggregation(unittest.TestCase):
         # same mean drift and the medians agree despite identical underlying speed.
         drift = 0.0702
         t0 = 0.1357
-        base = run_perf_check.merge_results({"k": _result([t0] * 3)}, {"k": _result([t0 + 3 * drift] * 3)})
-        pr = run_perf_check.merge_results({"k": _result([t0 + drift] * 3)}, {"k": _result([t0 + 2 * drift] * 3)})
+        base = run_perf_check.merge_results(
+            {"k": _timing_result([t0] * 3)}, {"k": _timing_result([t0 + 3 * drift] * 3)}
+        )
+        pr = run_perf_check.merge_results(
+            {"k": _timing_result([t0 + drift] * 3)}, {"k": _timing_result([t0 + 2 * drift] * 3)}
+        )
         self.assertAlmostEqual(base["k"]["median_time"], pr["k"]["median_time"])
 
         # the single-pass comparison this replaces would have reported ~+52%
@@ -70,12 +88,129 @@ class TestCounterbalancedAggregation(unittest.TestCase):
     def test_real_regression_still_surfaces(self):
         drift = 0.0702
         t0 = 0.1357
-        base = run_perf_check.merge_results({"k": _result([t0] * 3)}, {"k": _result([t0 + 3 * drift] * 3)})
+        base = run_perf_check.merge_results(
+            {"k": _timing_result([t0] * 3)}, {"k": _timing_result([t0 + 3 * drift] * 3)}
+        )
         pr = run_perf_check.merge_results(
-            {"k": _result([t0 + drift + 0.2] * 3)}, {"k": _result([t0 + 2 * drift + 0.2] * 3)}
+            {"k": _timing_result([t0 + drift + 0.2] * 3)}, {"k": _timing_result([t0 + 2 * drift + 0.2] * 3)}
         )
         slowdown = pr["k"]["median_time"] / base["k"]["median_time"] - 1
         self.assertGreater(slowdown, 0.5)
+
+
+def _decrypt(name):
+    config = SmdaConfig()
+    with open(os.path.join(config.PROJECT_ROOT, "tests", name), "rb") as f_binary:
+        binary = f_binary.read()
+    return bytes(bytearray(byte ^ (index % 256) for index, byte in enumerate(binary)))
+
+
+def _result(**overrides):
+    result = {
+        "backend": "intel",
+        "execution_times": [1.0],
+        "median_time": 1.0,
+        "num_functions": 2,
+        "num_instructions": 20,
+        "num_blocks": 4,
+        "functions": {"0x1000": {"num_blocks": 2, "num_instructions": 10}},
+        "report_hash": "a" * 64,
+        "python_version": "3.11.0",
+    }
+    result.update(overrides)
+    return result
+
+
+class TestReportIdentityHash(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_decrypt("cutwail_xored"))
+
+    def test_hash_is_stable_for_the_same_report(self):
+        self.assertEqual(computeReportIdentityHash(self.report), computeReportIdentityHash(self.report))
+
+    def test_hash_ignores_volatile_fields(self):
+        before = computeReportIdentityHash(self.report)
+        self.report.execution_time = self.report.execution_time + 1.0
+        self.report.timestamp = self.report.timestamp + datetime.timedelta(hours=1)
+        self.assertEqual(before, computeReportIdentityHash(self.report))
+
+    def test_hash_tracks_function_metadata(self):
+        before = computeReportIdentityHash(self.report)
+        function = list(self.report.getFunctions())[0]
+        original = function.pic_hash
+        function.pic_hash = 1234
+        try:
+            self.assertNotEqual(before, computeReportIdentityHash(self.report))
+        finally:
+            function.pic_hash = original
+        self.assertEqual(before, computeReportIdentityHash(self.report))
+
+
+class TestComparePerf(unittest.TestCase):
+    def _run(self, pr, base, extra_args=()):
+        with tempfile.TemporaryDirectory() as tmp:
+            pr_path = os.path.join(tmp, "pr.json")
+            base_path = os.path.join(tmp, "base.json")
+            with open(pr_path, "w") as f:
+                json.dump(pr, f)
+            with open(base_path, "w") as f:
+                json.dump(base, f)
+            return subprocess.run(
+                [sys.executable, str(_SCRIPTS / "compare_perf.py"), pr_path, base_path, *extra_args],
+                capture_output=True,
+                text=True,
+            )
+
+    def test_identical_results_pass(self):
+        completed = self._run({"fixture": _result()}, {"fixture": _result()})
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+
+    def test_report_hash_mismatch_is_a_correctness_failure(self):
+        completed = self._run({"fixture": _result(report_hash="b" * 64)}, {"fixture": _result()})
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("Report identity hash mismatch", completed.stdout)
+
+    def test_call_count_change_is_informational_by_default(self):
+        completed = self._run(
+            {"fixture": _result(total_calls=900, prim_calls=800)},
+            {"fixture": _result(total_calls=1000, prim_calls=900)},
+        )
+        self.assertEqual(0, completed.returncode)
+        self.assertIn("PYTHON CALL COUNTS", completed.stdout)
+        self.assertIn("-100", completed.stdout)
+
+    def test_call_count_change_can_be_made_fatal(self):
+        completed = self._run(
+            {"fixture": _result(total_calls=900)},
+            {"fixture": _result(total_calls=1000)},
+            extra_args=("--fail-on-call-count-change",),
+        )
+        self.assertEqual(1, completed.returncode)
+
+    def test_call_counts_skipped_across_python_versions(self):
+        completed = self._run(
+            {"fixture": _result(total_calls=900, python_version="3.13.0")},
+            {"fixture": _result(total_calls=1000, python_version="3.11.0")},
+        )
+        self.assertEqual(0, completed.returncode)
+        self.assertIn("Call-count comparison skipped", completed.stdout)
+        self.assertNotIn("PYTHON CALL COUNTS", completed.stdout)
+
+
+class TestRunPerfCheck(unittest.TestCase):
+    def test_records_hash_and_python_version(self):
+        module = _load_module("run_perf_check")
+        with tempfile.TemporaryDirectory() as tmp:
+            output = os.path.join(tmp, "results.json")
+            module.run_benchmark(2, output)
+            with open(output) as f:
+                results = json.load(f)
+        self.assertTrue(results)
+        for name, entry in results.items():
+            self.assertEqual(64, len(entry["report_hash"]), name)
+            self.assertTrue(entry["python_version"], name)
+            self.assertNotIn("total_calls", entry)
 
 
 if __name__ == "__main__":

--- a/tests/testSmdaReportPickle.py
+++ b/tests/testSmdaReportPickle.py
@@ -1,0 +1,62 @@
+import json
+import os
+import pickle
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+
+def _decrypt(name):
+    config = SmdaConfig()
+    with open(os.path.join(config.PROJECT_ROOT, "tests", name), "rb") as f_binary:
+        binary = f_binary.read()
+    decrypted = bytearray()
+    for index, byte in enumerate(binary):
+        decrypted.append(byte ^ (index % 256))
+    return bytes(decrypted)
+
+
+def _canonicalize(report):
+    as_dict = report.toDict()
+    as_dict.pop("timestamp", None)
+    as_dict.pop("execution_time", None)
+    return json.dumps(as_dict, sort_keys=True, separators=(",", ":"))
+
+
+class TestSmdaReportPickle(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_decrypt("cutwail_xored"))
+
+    def test_intel_report_is_picklable(self):
+        # SmdaReport.capstone and SmdaInstruction.detailed hold capstone objects backed by ctypes
+        # pointers, which raised "ctypes objects containing pointers cannot be pickled"
+        restored = pickle.loads(pickle.dumps(self.report))
+        self.assertEqual(_canonicalize(self.report), _canonicalize(restored))
+
+    def test_report_is_picklable_after_full_traversal(self):
+        for function in self.report.getFunctions():
+            for instruction in function.getInstructions():
+                instruction.getDetailed()
+        restored = pickle.loads(pickle.dumps(self.report))
+        self.assertEqual(_canonicalize(self.report), _canonicalize(restored))
+
+    def test_lazy_capstone_paths_work_after_unpickling(self):
+        restored = pickle.loads(pickle.dumps(self.report))
+        self.assertIsNone(restored.capstone)
+        self.assertIsNotNone(restored.getCapstone())
+        functions = list(restored.getFunctions())
+        instruction = list(functions[0].getInstructions())[0]
+        self.assertIsNone(instruction.detailed)
+        self.assertIsNotNone(instruction.getDetailed())
+
+    def test_object_graph_survives_unpickling(self):
+        restored = pickle.loads(pickle.dumps(self.report))
+        function = list(restored.getFunctions())[0]
+        self.assertIs(function.smda_report, restored)
+        self.assertIsNotNone(function._escaper)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked on #222** (`feat/audit-hardening`). This branch contains that PR's commits as its
> base; only the 17 commits described below (`c0e4afb..a0f21df`) are new here. Please merge #222
> first — afterwards this PR's diff reduces to those commits.

## Summary

Three strands, in the order they happened: a continuous fuzzing surface for the untrusted-input
paths; the determinism and crash fixes that fuzzing and the new perf-gate correctness channel
exposed; and parallel batch disassembly, which is what the picklability fix unlocks.

## Fuzzing (CI) — 5 commits

- `ci: add atheris fuzzing workflow and harnesses` — runs on GitHub Actions (ubuntu x86_64,
  Python 3.12; atheris ships no arm64/macOS wheels). Short runs on push/PR, longer weekly
  scheduled runs, tunable via dispatch. Seeds are derived at CI time from truncated `*_xored`
  fixture headers plus raw format magics; crash artifacts are uploaded on failure.
- `ci: harden the atheris fuzzing setup` — target bodies moved to `fuzzing/targets.py`, which
  imports no atheris, so crash artifacts replay anywhere (`fuzzing/replay.py`) and can be pinned
  as regression tests under `tests/fuzz_regressions/`. Adds three more targets (per-format loaders
  with `isCompatible()` bypassed; `disassembleBuffer()` with fuzzer-chosen arch/bitness/base;
  `SmdaReport.fromDict()` over fuzzer-generated JSON), constructs a fresh `Disassembler` per input
  so a crash no longer depends on the preceding input, persists/merges the corpus per target,
  promotes `RecursionError` to a defect, and exercises every target body from the regular test
  suite so an API change breaks a test rather than quietly neutering the fuzzers.
- `ci: use libFuzzer-legal escapes in the fuzzing dictionary` — the dex magics used `\n`, which
  libFuzzer's dictionary parser rejects; an illegal escape aborted every target before the first
  input. Encoded as `\x0a`, with a test so the dictionary cannot regress.
- `ci: replace libFuzzer merge and crash minimization with portable tools` — `-merge=1` and
  `-minimize_crash` re-execute `argv[0]`, which under atheris is the bare interpreter without the
  harness, so the corpus was never pruned and a crash would never have been minimized. Replaced by
  `prune_corpus.py` (bound by file count and total size, keeping the smallest inputs) and
  `minimize.py` (delta-debugs against the same exception type via `targets.py`, so it works off
  Linux too).
- `ci: record capstone and lief versions in the fuzzing job` — an editable install resolves the
  newest allowed versions; the Mach-O `bad_alloc` finding below only reproduces on lief 1.0.0.

## Correctness fixes — 4 commits

- `fix(loaders): guard every lief parse entry point against std::bad_alloc` — found by the new
  `formats` target: `MachoFileLoader.parseBinary` propagated `MemoryError` from `lief.MachO.parse`
  (one byte suffices on lief 1.0.0). `MemoryError` is non-operational, so it escaped the
  degradation paths and aborted the run instead of producing an error report. #222's
  `safe_lief_parse` missed this site because it kept the raw call to preserve the `FatBinary`
  container; the helper now takes an optional parser, and the Mach-O entry point, the three
  `DalvikDisassembler` `lief.DEX.parse` calls and `PeSynthesizer`'s xheader parse all route
  through it. Reachable on the ordinary path, not just via the fuzzer's `isCompatible` bypass.
- `fix(cil): resolve TypeDef/TypeSpec operands and make the fallback deterministic` —
  `format_operand` had no branch for `TypeDefRow`/`TypeSpecRow`, so they fell through to
  `str(operand)` and serialized a memory address into `SmdaInstruction.operands`. **njrat produced
  a different report on every run** (29 instructions, 11 of 64 functions); `pic_hash` hid it
  because the CIL escaper wildcards tokens. This changes njrat's report bytes — it does not move a
  frozen baseline, it creates one, since the previous bytes differed run to run. All 20 bundled
  `*_xored` fixtures now hash bit-identically across runs, with zero `object at 0x` occurrences.
- `fix(core): bounds-guard the disassembly window slice` — `_getDisasmWindowBuffer` raw-sliced the
  mapped image with an unvalidated relative offset, so a target below the image base gave a
  negative slice start, which Python reads from the end of the buffer: with base `0x400000` and
  target `0x3ffff0`, the last 15 bytes were decoded and booked into `code_map`/`ins2fn` as if they
  lived at the target. Output-neutral on all bundled fixtures. No candidate-side filter was added
  for the out-of-image starts the same traces reveal, since over-detection is intentional and that
  could move recall.
- `fix(common): stop display helpers crashing on partially-populated objects` — every offset-like
  field on these models is nullable, but `SmdaFunction.__str__`/`SmdaInstruction.__str__` used
  integer format specs, so a debugging aid raised `TypeError`. `SmdaReport.__str__` was a sibling
  found by the sweep, including its `status == "error"` branch. Folded in, both verified
  reachable: `DisassemblyResult.getApiRefs` used a truthiness guard on `addr_to_api` (zero-API
  binaries re-walked the table on every call, and once non-empty it never refreshed), and a
  duplicated dead assignment in `SmdaFunction.fromDict`'s dalvik branch. Output-neutral: all 8
  fixtures MATCH on the canonical report hash.

## Perf gate — 1 commit

`ci: add canonical report-hash and call-count channels to the perf gate`. The existing correctness
check compared only per-function `num_blocks`/`num_instructions`, so it would miss a `pic_hash`,
`apirefs`, `outrefs`-order or `binweight` regression, and local wall-clock cannot resolve small
changes on a loaded machine.

- `computeReportIdentityHash` in `smda.utility.common`: sha256 over `toDict()` minus
  `timestamp`/`execution_time`. A free function rather than a `SmdaReport` method, since the report
  is a public IDA-compatibility surface.
- `run_perf_check.py` records `report_hash` and `python_version` per fixture and hashes every
  iteration, failing loudly if one side disagrees with itself. Optional `--call-counts` adds
  `total_calls`/`prim_calls` from a dedicated untimed cProfile pass, discarding the first pass
  (one-time ApiScout/regex/demangler warm-up); two separate processes then agree to the digit on
  all 8 fixtures.
- `compare_perf.py` treats a hash mismatch as a correctness failure (exit 1, existing channel) and
  call-count deltas as an informational table, since a legitimate optimization changes them on
  purpose. `--fail-on-call-count-change` is available for bisecting; the channel is skipped when
  `python_version` differs.
- Composes with #222's counterbalanced base/PR/PR/base passes — `--append` and `--call-counts` are
  independent flags.

`fix(ci): keep the perf gate scripts type-clean and Python 3.14-safe` then cleans up after the
first CI run: `ProcessPoolExecutor` is constructed with explicit keywords so `ty` can match an
overload; `_parseBlocksFromTuples` keys `self.blocks` off the raw tuple address rather than the
nullable `SmdaInstruction.offset`; and `compare_perf.py`'s threshold help strings had a bare `%`,
which Python 3.14's argparse rejects with "badly formed help string" — pre-existing, exposed only
now that a test runs the script. Tree-wide sweep found no other instance of that shape.

## Batch mode and performance — 4 commits

- `fix(common): make SmdaReport picklable` — Intel reports could not be pickled at all
  (`ValueError: ctypes objects containing pointers cannot be pickled`). Two attributes hold
  capstone objects backed by ctypes pointers: `SmdaReport.capstone` and `SmdaInstruction.detailed`.
  The trigger on the default path is PIC hashing, not string extraction, which is why
  AArch64/CIL/Dalvik pickled clean. Both classes already declare `None` class-level defaults, so
  excluding the attributes in `__getstate__` suffices — no `__setstate__`. Downstream MCRIT
  consumers hit this today.
- `feat(utility): parallel batch disassembly` — `smda.utility.BatchProcessor.disassembleParallel`
  (a generator yielding one summary dict per completed file) plus `batch_analyze.py`, a sibling CLI
  of `analyze.py`. Measured on a 10-core box over 192 files: **22.77s → 5.08s, 4.5x**, with all 192
  canonical report hashes identical between the two runs. Reports are written in the worker so the
  parent is not a deserialization bottleneck; `ProcessPoolExecutor` with an explicit spawn context
  (per-future exception capture and `BrokenProcessPool` visibility where a `Pool` would hang); the
  `Disassembler` is constructed inside the task function, never in a pool initializer, which
  structurally prevents reintroducing Dalvik's instance-scoped `id()` caches; output naming is the
  path-relative stem, so same-named samples in different folders cannot overwrite each other.
  Determinism caveat documented rather than hidden: `SmdaConfig.TIMEOUT` is wall-clock, so under
  oversubscription a slow sample can time out where a serial run finished (`--timeout` exposed; the
  determinism proof runs with `TIMEOUT=0`).
- `perf(common): build SmdaInstructions straight from the raw disassembly tuples` — `getBlocksAsDict`
  allocated one intermediate 4-element list per instruction plus a list and dict entry per block,
  purely to be consumed on the next line. The transform is inlined, not removed, and the public
  `getBlocksAsDict` is kept. Byte-identical on all 8 fixtures; call counts −0.77% to −1.35% across
  every backend.
- `perf(intel): prefilter the post-call alignment decode` — the check decoded a full window through
  capstone for every instruction after a call: 3616 sites on the bundled fixtures, 32 of which
  return True. `isAlignmentSequence` can only return True when the first decoded instruction's
  bytes are in `GAP_SEQUENCES`, so a byte-level test is a necessary condition and rejecting on its
  negation cannot change an outcome — measured: 99.0% rejected, zero false rejects, the surviving
  37 sites identical before and after. `GAP_SEQUENCES` values become frozensets (`in` was an O(n)
  list scan). Byte-identical on all 8 fixtures; call counts cutwail −2.56%, asprox −1.70%,
  komplex −1.50%, bashlite −1.47%, non-intel fixtures exactly unchanged.

## Docs — 2 commits

- README batch-mode section (CLI + library helper, path-relative report naming, batch mode uses
  `disassembleFile` so raw dumps needing an explicit base address still belong in `analyze.py`).
- The cost of `CALCULATE_HASHING`/`CALCULATE_NESTING`/`CALCULATE_SCC` recorded next to the flags,
  as shares of Python calls per run on cutwail (10.0% / 4.6% / 3.2%; 17.8% together) rather than
  CPU percentages, because wall-clock on the measuring machine ranked the flag-disabled configs as
  *slower* than the default and cannot support a claim at that magnitude.
- Measured per-worker memory behaviour: no per-file accumulation (105 distinct PEs in one worker,
  +9 live objects total), peak dominated by the largest binary in flight, and recycling every file
  cost 30% wall clock for an 8% peak reduction — so `max_tasks_per_child` stays off by default and
  `--workers` is the lever. Also documents that spawn workers re-import the calling module, so
  `disassembleParallel` must be called under a `__main__` guard.

## Validation

```
make lint          # ruff check + format, clean
make test          # 887 passed, 2 skipped, 609 subtests passed
```

New test modules in the range: `tests/testBatchProcessor.py`, `tests/testSmdaReportPickle.py`,
`tests/testCilReportDeterminism.py`, `tests/testDisasmWindowBounds.py`,
`tests/testLiefParseOom.py`, `tests/testPartialObjectFormatting.py`, `tests/testPerfBenchmark.py`,
plus the fuzzing-target and corpus-tooling tests.

## Behaviour changes to be aware of

- **njrat's report bytes change** (CIL TypeDef/TypeSpec operands) — previously non-deterministic,
  so this establishes a baseline rather than moving one.
- Everything else in the range is output-neutral on the bundled fixtures, verified by the new
  canonical report hash.
