### PR TITLE
perf: cut a third of the per-instruction work out of the disassembly pipeline

### DIFF
--- a/batch_analyze.py
+++ b/batch_analyze.py
@@ -94,7 +94,8 @@ if __name__ == "__main__":
 
     os.makedirs(ARGS.output_path, exist_ok=True)
 
-    TOTAL = len(collectInputFiles(ARGS.input_paths))
+    COLLECTED = collectInputFiles(ARGS.input_paths)
+    TOTAL = len(COLLECTED)
     WORKERS = ARGS.workers if ARGS.workers > 0 else getDefaultWorkerCount()
     print(f"Disassembling {TOTAL} file(s) with {WORKERS} worker(s) into {ARGS.output_path}")
     if ARGS.timeout is None:
@@ -107,6 +108,7 @@ if __name__ == "__main__":
         timeout=ARGS.timeout,
         resume=ARGS.resume,
         max_tasks_per_child=ARGS.max_tasks_per_child,
+        collected=COLLECTED,
     )
 
     START = time.time()

--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -282,12 +282,19 @@ class DisassemblyResult:
             verified_refs = sorted(block_starts.intersection(self.code_refs_from[last_ins_addr]))
             if verified_refs:
                 block_refs[block[0][0]] = verified_refs
+        # block_refs was seeded from sorted(block_starts), so it only needs re-sorting if the
+        # exception pass introduced a key that was not already a block start
+        added_key = False
         for block_start, successors in self._getExceptionSuccessors(func_addr, blocks).items():
             merged_successors = set(block_refs.get(block_start, []))
             merged_successors.update(successors)
             block_refs[block_start] = sorted(merged_successors)
             for successor in successors:
-                block_refs.setdefault(successor, [])
+                if successor not in block_refs:
+                    block_refs[successor] = []
+                    added_key = True
+        if not added_key:
+            return block_refs
         return {block_start: block_refs[block_start] for block_start in sorted(block_refs)}
 
     def getInRefs(self, func_addr):
@@ -297,11 +304,9 @@ class DisassemblyResult:
         return sorted(in_refs)
 
     def getOutRefs(self, func_addr):
-        ins_addrs = set()
         code_refs_from = self.code_refs_from
-        for block in self.functions[func_addr]:
-            for ins in block:
-                ins_addrs.add(ins[0])
+        blocks = self.functions[func_addr]
+        ins_addrs = {ins[0] for block in blocks for ins in block}
         # function may be recursive
         ins_addrs.discard(func_addr)
         out_refs = {}

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import contextlib
 import logging
 import re
 
@@ -53,13 +52,19 @@ _HEX_OPERAND = re.compile(r"0x[0-9a-fA-F]+")
 _IMM_TOKEN = re.compile(r"#?-?0x[0-9a-fA-F]+|#-?\d+")
 
 
-def _immediate_tokens(op_str):
-    values = set()
+def _hasDataRefImmediate(op_str, base_addr, upper_addr, is_in_code_areas):
+    """Whether any printed immediate could name a data address, short-circuiting on the first."""
+    # the token pattern cannot match without one of these two markers
+    if "0x" not in op_str and "#" not in op_str:
+        return False
     for match in _IMM_TOKEN.finditer(op_str):
-        token = match.group().lstrip("#")
-        with contextlib.suppress(ValueError):
-            values.add(int(token, 0))
-    return values
+        try:
+            value = int(match.group().lstrip("#"), 0)
+        except ValueError:
+            continue
+        if base_addr <= value < upper_addr and not is_in_code_areas(value):
+            return True
+    return False
 
 
 class AArch64Backend(ArchBackend):
@@ -268,10 +273,7 @@ class AArch64Backend(ArchBackend):
         binary_info = d.disassembly.binary_info
         base_addr = binary_info.base_addr
         upper_addr = base_addr + binary_info.binary_size
-        if not any(
-            base_addr <= value < upper_addr and not binary_info.isInCodeAreas(value)
-            for value in _immediate_tokens(i_op_str)
-        ):
+        if not _hasDataRefImmediate(i_op_str, base_addr, upper_addr, binary_info.isInCodeAreas):
             # no printed immediate can yield a data ref, so the detail re-decode
             # below would record nothing.
             return

--- a/src/smda/aarch64/AArch64InstructionEscaper.py
+++ b/src/smda/aarch64/AArch64InstructionEscaper.py
@@ -9,6 +9,14 @@ from smda.aarch64.AArch64CapstoneVerification import (
 
 LOGGER = logging.getLogger(__name__)
 
+_KEEP_MASK_MEMO = {}
+# mirrors the _shift_extend class attribute below; additions must be made in both places
+_SHIFT_EXTEND_KEYWORDS = ("lsl", "lsr", "asr", "ror", "sxt", "uxt")
+_SHIFT_EXTEND_IMMEDIATE_RE = re.compile(
+    r"\b(?:lsl|lsr|asr|ror|sxtw|uxtw|sxtb|uxtb|sxth|uxth|sxtx|uxtx)\s*#-?(?:0x[0-9a-fA-F]+|\d+)",
+    re.IGNORECASE,
+)
+
 
 class AArch64InstructionEscaper:
     _aritlog_group = {
@@ -547,9 +555,15 @@ class AArch64InstructionEscaper:
         The check is purely text-based (we look at `ins.operands`) so it
         is independent of capstone's detailed disassembly.
         """
-        operands = (ins.operands or "").strip()
-        if not operands:
+        operands = ins.operands
+        # stripping cannot change whether a "#" is present, and no "#" means no immediate
+        if not operands or "#" not in operands:
             return False
+        # the substitution below only ever deletes text containing "#", so without a
+        # shift/extend keyword the cleaned string still holds the "#" seen above
+        lowered = operands.lower()
+        if not any(keyword in lowered for keyword in _SHIFT_EXTEND_KEYWORDS):
+            return True
         # Strip shift/extend modifiers (e.g. "lsl #3", "sxtw #0") so they
         # don't count as immediates.
         #
@@ -559,13 +573,7 @@ class AArch64InstructionEscaper:
         #
         # Note: the regex below mirrors `_shift_extend` (defined above)
         # so any future additions to that pattern should be mirrored here.
-        cleaned = re.sub(
-            r"\b(?:lsl|lsr|asr|ror|sxtw|uxtw|sxtb|uxtb|sxth|uxth|sxtx|uxtx)\s*#-?(?:0x[0-9a-fA-F]+|\d+)",
-            "",
-            operands,
-            flags=re.IGNORECASE,
-        )
-        return "#" in cleaned
+        return "#" in _SHIFT_EXTEND_IMMEDIATE_RE.sub("", operands)
 
     # Per-mnemonic immediate-field masks. Each entry maps a base mnemonic
     # (after stripping condition codes such as "b.eq" -> "b") to an 8-bit
@@ -651,13 +659,19 @@ class AArch64InstructionEscaper:
         the base mnemonic (so that 'b.eq' resolves via 'b' when no cond
         special case applies).
         """
+        if mnemonic in _KEEP_MASK_MEMO:
+            return _KEEP_MASK_MEMO[mnemonic]
         keep = cls._AARCH64_IMMEDIATE_KEEP_MASKS.get(mnemonic)
-        if keep is not None:
-            return keep
-        for prefix, mask in cls._AARCH64_CONDITIONAL_KEEP_MASKS.items():
-            if mnemonic.startswith(prefix):
-                return mask
-        return cls._AARCH64_IMMEDIATE_KEEP_MASKS.get(cls._baseMnemonic(mnemonic))
+        if keep is None:
+            for prefix, mask in cls._AARCH64_CONDITIONAL_KEEP_MASKS.items():
+                if mnemonic.startswith(prefix):
+                    keep = mask
+                    break
+            else:
+                keep = cls._AARCH64_IMMEDIATE_KEEP_MASKS.get(cls._baseMnemonic(mnemonic))
+        # pure function of a short mnemonic drawn from a bounded vocabulary
+        _KEEP_MASK_MEMO[mnemonic] = keep
+        return keep
 
     @staticmethod
     def escapeToOpcodeOnly(ins):

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -63,6 +63,10 @@ def resolve_token(pe, token: Token) -> Any:
 
 def format_operand(pe, operand: Any) -> str:
     """ """
+    # half of all operands are None and used to traverse every isinstance arm to reach the
+    # empty-string one at the bottom, seven of those checks going through ABCMeta
+    if operand is None:
+        return ""
     if isinstance(operand, Token):
         operand = resolve_token(pe, operand)
     if isinstance(operand, str):
@@ -91,8 +95,6 @@ def format_operand(pe, operand: Any) -> str:
         return f"TypeSpec({signature.hex()})" if signature else "TypeSpec()"
     elif isinstance(operand, (dnfile.mdtable.FieldRow, dnfile.mdtable.MethodDefRow)):
         return f"{operand.Name}"
-    elif operand is None:
-        return ""
 
     # never fall through to str(operand): the default object repr embeds a memory address,
     # which made every report of the same input serialize differently
@@ -100,16 +102,31 @@ def format_operand(pe, operand: Any) -> str:
 
 
 class DnfileMethodBodyReader(CilMethodBodyReaderBase):
+    _CHUNK = 4096
+
     def __init__(self, pe, row):
         """ """
         self.pe: dnPE = pe
         self.offset: int = self.pe.get_offset_from_rva(row.Rva)
+        self._buf: bytes = b""
+        self._buf_start: int = 0
 
     def read(self, n: int) -> bytes:
         """ """
-        data: bytes = self.pe.get_data(self.pe.get_rva_from_offset(self.offset), n)
+        start = self.offset - self._buf_start
+        if start < 0 or start + n > len(self._buf):
+            # pefile clips a read at the end of the containing section, so a chunk that would
+            # run past it comes back short; fall back to the exact request in that case
+            self._buf = self.pe.get_data(self.pe.get_rva_from_offset(self.offset), self._CHUNK)
+            self._buf_start = self.offset
+            start = 0
+            if len(self._buf) < n:
+                self._buf = b""
+                data: bytes = self.pe.get_data(self.pe.get_rva_from_offset(self.offset), n)
+                self.offset += n
+                return data
         self.offset += n
-        return data
+        return self._buf[start : start + n]
 
     def tell(self) -> int:
         """ """
@@ -139,10 +156,10 @@ class CilDisassembler:
     def _addLabelProviders(self):
         self.label_providers.append(self.cil_label_provider)
 
-    def _updateLabelProviders(self, binary_info):
+    def _updateLabelProviders(self, binary_info, parsed=None):
         for provider in self.label_providers:
             try:
-                provider.update(binary_info)
+                provider.update(binary_info, parsed=parsed)
             except Exception as exc:
                 reraise_non_operational_exception(exc)
                 LOGGER.error("Label provider %s failed to update: %r", provider.__class__.__name__, exc)
@@ -191,9 +208,9 @@ class CilDisassembler:
             i_mnemonic = str(insn.opcode)
             i_op_str = format_operand(pe, insn.operand)
             # https://en.wikipedia.org/wiki/List_of_CIL_instructions
-            if i_mnemonic in ["ret", "endfinally", "endfilter"]:
+            if i_mnemonic in {"ret", "endfinally", "endfilter"}:
                 state.setNextInstructionReachable(False)
-            if i_mnemonic in [
+            if i_mnemonic in {
                 "beq",
                 "beq.s",
                 "bge",
@@ -228,15 +245,15 @@ class CilDisassembler:
                 "brzero.s",
                 "leave",
                 "leave.s",
-            ]:
+            }:
                 target = int(i_op_str, 16)
                 state.addCodeRef(i_address, target, by_jump=True)
                 # an unconditional branch does not fall through; leaving reachability set
                 # emitted a bogus edge to the next instruction, which addCodeRef then also
                 # registered as a jump target (is_jmp was just set by the branch itself)
-                if i_mnemonic in ["br", "br.s", "leave", "leave.s"]:
+                if i_mnemonic in {"br", "br.s", "leave", "leave.s"}:
                     state.setNextInstructionReachable(False)
-            if i_mnemonic in ["jmp"]:
+            if i_mnemonic == "jmp":
                 # jmp's operand is InlineMethod (a tail-jump to another method), not a
                 # same-function branch offset, so i_op_str is usually a method name/token
                 # string here rather than a hex address like the branches above.
@@ -251,7 +268,7 @@ class CilDisassembler:
             # falls through to the token's own text, which is not a recovered string
             if i_mnemonic == "ldstr" and i_op_str.startswith('"') and i_op_str.endswith('"'):
                 self.disassembly.addStringRef(start_addr, i_address, i_op_str[1:-1])
-            if i_mnemonic in ["call", "calli", "callvirt"]:
+            if i_mnemonic in {"call", "calli", "callvirt"}:
                 state.is_leaf_function = False
                 self._updateApiInformation(i_address, i_bytes, i_op_str)
                 # https://blog.objektkultur.de/about-tail-recursion-in-.net/
@@ -265,9 +282,9 @@ class CilDisassembler:
                         method_addr = self.cil_label_provider.getAddress(method_name)
                         if method_addr is not None:
                             i_op_str = f"0x{method_addr:x}"
-            if i_mnemonic in ["throw", "rethrow"]:
+            if i_mnemonic in {"throw", "rethrow"}:
                 state.setNextInstructionReachable(False)
-            if i_mnemonic in ["switch"]:
+            if i_mnemonic == "switch":
                 next_addrs = []
                 for target in insn.operand:
                     next_addrs.append(target)
@@ -284,7 +301,6 @@ class CilDisassembler:
             binary_info.binary_size,
             binary_info.base_addr,
         )
-        self._updateLabelProviders(binary_info)
         self.disassembly = DisassemblyResult()
         self.disassembly.smda_version = self.config.VERSION
         self.disassembly.setConfidenceThreshold(self.config.CONFIDENCE_THRESHOLD)
@@ -296,7 +312,9 @@ class CilDisassembler:
         self.disassembly.language = {".net": 1.0}
 
         LOGGER.debug("Starting parser-based analysis.")
+        # one parse feeds both the symbol provider and the MethodDef walk below
         pe = dnfile.dnPE(data=binary_info.raw_data)
+        self._updateLabelProviders(binary_info, parsed=pe)
         # a corrupted metadata signature leaves dnfile with no tables at all; the symbol
         # provider already degrades on that, so the disassembler must not raise on it
         method_defs = getattr(getattr(getattr(pe, "net", None), "mdtables", None), "MethodDef", None)

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -46,7 +46,7 @@ class FunctionAnalysisState:
     def addInstruction(self, i_address, i_size, i_mnemonic, i_op_str, i_bytes):
         ins = (i_address, i_size, i_mnemonic, i_op_str, i_bytes)
         self.instructions.append(ins)
-        self.instruction_start_bytes.add(ins[0])
+        self.instruction_start_bytes.add(i_address)
         self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:
             self.addCodeRef(i_address, i_address + i_size, self.is_jmp)
@@ -54,16 +54,16 @@ class FunctionAnalysisState:
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
-        refs_from = self.code_refs_from.get(addr_from)
-        if refs_from is None:
-            self.code_refs_from[addr_from] = {addr_to}
+        code_refs_from = self.code_refs_from
+        if addr_from in code_refs_from:
+            code_refs_from[addr_from].add(addr_to)
         else:
-            refs_from.add(addr_to)
-        refs_to = self.code_refs_to.get(addr_to)
-        if refs_to is None:
-            self.code_refs_to[addr_to] = {addr_from}
+            code_refs_from[addr_from] = {addr_to}
+        code_refs_to = self.code_refs_to
+        if addr_to in code_refs_to:
+            code_refs_to[addr_to].add(addr_from)
         else:
-            refs_to.add(addr_from)
+            code_refs_to[addr_to] = {addr_from}
         if by_jump:
             self.is_jmp = True
             self.jump_refs.add((addr_from, addr_to))
@@ -86,20 +86,40 @@ class FunctionAnalysisState:
         self.data_bytes.update(range(addr_to, addr_to + size))
 
     def finalizeAnalysis(self, as_gap=False):
-        fn_min = min([ins[0] for ins in self.instructions])
-        fn_max = max([ins[0] + ins[1] for ins in self.instructions])
-
         self.disassembly.function_symbols[self.start_addr] = self.label
-        self.disassembly.function_borders[self.start_addr] = (fn_min, fn_max)
-        for ins in self.instructions:
-            self.disassembly.instructions[ins[0]] = (ins[2], ins[1])
-            for offset in range(ins[1]):
-                self.disassembly.code_map[ins[0] + offset] = ins[0]
-                self.disassembly.ins2fn[ins[0] + offset] = self.start_addr
+        instructions_map = self.disassembly.instructions
+        code_map = self.disassembly.code_map
+        ins2fn = self.disassembly.ins2fn
+        start_addr = self.start_addr
+        instructions = self.instructions
+        fn_min = instructions[0][0]
+        fn_max = fn_min + instructions[0][1]
+        # this loop must stay ahead of getBlocks() below, which sorts self.instructions
+        for ins in instructions:
+            ins_addr = ins[0]
+            ins_end = ins_addr + ins[1]
+            if ins_addr < fn_min:
+                fn_min = ins_addr
+            if ins_end > fn_max:
+                fn_max = ins_end
+            instructions_map[ins_addr] = (ins[2], ins[1])
+            for byte_addr in range(ins_addr, ins_end):
+                code_map[byte_addr] = ins_addr
+                ins2fn[byte_addr] = start_addr
+        self.disassembly.function_borders[start_addr] = (fn_min, fn_max)
         self.disassembly.data_map.update(self.data_bytes)
         self.disassembly.functions[self.start_addr] = self.getBlocks()
-        for cref in self.code_refs:
-            self.disassembly.addCodeRefs(cref[0], cref[1])
+        code_refs_from = self.disassembly.code_refs_from
+        code_refs_to = self.disassembly.code_refs_to
+        for addr_from, addr_to in self.code_refs:
+            if addr_from in code_refs_from:
+                code_refs_from[addr_from].add(addr_to)
+            else:
+                code_refs_from[addr_from] = {addr_to}
+            if addr_to in code_refs_to:
+                code_refs_to[addr_to].add(addr_from)
+            else:
+                code_refs_to[addr_to] = {addr_from}
         for dref in self.data_refs:
             self.disassembly.addDataRefs(dref[0], dref[1])
         if self.is_recursive:

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -2,8 +2,8 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
-CALL_INS = ["call", "calli", "callvirt"]
-END_INS = ["ret", "throw", "rethrow", "endfinally", "endfilter"]
+CALL_INS = frozenset(["call", "calli", "callvirt"])
+END_INS = frozenset(["ret", "throw", "rethrow", "endfinally", "endfilter"])
 
 
 class FunctionAnalysisState:
@@ -121,39 +121,41 @@ class FunctionAnalysisState:
         if self.blocks:
             return self.blocks
         self.instructions.sort()
-        ins = {i[0]: ind for ind, i in enumerate(self.instructions)}
+        instructions = self.instructions
+        last_index = len(instructions) - 1
+        code_refs_from = self.code_refs_from
+        code_refs_to = self.code_refs_to
+        ins = {i[0]: ind for ind, i in enumerate(instructions)}
         potential_starts = {self.code_start_addr}
-        potential_starts.update(list(self.jump_targets))
+        potential_starts.update(self.jump_targets)
         blocks = []
         for start in sorted(potential_starts):
             if start not in ins:
                 continue
             block = []
-            for i in range(ins[start], len(self.instructions)):
-                current = self.instructions[i]
+            for i in range(ins[start], last_index + 1):
+                current = instructions[i]
                 block.append(current)
+                current_addr = current[0]
+                is_last = i == last_index
+                next_ins_addr = -1 if is_last else instructions[i + 1][0]
                 # if one code reference is to another address than the next
+                refs_from = code_refs_from.get(current_addr)
+                if refs_from is not None and current[2] not in CALL_INS and not is_last:
+                    num_refs_from = len(refs_from)
+                    if num_refs_from > 1 or (num_refs_from == 1 and next_ins_addr not in refs_from):
+                        # if we can reach a colliding address from here, the block is broken and should end.
+                        reachable_collisions = refs_from.intersection(self.colliding_addresses)
+                        next_addr = current_addr + current[1]
+                        is_next_addr = next_addr in reachable_collisions
+                        if reachable_collisions and is_next_addr:
+                            # we should remove the from/to code references for this collision as there should be no non CFG instruction references between instructions of different functions
+                            self.removeCodeRef(current_addr, next_addr)
+                        break
                 if (
-                    current[0] in self.code_refs_from
-                    and current[2] not in CALL_INS
-                    and i != len(self.instructions) - 1
-                    and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
-                ):
-                    # if we can reach a colliding address from here, the block is broken and should end.
-                    reachable_collisions = self.code_refs_from[current[0]].intersection(self.colliding_addresses)
-                    next_addr = current[0] + current[1]
-                    is_next_addr = next_addr in reachable_collisions
-                    if reachable_collisions and is_next_addr:
-                        # we should remove the from/to code references for this collision as there should be no non CFG instruction references between instructions of different functions
-                        self.removeCodeRef(current[0], next_addr)
-                    break
-                if (
-                    i != len(self.instructions) - 1
-                    and self.instructions[i + 1][0] in self.code_refs_to
-                    and (
-                        len(self.code_refs_to[self.instructions[i + 1][0]]) > 1
-                        or self.instructions[i + 1][0] in potential_starts
-                    )
+                    not is_last
+                    and next_ins_addr in code_refs_to
+                    and (next_ins_addr in potential_starts or len(code_refs_to[next_ins_addr]) > 1)
                 ):
                     break
                 if current[2] in END_INS:

--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -84,9 +84,9 @@ class FunctionAnalysisState:
         ins = (i_address, i_size, i_mnemonic, i_op_str, i_bytes)
         self.instructions.append(ins)
         self._instructions_sorted = False
-        self.instruction_start_bytes.add(ins[0])
-        if ins[0] > self.max_instruction_start:
-            self.max_instruction_start = ins[0]
+        self.instruction_start_bytes.add(i_address)
+        if i_address > self.max_instruction_start:
+            self.max_instruction_start = i_address
         self.current_block.append(ins)
         self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:
@@ -95,16 +95,16 @@ class FunctionAnalysisState:
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
-        refs_from = self.code_refs_from.get(addr_from)
-        if refs_from is None:
-            self.code_refs_from[addr_from] = {addr_to}
+        code_refs_from = self.code_refs_from
+        if addr_from in code_refs_from:
+            code_refs_from[addr_from].add(addr_to)
         else:
-            refs_from.add(addr_to)
-        refs_to = self.code_refs_to.get(addr_to)
-        if refs_to is None:
-            self.code_refs_to[addr_to] = {addr_from}
+            code_refs_from[addr_from] = {addr_to}
+        code_refs_to = self.code_refs_to
+        if addr_to in code_refs_to:
+            code_refs_to[addr_to].add(addr_from)
         else:
-            refs_to.add(addr_from)
+            code_refs_to[addr_to] = {addr_from}
         if by_jump:
             self.is_jmp = True
             self.jump_refs.add((addr_from, addr_to))
@@ -157,25 +157,40 @@ class FunctionAnalysisState:
         return conflicts
 
     def _finalizeRegularAnalysis(self):
-        fn_min = min(ins[0] for ins in self.instructions)
-        fn_max = max(ins[0] + ins[1] for ins in self.instructions)
-
         self.disassembly.function_symbols[self.start_addr] = self.label
-        self.disassembly.function_borders[self.start_addr] = (fn_min, fn_max)
         instructions_map = self.disassembly.instructions
         code_map = self.disassembly.code_map
         ins2fn = self.disassembly.ins2fn
         start_addr = self.start_addr
-        for ins in self.instructions:
+        instructions = self.instructions
+        fn_min = instructions[0][0]
+        fn_max = fn_min + instructions[0][1]
+        # this loop must stay ahead of getBlocks() below, which sorts self.instructions
+        for ins in instructions:
             ins_addr = ins[0]
+            ins_end = ins_addr + ins[1]
+            if ins_addr < fn_min:
+                fn_min = ins_addr
+            if ins_end > fn_max:
+                fn_max = ins_end
             instructions_map[ins_addr] = (ins[2], ins[1])
-            for byte_addr in range(ins_addr, ins_addr + ins[1]):
+            for byte_addr in range(ins_addr, ins_end):
                 code_map[byte_addr] = ins_addr
                 ins2fn[byte_addr] = start_addr
+        self.disassembly.function_borders[start_addr] = (fn_min, fn_max)
         self.disassembly.data_map.update(self.data_bytes)
         self.disassembly.functions[self.start_addr] = self.getBlocks()
-        for cref in self.code_refs:
-            self.disassembly.addCodeRefs(cref[0], cref[1])
+        code_refs_from = self.disassembly.code_refs_from
+        code_refs_to = self.disassembly.code_refs_to
+        for addr_from, addr_to in self.code_refs:
+            if addr_from in code_refs_from:
+                code_refs_from[addr_from].add(addr_to)
+            else:
+                code_refs_from[addr_from] = {addr_to}
+            if addr_to in code_refs_to:
+                code_refs_to[addr_to].add(addr_from)
+            else:
+                code_refs_to[addr_to] = {addr_from}
         for dref in self.data_refs:
             self.disassembly.addDataRefs(dref[0], dref[1])
         if self.is_recursive:

--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -7,6 +7,7 @@ basic-block boundary decisions.
 """
 
 import logging
+from operator import itemgetter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -127,7 +128,7 @@ class FunctionAnalysisState:
 
     def backtrackInstructions(self, addr_from, num_instructions):
         if not self._instructions_sorted:
-            self.instructions.sort(key=lambda x: x[0])
+            self.instructions.sort(key=itemgetter(0))
             self._instructions_sorted = True
         # Binary search for the first instruction with address >= addr_from
         low = 0
@@ -248,9 +249,16 @@ class FunctionAnalysisState:
         if self.blocks:
             return self.blocks
         if not self._instructions_sorted:
-            self.instructions.sort(key=lambda x: x[0])
+            self.instructions.sort(key=itemgetter(0))
             self._instructions_sorted = True
-        ins = {i[0]: ind for ind, i in enumerate(self.instructions)}
+        instructions = self.instructions
+        last_index = len(instructions) - 1
+        code_refs_from = self.code_refs_from
+        code_refs_to = self.code_refs_to
+        colliding_addresses = self.colliding_addresses
+        call_mnemonics = self.CALL_MNEMONICS
+        end_mnemonics = self.END_MNEMONICS
+        ins = {i[0]: ind for ind, i in enumerate(instructions)}
         potential_starts = {self.start_addr}
         potential_starts.update(self.jump_targets)
         blocks = []
@@ -258,37 +266,41 @@ class FunctionAnalysisState:
             if start not in ins:
                 continue
             block = []
-            for i in range(ins[start], len(self.instructions)):
-                current = self.instructions[i]
-                current_mnemonic = current[2].split(" ")[-1]
+            for i in range(ins[start], last_index + 1):
+                current = instructions[i]
+                current_mnemonic = current[2]
+                if " " in current_mnemonic:
+                    current_mnemonic = current_mnemonic.rpartition(" ")[2]
                 block.append(current)
+                current_addr = current[0]
+                is_last = i == last_index
+                next_ins_addr = -1 if is_last else instructions[i + 1][0]
                 # if one code reference is to another address than the next
-                if current[0] in self.code_refs_from:
+                refs_from = code_refs_from.get(current_addr)
+                if refs_from is not None:
+                    num_refs_from = len(refs_from)
                     if (
-                        current_mnemonic not in self.CALL_MNEMONICS
-                        and i != len(self.instructions) - 1
-                        and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
+                        current_mnemonic not in call_mnemonics
+                        and not is_last
+                        and (num_refs_from > 1 or (num_refs_from == 1 and next_ins_addr not in refs_from))
                     ):
                         break
                     # if we can reach a colliding address from here, the block is broken and should end.
-                    if self.colliding_addresses:
-                        reachable_collisions = self.code_refs_from[current[0]].intersection(self.colliding_addresses)
-                        next_addr = current[0] + current[1]
+                    if colliding_addresses:
+                        reachable_collisions = refs_from.intersection(colliding_addresses)
+                        next_addr = current_addr + current[1]
                         is_next_addr = next_addr in reachable_collisions
                         if reachable_collisions and is_next_addr:
                             # we should remove the from/to code references for this collision as there should be no non CFG instruction references between instructions of different functions
-                            self.removeCodeRef(current[0], next_addr)
+                            self.removeCodeRef(current_addr, next_addr)
                             break
                 if (
-                    i != len(self.instructions) - 1
-                    and self.instructions[i + 1][0] in self.code_refs_to
-                    and (
-                        len(self.code_refs_to[self.instructions[i + 1][0]]) > 1
-                        or self.instructions[i + 1][0] in potential_starts
-                    )
+                    not is_last
+                    and next_ins_addr in code_refs_to
+                    and (next_ins_addr in potential_starts or len(code_refs_to[next_ins_addr]) > 1)
                 ):
                     break
-                if current_mnemonic in self.END_MNEMONICS:
+                if current_mnemonic in end_mnemonics:
                     break
             if block:
                 blocks.append(block)

--- a/src/smda/common/LanguageAnalyzer.py
+++ b/src/smda/common/LanguageAnalyzer.py
@@ -15,6 +15,9 @@ from smda.utility.MachoBinary import get_active_macho_binary
 
 LOGGER = logging.getLogger(__name__)
 
+_PRINTABLE_STRINGS_RE = re.compile(b"[ -~]{6,128}")
+_BORLAND_LOCALES = b"borland\\locales"
+
 
 class LanguageAnalyzer:
     def __init__(self, disassembly):
@@ -55,10 +58,8 @@ class LanguageAnalyzer:
 
     def getStrings(self):
         if self.strings is None:
-            self.strings = [
-                match.group("string")
-                for match in re.finditer(b"(?P<string>[ -~]{6,128})", self.disassembly.binary_info.binary)
-            ]
+            # single-group findall yields the group directly, so this is the same list
+            self.strings = _PRINTABLE_STRINGS_RE.findall(self.disassembly.binary_info.binary)
         return self.strings
 
     def getVisualBasicScore(self):
@@ -113,10 +114,26 @@ class LanguageAnalyzer:
             self._delphi_score = self._computeDelphiScore()
         return self._delphi_score
 
+    @staticmethod
+    def _containsBorlandLocales(data):
+        """Case-insensitive search for the literal "Borland\\Locales".
+
+        Anchored on the backslash rather than lowercasing the whole image: the needle has no
+        regex metacharacters, so this is a plain substring predicate over a buffer that can be
+        megabytes wide.
+        """
+        position = data.find(b"\\", 7)
+        while position != -1:
+            # the start index is kept >= 7 so a negative slice can never wrap to the tail
+            if data[position - 7 : position + 8].lower() == _BORLAND_LOCALES:
+                return True
+            position = data.find(b"\\", position + 1)
+        return False
+
     def _computeDelphiScore(self):
         delphi_score = 0.0
         # Check if Delphi-Locales are present in strings
-        if re.search(rb"Borland\\Locales", self.disassembly.binary_info.binary, re.IGNORECASE):
+        if self._containsBorlandLocales(self.disassembly.binary_info.binary):
             delphi_score = max(delphi_score, 0.25)
         if self._getPETimestamp() == 0x2A425E19:
             delphi_score = max(delphi_score, 0.25)

--- a/src/smda/common/LanguageAnalyzer.py
+++ b/src/smda/common/LanguageAnalyzer.py
@@ -28,6 +28,8 @@ class LanguageAnalyzer:
         self._cpp_symbol_count = 0
         self._guess = None
         self._delphi_objects = None
+        self._delphi_score = None
+        self._cpp_symbol_score = None
 
     def validPEHeader(self):
         is_pe = self.disassembly.binary_info.binary[0:2] == b"\x4d\x5a"
@@ -52,7 +54,7 @@ class LanguageAnalyzer:
             return 0
 
     def getStrings(self):
-        if not self.strings:
+        if self.strings is None:
             self.strings = [
                 match.group("string")
                 for match in re.finditer(b"(?P<string>[ -~]{6,128})", self.disassembly.binary_info.binary)
@@ -107,6 +109,11 @@ class LanguageAnalyzer:
         return self.getDelphiScore() > 0.5
 
     def getDelphiScore(self):
+        if self._delphi_score is None:
+            self._delphi_score = self._computeDelphiScore()
+        return self._delphi_score
+
+    def _computeDelphiScore(self):
         delphi_score = 0.0
         # Check if Delphi-Locales are present in strings
         if re.search(rb"Borland\\Locales", self.disassembly.binary_info.binary, re.IGNORECASE):
@@ -171,6 +178,11 @@ class LanguageAnalyzer:
         The returned count is capped at ``CPP_SYMBOL_EVIDENCE_THRESHOLD``; it reports
         how much evidence was needed, not how many C++ symbols the binary holds.
         """
+        if self._cpp_symbol_score is None:
+            self._cpp_symbol_score = self._computeCppSymbolScore()
+        return self._cpp_symbol_score
+
+    def _computeCppSymbolScore(self):
         try:
             lief_binary = self.disassembly.binary_info.getLiefBinary()
         except Exception as exc:

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -24,6 +24,9 @@ from smda.DisassemblyResult import DisassemblyResult
 
 LOGGER = logging.getLogger(__name__)
 
+# a leading sign is preserved so that negative displacements ("[rip - 0x20]") resolve correctly
+_REFERENCED_ADDR_RE = re.compile(r"(?P<sign>[+-])?\s*0x(?P<value>[a-fA-F0-9]+)")
+
 
 class RecursiveDisassembler:
     """Architecture-agnostic recursive CFG-recovery engine.
@@ -157,7 +160,7 @@ class RecursiveDisassembler:
     def getReferencedAddr(self, op_str):
         # preserve a leading sign so that negative displacements (e.g. "qword ptr [rip - 0x20]")
         # resolve to the correct address instead of being treated as positive
-        referenced_addr = re.search(r"(?P<sign>[+-])?\s*0x(?P<value>[a-fA-F0-9]+)", op_str)
+        referenced_addr = _REFERENCED_ADDR_RE.search(op_str)
         if referenced_addr:
             value = int(referenced_addr.group("value"), 16)
             return -value if referenced_addr.group("sign") == "-" else value

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import re
 from bisect import bisect_right
+from itertools import chain
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.ExceptionHandling import reraise_non_operational_exception
@@ -284,7 +285,7 @@ class RecursiveDisassembler:
                 LOGGER.debug("  analyzeFunction() now processing block @0x%08x", state.block_start)
             # in capstone, disassembly is more expensive than calling the function, so we use the maximum instruction
             # size as look-ahead. disasm_lite() also provides faster disassembly than disasm(), so we work with tuples.
-            cache = list(self.capstone.disasm_lite(self._getDisasmWindowBuffer(state.block_start), state.block_start))
+            cache = self.capstone.disasm_lite(self._getDisasmWindowBuffer(state.block_start), state.block_start)
             cache_pos = 0
             previous_i = None
             while True:
@@ -301,12 +302,12 @@ class RecursiveDisassembler:
                             i_mnemonic + " " + i_op_str,
                         )
                     cache_pos += i_size
-                    state.setNextInstructionReachable(True)
+                    state.is_next_instruction_reachable = True
                     # count "suspicious" all-zero instructions (e.g. x86 `00 00`,
                     # AArch64 `udf #0`) that indicate non-function code. Testing for an
                     # all-zero decoded instruction is architecture-independent; a
                     # fixed-width constant would never match wider fixed-width ISAs.
-                    if i_bytes and not any(i_bytes):
+                    if i_bytes and not i_bytes[0] and not any(i_bytes):
                         state.suspicious_ins_count += 1
                         LOGGER.debug(
                             "    analyzeFunction() found suspicious function @0x%08x",
@@ -326,7 +327,7 @@ class RecursiveDisassembler:
                     if (
                         i_address not in self.disassembly.code_map
                         and i_address not in self.disassembly.data_map
-                        and not state.isProcessed(i_address)
+                        and i_address not in state.processed_bytes
                     ):
                         if debug_logging:
                             LOGGER.debug(
@@ -356,23 +357,24 @@ class RecursiveDisassembler:
                     else:
                         LOGGER.debug("  analyzeFunction() was already present in local function.")
                         state.setBlockEndingInstruction(True)
-                    if state.isBlockEndingInstruction():
+                    if state.is_block_ending_instruction:
                         state.endBlock()
                         break
                 else:
                     # if the inner loop did not break, we need to refill the cache in order to finish the block-analysis
-                    cache = list(
-                        self.capstone.disasm_lite(
-                            self._getDisasmWindowBuffer(state.block_start + cache_pos),
-                            state.block_start + cache_pos,
-                        )
+                    cache = self.capstone.disasm_lite(
+                        self._getDisasmWindowBuffer(state.block_start + cache_pos),
+                        state.block_start + cache_pos,
                     )
-                    if not cache:
+                    # a generator is always truthy, so emptiness has to be probed by consuming
+                    first_of_refill = next(cache, None)
+                    if first_of_refill is None:
                         break
+                    cache = chain((first_of_refill,), cache)
                     continue
                 # if the inner loop did break, the cache didn't run empty and thus block-analysis is finished
                 break
-            if not state.isBlockEndingInstruction():
+            if not state.is_block_ending_instruction:
                 if i is not None:
                     i_address, i_size, i_mnemonic, i_op_str = i
                     LOGGER.debug(

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import re
 import struct
+from operator import itemgetter
 from typing import Any, Dict, List, Optional
 
 from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper
@@ -413,7 +414,11 @@ class SmdaFunction:
         yield from self.code_outrefs
 
     def _calculateSccs(self):
-        tarjan = Tarjan(self.getNormalizedBlockRefs())
+        normalized_blockrefs = self.getNormalizedBlockRefs()
+        # a one-node graph has exactly one component whether or not it self-loops
+        if len(normalized_blockrefs) == 1:
+            return [list(normalized_blockrefs)]
+        tarjan = Tarjan(normalized_blockrefs)
         tarjan.calculateScc()
         return tarjan.getResult()
 
@@ -423,6 +428,9 @@ class SmdaFunction:
             normalized_blockrefs = self.getNormalizedBlockRefs()
             root = self._getCfgRoot(normalized_blockrefs)
             if normalized_blockrefs and root is not None:
+                # a one-node graph dominates only itself, so the tree is empty and the depth 0
+                if len(normalized_blockrefs) == 1:
+                    return 0
                 tree = build_dominator_tree(normalized_blockrefs, root)
                 if tree:
                     nesting_depth = get_nesting_depth(normalized_blockrefs, tree, root)
@@ -434,27 +442,39 @@ class SmdaFunction:
         return struct.unpack("<Q", hashlib.sha256(self.getPicHashSequence(binary_info)).digest()[:8])[0]
 
     def getPicHashSequence(self, binary_info):
-        escaped_binary_seqs = []
-        for key in self._sorted_block_keys:
-            for instruction in self.blocks[key]:
-                escaped_binary_seqs.append(
-                    instruction.getEscapedBinary(
-                        self._escaper,
-                        escape_intraprocedural_jumps=True,
-                        lower_addr=binary_info.base_addr,
-                        upper_addr=binary_info.base_addr + binary_info.binary_size,
-                    )
+        escaper = self._escaper
+        blocks = self.blocks
+        if escaper is None:
+            escaped_binary_seqs = [instruction.bytes for key in self._sorted_block_keys for instruction in blocks[key]]
+        else:
+            lower_addr = binary_info.base_addr
+            upper_addr = lower_addr + binary_info.binary_size
+            escaped_binary_seqs = [
+                escaper.escapeBinary(
+                    instruction,
+                    escape_intraprocedural_jumps=True,
+                    lower_addr=lower_addr,
+                    upper_addr=upper_addr,
                 )
+                for key in self._sorted_block_keys
+                for instruction in blocks[key]
+            ]
         return "".join(escaped_binary_seqs).encode("ascii")
 
     def getOpcHash(self):
         return struct.unpack("<Q", hashlib.sha256(self.getOpcHashSequence()).digest()[:8])[0]
 
     def getOpcHashSequence(self):
-        escaped_binary_seqs = []
-        for key in self._sorted_block_keys:
-            for instruction in self.blocks[key]:
-                escaped_binary_seqs.append(instruction.getEscapedToOpcodeOnly(self._escaper))
+        escaper = self._escaper
+        blocks = self.blocks
+        if escaper is None:
+            escaped_binary_seqs = [instruction.bytes for key in self._sorted_block_keys for instruction in blocks[key]]
+        else:
+            escaped_binary_seqs = [
+                escaper.escapeToOpcodeOnly(instruction)
+                for key in self._sorted_block_keys
+                for instruction in blocks[key]
+            ]
         return "".join(escaped_binary_seqs).encode("ascii")
 
     def _parseBlocksFromTuples(self, disasm_blocks):
@@ -468,14 +488,13 @@ class SmdaFunction:
         """
         self.blocks = {}
         for block in disasm_blocks:
-            instructions = []
             block_start = block[0][0]
-            for ins_addr, _, ins_mnem, ins_ops, ins_raw_bytes in block:
-                instructions.append(
-                    SmdaInstruction([ins_addr, ins_raw_bytes.hex(), str(ins_mnem), str(ins_ops)], smda_function=self)
-                )
-            self.blocks[block_start] = instructions
-            self.binweight += sum(len(ins.bytes or "") / 2 for ins in instructions)
+            self.blocks[block_start] = [
+                SmdaInstruction([ins[0], ins[4].hex(), str(ins[2]), str(ins[3])], smda_function=self) for ins in block
+            ]
+            # len(hex) == 2 * len(raw), so the per-instruction len(hex)/2 this replaces summed to
+            # the raw byte count; binweight is serialized, so it must stay that value and a float
+            self.binweight += float(sum(map(len, map(itemgetter(4), block))))
         self._sorted_block_keys = sorted(self.blocks.keys())
         # invalidate any cached SmdaBasicBlock objects built from a previous block set
         self._basic_blocks = None

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -578,7 +578,8 @@ class SmdaReport:
 
     def toFile(self, output_filepath) -> None:
         with open(output_filepath, "w", encoding="utf-8") as fout:
-            json.dump(self.toDict(), fout, indent=1, sort_keys=True)
+            # one C-level encode of the whole report instead of json.dump's chunked writes
+            fout.write(json.dumps(self.toDict(), indent=1, sort_keys=True))
             LOGGER.info(f"SmdaReport saved to: {output_filepath}")
 
     def __str__(self):

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -34,12 +34,12 @@ class CilSymbolProvider(AbstractLabelProvider):
         """ensure a proper utf-8 escaped string"""
         return value.encode("utf-8").decode("utf-8")
 
-    def update(self, binary_info):
+    def update(self, binary_info, parsed=None):
         self._addr_to_func_symbols = {}
         self._func_symbol_to_addr = {}
         self._ambiguous_func_symbols = set()
         try:
-            pe = dnfile.dnPE(data=binary_info.raw_data)
+            pe = dnfile.dnPE(data=binary_info.raw_data) if parsed is None else parsed
         except Exception as exc:
             reraise_non_operational_exception(exc)
             LOGGER.debug("Failed to parse CIL symbols: %s", exc)

--- a/src/smda/common/labelprovider/GoLabelProvider.py
+++ b/src/smda/common/labelprovider/GoLabelProvider.py
@@ -33,6 +33,28 @@ _PCLNTAB_VERSIONS = {
 _PCLNTAB_HEADER_RE = re.compile(
     b"(?:(?:\xfb|\xfa|\xf0|\xf1)\xff\xff\xff|\xff\xff\xff(?:\xfb|\xfa|\xf0|\xf1))\x00\x00[\x01\x02\x04][\x04\x08]"
 )
+# both alternatives of the pattern above contain this run, at offset 1 in the little-endian
+# spelling and offset 0 in the big-endian one
+_PCLNTAB_ANCHOR = b"\xff\xff\xff"
+
+
+def findPcLntabHeaderOffsets(binary_bytes):
+    """Offsets where _PCLNTAB_HEADER_RE matches, found by anchoring on the literal run.
+
+    The pattern starts with an alternation, so the regex engine has no prefix to fast-search
+    on and enters the matcher at every offset of the image. Locating the anchor first and
+    re-using the same compiled pattern to confirm each candidate keeps the accepted set
+    identical by construction; two matches cannot overlap, so the non-overlapping scan this
+    replaces could not have reported a different count either.
+    """
+    hits = []
+    position = binary_bytes.find(_PCLNTAB_ANCHOR)
+    while position != -1:
+        for start in (position - 1, position):
+            if start >= 0 and _PCLNTAB_HEADER_RE.match(binary_bytes, start):
+                hits.append(start)
+        position = binary_bytes.find(_PCLNTAB_ANCHOR, position + 1)
+    return sorted(set(hits))
 
 
 class GoSymbolProvider(AbstractLabelProvider):
@@ -90,7 +112,7 @@ class GoSymbolProvider(AbstractLabelProvider):
         if pclntab_offset is None or self._readPcLntabHeader(binary_bytes, pclntab_offset) is None:
             pclntab_offset = None
             # scan for offset of structure
-            hits = [match.start() for match in _PCLNTAB_HEADER_RE.finditer(binary_bytes)]
+            hits = findPcLntabHeaderOffsets(binary_bytes)
             if len(hits) == 1:
                 pclntab_offset = hits[0]
         if binary_info is not None:

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -70,17 +70,16 @@ class WinApiResolver(AbstractLabelProvider):
         api_map = {}
         for dll_entry in api_db["dlls"]:
             LOGGER.debug("  building address map for: %s", dll_entry)
-            for export in api_db["dlls"][dll_entry]["exports"]:
+            dll = api_db["dlls"][dll_entry]
+            dll_name = "_".join(dll_entry.split("_")[2:])
+            has_64bit |= dll["bitness"] == 64
+            base_address = dll["base_address"]
+            for export in dll["exports"]:
                 num_apis_loaded += 1
-                api_name = "{}".format(export["name"])
+                api_name = str(export["name"])
                 if api_name == "None":
                     api_name = "None<{}>".format(export["ordinal"])
-                dll_name = "_".join(dll_entry.split("_")[2:])
-                bitness = api_db["dlls"][dll_entry]["bitness"]
-                has_64bit |= bitness == 64
-                base_address = api_db["dlls"][dll_entry]["base_address"]
-                virtual_address = base_address + export["address"]
-                api_map[virtual_address] = (dll_name, api_name)
+                api_map[base_address + export["address"]] = (dll_name, api_name)
         LOGGER.debug(
             "loaded %d exports from %d DLLs (%s).",
             num_apis_loaded,

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -1416,11 +1416,17 @@ class DalvikDisassembler:
         scan = data_off + ((4 - (data_off % 4)) % 4)
         # Sort intervals for linear skip advancement.
         claimed_intervals.sort()
+        # scan only ever increases, so an interval ending at or before it stays dead.
+        first_alive = 0
+        num_intervals = len(claimed_intervals)
         while scan + 16 <= data_end and len(candidates) < max_candidates:
             if decode_attempts >= self._MAX_ORPHAN_DECODE_ATTEMPTS:
                 break
+            while first_alive < num_intervals and claimed_intervals[first_alive][1] <= scan:
+                first_alive += 1
             advanced = False
-            for a, b in claimed_intervals:
+            for index in range(first_alive, num_intervals):
+                a, b = claimed_intervals[index]
                 if a <= scan < b:
                     scan = b if b % 4 == 0 else b + (4 - (b % 4))
                     advanced = True
@@ -1461,6 +1467,8 @@ class DalvikDisassembler:
                 candidates.append(accepted)
                 self._claimCodeItemRange(claimed_intervals, scan, hdr["insns_size"])
                 claimed_intervals.sort()
+                first_alive = 0
+                num_intervals = len(claimed_intervals)
             scan += 4
         return candidates
 

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -158,6 +158,7 @@ class DexReferenceResolver:
         # resolver's lifetime (resolver tables and analyzeBuffer's method list do);
         # an id reused after GC would alias a stale entry.
         self._type_format_cache = {}
+        self._proto_format_cache = {}
         self._loadExtendedTables()
 
     def _indexItems(self, items):
@@ -247,11 +248,15 @@ class DexReferenceResolver:
     def _formatProto(self, prototype):
         if prototype is None:
             return "()<?>"
-        params = []
-        for param in getattr(prototype, "parameters_type", []):
-            params.append(self._formatType(param))
+        cached = self._proto_format_cache.get(id(prototype))
+        if cached is not None:
+            return cached[1]
+        params = [self._formatType(param) for param in getattr(prototype, "parameters_type", [])]
         return_type = self._formatType(getattr(prototype, "return_type", None))
-        return f"({''.join(params)}){return_type}"
+        result = f"({''.join(params)}){return_type}"
+        # the prototype is stored alongside its result so the cache pins the object whose id keys it
+        self._proto_format_cache[id(prototype)] = (prototype, result)
+        return result
 
     def formatMethod(self, method):
         if method is None:
@@ -1003,7 +1008,7 @@ class DalvikDisassembler:
         # advance by 2 on resync — stepping by 1 wastes a decode attempt at every
         # odd offset on adversarial input.
         while idx < len(bytecode):
-            if any(start <= idx < end for start, end in payload_ranges):
+            if payload_ranges and any(start <= idx < end for start, end in payload_ranges):
                 idx += 2
                 continue
             try:

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -10,6 +10,7 @@ from smda.dalvik.DalvikFunctionAnalysisState import DalvikFunctionAnalysisState
 from smda.dalvik.DalvikOpcodeDecoder import (
     OPCODES,
     decode_instruction,
+    decode_instruction_shallow,
     parse_code_item_header,
     read_sleb128,
     read_uleb128,
@@ -1003,7 +1004,6 @@ class DalvikDisassembler:
         seen_ranges = set(payload_ranges)
         had_backward_payload = False
         idx = 0
-        null_resolve = lambda ref_kind, ref_index: ""  # noqa: E731
         # Dalvik instructions are 16-bit aligned (one "code unit"), so always
         # advance by 2 on resync — stepping by 1 wastes a decode attempt at every
         # odd offset on adversarial input.
@@ -1012,22 +1012,22 @@ class DalvikDisassembler:
                 idx += 2
                 continue
             try:
-                decoded = decode_instruction(bytecode, idx, null_resolve)
+                size_bytes, payload_idx = decode_instruction_shallow(bytecode, idx)
             except ValueError:
                 idx += 2
                 continue
             valid.add(idx)
-            if decoded.payload_idx is not None:
-                payload_size = self._getPayloadSize(bytecode, decoded.payload_idx)
+            if payload_idx is not None:
+                payload_size = self._getPayloadSize(bytecode, payload_idx)
                 if payload_size:
-                    range_pair = (decoded.payload_idx, decoded.payload_idx + payload_size)
+                    range_pair = (payload_idx, payload_idx + payload_size)
                     if range_pair not in seen_ranges:
                         payload_ranges.append(range_pair)
                         seen_ranges.add(range_pair)
                         # Backward or self-overlapping payload relative to this insn.
-                        if decoded.payload_idx <= idx:
+                        if payload_idx <= idx:
                             had_backward_payload = True
-            idx += decoded.size_bytes
+            idx += size_bytes
         return valid, payload_ranges, had_backward_payload
 
     def _buildValidInstructionStarts(self, bytecode):

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -93,7 +93,7 @@ class DalvikFunctionAnalysisState:
     def addInstruction(self, i_address, i_size, i_mnemonic, i_op_str, i_bytes):
         ins = (i_address, i_size, i_mnemonic, i_op_str, i_bytes)
         self.instructions.append(ins)
-        self.instruction_start_bytes.add(ins[0])
+        self.instruction_start_bytes.add(i_address)
         self.current_block.append(ins)
         self.processed_bytes.update(range(i_address, i_address + i_size))
         if self.is_next_instruction_reachable:
@@ -101,16 +101,16 @@ class DalvikFunctionAnalysisState:
 
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
         self.code_refs.add((addr_from, addr_to))
-        refs_from = self.code_refs_from.get(addr_from)
-        if refs_from is None:
-            self.code_refs_from[addr_from] = {addr_to}
+        code_refs_from = self.code_refs_from
+        if addr_from in code_refs_from:
+            code_refs_from[addr_from].add(addr_to)
         else:
-            refs_from.add(addr_to)
-        refs_to = self.code_refs_to.get(addr_to)
-        if refs_to is None:
-            self.code_refs_to[addr_to] = {addr_from}
+            code_refs_from[addr_from] = {addr_to}
+        code_refs_to = self.code_refs_to
+        if addr_to in code_refs_to:
+            code_refs_to[addr_to].add(addr_from)
         else:
-            refs_to.add(addr_from)
+            code_refs_to[addr_to] = {addr_from}
         if by_jump:
             self.jump_refs.add((addr_from, addr_to))
             self.jump_targets.add(addr_to)
@@ -140,25 +140,45 @@ class DalvikFunctionAnalysisState:
         return backtracked[-num_instructions:]
 
     def _finalizeRegularAnalysis(self):
-        fn_min = min([ins[0] for ins in self.instructions])
-        fn_max = max([ins[0] + ins[1] for ins in self.instructions])
-
         if self.is_partial:
             self.metadata["partial_disassembly"] = True
             self.metadata["decode_error_count"] = self.decode_error_count
 
         self.disassembly.function_symbols[self.start_addr] = self.label
-        self.disassembly.function_borders[self.start_addr] = (fn_min, fn_max)
         self.disassembly.function_metadata[self.start_addr] = self.metadata
-        for ins in self.instructions:
-            self.disassembly.instructions[ins[0]] = (ins[2], ins[1])
-            for offset in range(ins[1]):
-                self.disassembly.code_map[ins[0] + offset] = ins[0]
-                self.disassembly.ins2fn[ins[0] + offset] = self.start_addr
+        instructions_map = self.disassembly.instructions
+        code_map = self.disassembly.code_map
+        ins2fn = self.disassembly.ins2fn
+        start_addr = self.start_addr
+        instructions = self.instructions
+        fn_min = instructions[0][0]
+        fn_max = fn_min + instructions[0][1]
+        # this loop must stay ahead of getBlocks() below, which sorts self.instructions
+        for ins in instructions:
+            ins_addr = ins[0]
+            ins_end = ins_addr + ins[1]
+            if ins_addr < fn_min:
+                fn_min = ins_addr
+            if ins_end > fn_max:
+                fn_max = ins_end
+            instructions_map[ins_addr] = (ins[2], ins[1])
+            for byte_addr in range(ins_addr, ins_end):
+                code_map[byte_addr] = ins_addr
+                ins2fn[byte_addr] = start_addr
+        self.disassembly.function_borders[start_addr] = (fn_min, fn_max)
         self.disassembly.data_map.update(self.data_bytes)
         self.disassembly.functions[self.start_addr] = self.getBlocks()
-        for cref in self.code_refs:
-            self.disassembly.addCodeRefs(cref[0], cref[1])
+        code_refs_from = self.disassembly.code_refs_from
+        code_refs_to = self.disassembly.code_refs_to
+        for addr_from, addr_to in self.code_refs:
+            if addr_from in code_refs_from:
+                code_refs_from[addr_from].add(addr_to)
+            else:
+                code_refs_from[addr_from] = {addr_to}
+            if addr_to in code_refs_to:
+                code_refs_to[addr_to].add(addr_from)
+            else:
+                code_refs_to[addr_to] = {addr_from}
         for dref in self.data_refs:
             self.disassembly.addDataRefs(dref[0], dref[1])
         if self.is_recursive:

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -4,24 +4,26 @@ LOGGER = logging.getLogger(__name__)
 
 # Dalvik-specific lists for block derivation
 # Any invoke-* is a call
-CALL_INS = [
-    "invoke-virtual",
-    "invoke-super",
-    "invoke-direct",
-    "invoke-static",
-    "invoke-interface",
-    "invoke-virtual/range",
-    "invoke-super/range",
-    "invoke-direct/range",
-    "invoke-static/range",
-    "invoke-interface/range",
-    "invoke-polymorphic",
-    "invoke-polymorphic/range",
-    "invoke-custom",
-    "invoke-custom/range",
-]
+CALL_INS = frozenset(
+    [
+        "invoke-virtual",
+        "invoke-super",
+        "invoke-direct",
+        "invoke-static",
+        "invoke-interface",
+        "invoke-virtual/range",
+        "invoke-super/range",
+        "invoke-direct/range",
+        "invoke-static/range",
+        "invoke-interface/range",
+        "invoke-polymorphic",
+        "invoke-polymorphic/range",
+        "invoke-custom",
+        "invoke-custom/range",
+    ]
+)
 # Any return-* or throw is an end instruction
-END_INS = ["return-void", "return", "return-wide", "return-object", "throw"]
+END_INS = frozenset(["return-void", "return", "return-wide", "return-object", "throw"])
 
 
 class DalvikFunctionAnalysisState:
@@ -213,32 +215,33 @@ class DalvikFunctionAnalysisState:
         if self.blocks:
             return self.blocks
         self.instructions.sort()
-        ins = {i[0]: ind for ind, i in enumerate(self.instructions)}
+        instructions = self.instructions
+        last_index = len(instructions) - 1
+        code_refs_from = self.code_refs_from
+        code_refs_to = self.code_refs_to
+        ins = {i[0]: ind for ind, i in enumerate(instructions)}
         potential_starts = {self.start_addr}
-        potential_starts.update(list(self.jump_targets))
+        potential_starts.update(self.jump_targets)
         potential_starts.update(self.block_starts)
         blocks = []
         for start in sorted(potential_starts):
             if start not in ins:
                 continue
             block = []
-            for i in range(ins[start], len(self.instructions)):
-                current = self.instructions[i]
+            for i in range(ins[start], last_index + 1):
+                current = instructions[i]
                 block.append(current)
+                is_last = i == last_index
+                next_ins_addr = -1 if is_last else instructions[i + 1][0]
+                refs_from = code_refs_from.get(current[0])
+                if refs_from is not None and current[2] not in CALL_INS and not is_last:
+                    num_refs_from = len(refs_from)
+                    if num_refs_from > 1 or (num_refs_from == 1 and next_ins_addr not in refs_from):
+                        break
                 if (
-                    current[0] in self.code_refs_from
-                    and current[2] not in CALL_INS
-                    and i != len(self.instructions) - 1
-                    and any(r != self.instructions[i + 1][0] for r in self.code_refs_from[current[0]])
-                ):
-                    break
-                if (
-                    i != len(self.instructions) - 1
-                    and self.instructions[i + 1][0] in self.code_refs_to
-                    and (
-                        len(self.code_refs_to[self.instructions[i + 1][0]]) > 1
-                        or self.instructions[i + 1][0] in potential_starts
-                    )
+                    not is_last
+                    and next_ins_addr in code_refs_to
+                    and (next_ins_addr in potential_starts or len(code_refs_to[next_ins_addr]) > 1)
                 ):
                     break
                 if current[2] in END_INS:

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -851,6 +851,38 @@ _OPCODE_DECODE: Dict[int, tuple] = {
 }
 
 
+def _null_resolve(ref_kind, ref_index):
+    return ""
+
+
+def decode_instruction_shallow(bytecode, byte_idx):
+    """Return ``(size_bytes, payload_idx)`` without building a full decoded instruction.
+
+    The linear start sweep consumes only those two fields, but paid for operand formatting,
+    register lists and reference resolution at every offset of the bytecode. The validity
+    checks below are the same three, in the same order, so this raises ValueError on exactly
+    the offsets decode_instruction rejects. Where an opcode declares a payload the real format
+    decoder still produces the target, so payload_idx cannot drift from the full decode.
+    """
+    opcode_value = bytecode[byte_idx]
+    entry = _OPCODE_DECODE.get(opcode_value)
+    if entry is None:
+        raise ValueError(f"Unknown Dalvik opcode 0x{opcode_value:02x}")
+    opcode, decoder = entry
+
+    size_bytes = opcode.size_units * 2
+    if byte_idx + size_bytes > len(bytecode):
+        raise ValueError("Truncated Dalvik instruction")
+
+    if decoder is None:
+        raise ValueError(f"Unsupported Dalvik format {opcode.fmt}")
+
+    if not opcode.payload_kind:
+        return size_bytes, None
+    raw_bytes = bytes(bytecode[byte_idx : byte_idx + size_bytes])
+    return size_bytes, decoder(raw_bytes, byte_idx, opcode, _null_resolve).get("payload_idx")
+
+
 def decode_instruction(bytecode, byte_idx, resolve_ref):
     opcode_value = bytecode[byte_idx]
     entry = _OPCODE_DECODE.get(opcode_value)

--- a/src/smda/dalvik/DalvikOpcodeDecoder.py
+++ b/src/smda/dalvik/DalvikOpcodeDecoder.py
@@ -843,19 +843,27 @@ def _decode_fmt_51l(raw_bytes, byte_idx, opcode, resolve_ref):
 FORMAT_DECODERS["51l"] = _decode_fmt_51l
 
 
+# the format decoder is resolved once here rather than per decoded instruction, so the hot path
+# does one int-keyed probe instead of two probes plus a string-keyed lookup; an opcode whose
+# format has no decoder keeps a None and still raises at decode time, exactly as before
+_OPCODE_DECODE: Dict[int, tuple] = {
+    value: (opcode, FORMAT_DECODERS.get(opcode.fmt)) for value, opcode in OPCODES.items()
+}
+
+
 def decode_instruction(bytecode, byte_idx, resolve_ref):
     opcode_value = bytecode[byte_idx]
-    if opcode_value not in OPCODES:
+    entry = _OPCODE_DECODE.get(opcode_value)
+    if entry is None:
         raise ValueError(f"Unknown Dalvik opcode 0x{opcode_value:02x}")
+    opcode, decoder = entry
 
-    opcode = OPCODES[opcode_value]
     size_bytes = opcode.size_units * 2
     if byte_idx + size_bytes > len(bytecode):
         raise ValueError("Truncated Dalvik instruction")
 
     raw_bytes = bytes(bytecode[byte_idx : byte_idx + size_bytes])
 
-    decoder = FORMAT_DECODERS.get(opcode.fmt)
     if decoder is None:
         raise ValueError(f"Unsupported Dalvik format {opcode.fmt}")
 

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -37,6 +37,18 @@ _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
 # still admitting its one strong signal (0x55 "push ebp/rbp", scored 51/33).
 _ENTRY_SHAPE_MIN_SCORE = 30
 
+# Written as `A(BA)+B` rather than the equivalent `(AB){2,}` so the pattern starts with a literal:
+# only then does the regex engine emit a prefix fast-search instead of entering the matcher at
+# every offset of the mapped image.
+_RE_STUB_BLOCK = re.compile(b"\xff\x25(?:.{4}\xff\x25)+.{4}", re.DOTALL)
+_RE_STUB_ENTRY = re.compile(b"\xff\x25(?P<function>.{4})", re.DOTALL)
+_RE_PLT_BLOCK = re.compile(b"\xff\x25(?:.{4}\x68.{4}\xe9.{4}\xff\x25)+.{4}\x68.{4}\xe9.{4}", re.DOTALL)
+_RE_PLTSEC_BLOCK = re.compile(
+    b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?:.{4}\x0f\x1f\x44\x00\x00\xf3\x0f\x1e\xfa\xf2\xff\x25)+.{4}\x0f\x1f\x44\x00\x00",
+    re.DOTALL,
+)
+_RE_PLTSEC_ENTRY = re.compile(b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?P<function>.{4})", re.DOTALL)
+
 
 class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
@@ -396,8 +408,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
 
     def locateStubChainCandidates(self):
         # binaries often contain long sequences of stubs, consisting only of jmp dword ptr <offset>, add such chains as candidates
-        for block in re.finditer(b"(?P<block>(\xff\x25[\\S\\s]{4}){2,})", self.disassembly.binary_info.binary):
-            for match in re.finditer(b"\xff\x25(?P<function>[\\S\\s]{4})", block.group("block")):
+        for block in _RE_STUB_BLOCK.finditer(self.disassembly.binary_info.binary):
+            for match in _RE_STUB_ENTRY.finditer(block.group(0)):
                 stub_addr = self.disassembly.binary_info.base_addr + block.start() + match.start()
                 if not self._passesCodeFilter(stub_addr):
                     continue
@@ -407,11 +419,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 if stub_addr_masked in self.candidates:
                     self.candidates[stub_addr_masked].setIsStub(True)
         # structure for plt entries is similar but interleaved with additional code not considered functions
-        for block in re.finditer(
-            b"(?P<block>(\xff\x25[\\S\\s]{4}\x68[\\S\\s]{4}\xe9[\\S\\s]{4}){2,})",
-            self.disassembly.binary_info.binary,
-        ):
-            for match in re.finditer(b"\xff\x25(?P<function>[\\S\\s]{4})", block.group("block")):
+        for block in _RE_PLT_BLOCK.finditer(self.disassembly.binary_info.binary):
+            for match in _RE_STUB_ENTRY.finditer(block.group(0)):
                 stub_addr = self.disassembly.binary_info.base_addr + block.start() + match.start()
                 if not self._passesCodeFilter(stub_addr):
                     continue
@@ -440,14 +449,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         .plt.sec:000000000000CF74                                           ; ---------------------------------------------------------------------------
         .plt.sec:000000000000CF7B 0F 1F 44 00 00                                            align 20h
         """
-        for block in re.finditer(
-            b"(?P<block>(\xf3\x0f\x1e\xfa\xf2\xff\x25[\\S\\s]{4}\x0f\x1f\x44\x00\x00){2,})",
-            self.disassembly.binary_info.binary,
-        ):
-            for match in re.finditer(
-                b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?P<function>[\\S\\s]{4})",
-                block.group("block"),
-            ):
+        for block in _RE_PLTSEC_BLOCK.finditer(self.disassembly.binary_info.binary):
+            for match in _RE_PLTSEC_ENTRY.finditer(block.group(0)):
                 stub_addr = self.disassembly.binary_info.base_addr + block.start() + match.start()
                 if not self._passesCodeFilter(stub_addr):
                     continue

--- a/src/smda/intel/IntelInstructionEscaper.py
+++ b/src/smda/intel/IntelInstructionEscaper.py
@@ -44,6 +44,8 @@ _COND_JUMP_MNEMONICS = frozenset(
     }
 )
 _ALL_JUMP_MNEMONICS = _JUMP_CALL_MNEMONICS | _COND_JUMP_MNEMONICS
+_IMMEDIATE_RE = re.compile(r"0x[0-9a-fA-F]{1,16}")
+_PTR_REF_RE = re.compile(r"\[(rip (\+|\-) )?(?P<dword_offset>0x[a-fA-F0-9]+)\]")
 
 
 class IntelInstructionEscaper:
@@ -2167,10 +2169,11 @@ class IntelInstructionEscaper:
     @classmethod
     def _getPrefixLen(cls, ins_bytes):
         prefixes = cls._PREFIXES
-        return next(
-            (i for i in range(0, len(ins_bytes), 2) if ins_bytes[i : i + 2] not in prefixes),
-            len(ins_bytes),
-        )
+        length = len(ins_bytes)
+        index = 0
+        while index < length and ins_bytes[index : index + 2] in prefixes:
+            index += 2
+        return index
 
     @staticmethod
     def escapeToOpcodeOnly(ins):
@@ -2200,34 +2203,38 @@ class IntelInstructionEscaper:
     @staticmethod
     def escapeBinary(ins, escape_intraprocedural_jumps=False, lower_addr=None, upper_addr=None):
         escaped_sequence = ins.bytes
-        mnemonic = ins.mnemonic.split(" ")[-1]
+        mnemonic = ins.mnemonic
+        if " " in mnemonic:
+            mnemonic = mnemonic.rpartition(" ")[2]
         # remove segment, operand, address, repeat override prefixes
-        if mnemonic in _JUMP_CALL_MNEMONICS or mnemonic in _COND_JUMP_MNEMONICS:
-            escaped_sequence = IntelInstructionEscaper.escapeBinaryJumpCall(ins, escape_intraprocedural_jumps)
+        if mnemonic in _ALL_JUMP_MNEMONICS:
+            return IntelInstructionEscaper.escapeBinaryJumpCall(ins, escape_intraprocedural_jumps)
+        operands = ins.operands
+        # every test below needs "0x" as a substring, and capstone emits lowercase hex only
+        if "0x" not in operands:
             return escaped_sequence
-        if "ptr [0x" in ins.operands or "[rip + 0x" in ins.operands or "[rip - 0x" in ins.operands:
+        if "ptr [0x" in operands or "[rip + 0x" in operands or "[rip - 0x" in operands:
             escaped_sequence = IntelInstructionEscaper.escapeBinaryPtrRef(ins)
         if (
             lower_addr is not None
+            and lower_addr > 0x00100000
             and upper_addr is not None
-            and (
-                ins.operands.startswith("0x")
-                or ", 0x" in ins.operands
-                or "+ 0x" in ins.operands
-                or "- 0x" in ins.operands
-            )
+            and (operands.startswith("0x") or ", 0x" in operands or "+ 0x" in operands or "- 0x" in operands)
         ):
-            immediates = []
-            for immediate_match in re.finditer(r"0x[0-9a-fA-F]{1,16}", ins.operands):
+            for immediate_match in _IMMEDIATE_RE.finditer(operands):
                 immediate = int(immediate_match.group()[2:], 16)
-                if lower_addr > 0x00100000 and lower_addr <= immediate < upper_addr:
-                    immediates.append(immediate)
+                if lower_addr <= immediate < upper_addr:
                     escaped_sequence = IntelInstructionEscaper.escapeBinaryValue(ins, escaped_sequence, immediate)
         return escaped_sequence
 
     @staticmethod
     def escapeBinaryJumpCall(ins, escape_intraprocedural_jumps=False):
-        clean_bytes = IntelInstructionEscaper.getByteWithoutPrefixes(ins)
+        ins_bytes = ins.bytes
+        prefixes = IntelInstructionEscaper._PREFIXES
+        prefix_len = 0
+        while prefix_len < len(ins_bytes) and ins_bytes[prefix_len : prefix_len + 2] in prefixes:
+            prefix_len += 2
+        clean_bytes = ins_bytes[prefix_len:]
         if escape_intraprocedural_jumps and (clean_bytes.startswith(("7", "e0", "e1", "e2", "e3", "eb"))):
             return ins.bytes[:-2] + "??"
         if escape_intraprocedural_jumps and clean_bytes.startswith("0f8"):
@@ -2259,7 +2266,7 @@ class IntelInstructionEscaper:
     @staticmethod
     def escapeBinaryPtrRef(ins):
         escaped_sequence = ins.bytes
-        addr_match = re.search(r"\[(rip (\+|\-) )?(?P<dword_offset>0x[a-fA-F0-9]+)\]", ins.operands)
+        addr_match = _PTR_REF_RE.search(ins.operands)
         if addr_match:
             offset = int(addr_match.group("dword_offset"), 16)
             disp_size = 4

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -6,6 +6,10 @@ from smda.intel.definitions import RET_INS
 
 LOGGER = logging.getLogger(__name__)
 
+_DIRECT_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, dword ptr \[[^ ]+ \+ 0x[0-9a-f]+\]")
+_X64_LEA_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, \[rip (\+|\-) 0x[0-9a-f]+\]")
+_X64_BONUS_OFFSET_RE = re.compile(r"[a-z0-9]{2,3},.*0x[0-9a-f]+\]")
+
 
 class JumpTableAnalyzer:
     """Perform jump table handling.
@@ -78,7 +82,7 @@ class JumpTableAnalyzer:
         data_ref_instruction_addr = None
         off_jumptable = None
         for instr in backtracked[::-1]:
-            if instr[2] == "mov" and re.match(r"[a-z0-9]{2,3}, dword ptr \[[^ ]+ \+ 0x[0-9a-f]+\]", instr[3]):
+            if instr[2] == "mov" and _DIRECT_TABLE_RE.match(instr[3]):
                 data_ref_instruction_addr = instr[0]
                 off_jumptable = self.disassembler.getReferencedAddr(instr[3])
                 state.addDataRef(data_ref_instruction_addr, off_jumptable, size=4)
@@ -95,7 +99,7 @@ class JumpTableAnalyzer:
     def _x64Handler(self, state, backtracked, target_register=None):
         off_jumptable = None
         for instr in backtracked[::-1]:
-            if instr[2] == "lea" and re.match(r"[a-z0-9]{2,3}, \[rip (\+|\-) 0x[0-9a-f]+\]", instr[3]):
+            if instr[2] == "lea" and _X64_LEA_TABLE_RE.match(instr[3]):
                 if target_register and target_register not in instr[3]:
                     continue
                 data_ref_instruction_addr = instr[0]
@@ -110,7 +114,7 @@ class JumpTableAnalyzer:
     def _getx64BonusOffset(self, backtracked):
         bonus_offset = 0
         for instr in backtracked[::-1][:3]:
-            if instr[2] == "mov" and re.match(r"[a-z0-9]{2,3},.*0x[0-9a-f]+\]", instr[3]):
+            if instr[2] == "mov" and _X64_BONUS_OFFSET_RE.match(instr[3]):
                 bonus_offset = self.disassembler.getReferencedAddr(instr[3])
                 break
         return bonus_offset

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -102,6 +102,22 @@ INT80_EXIT_NUMBERS = {1, 252}  # exit, exit_group
 _TRAP_TERMINATOR_INS = frozenset({"int3", "hlt"})
 _SYSCALL_INS = frozenset({"syscall"})
 
+_KIND_CALL, _KIND_JMP, _KIND_LOOP, _KIND_CJMP, _KIND_RET, _KIND_TRAP, _KIND_SYSCALL = range(7)
+_KIND_TABLES = (
+    (CALL_INS, _KIND_CALL),
+    (JMP_INS, _KIND_JMP),
+    (LOOP_INS, _KIND_LOOP),
+    (CJMP_INS, _KIND_CJMP),
+    (RET_INS, _KIND_RET),
+    (_TRAP_TERMINATOR_INS, _KIND_TRAP),
+    (_SYSCALL_INS, _KIND_SYSCALL),
+)
+# one lookup replaces the membership chain that 77% of instructions fell all the way through;
+# collapsing to a single dict is only valid while the tables stay disjoint
+_INS_KIND = {mnemonic: kind for table, kind in _KIND_TABLES for mnemonic in table}
+if len(_INS_KIND) != sum(len(table) for table, _ in _KIND_TABLES):
+    raise AssertionError("intel control-flow mnemonic tables overlap")
+
 
 class X86Backend(ArchBackend):
     """x86/x64 backend: capstone setup, x86 collaborators and the x86 control-flow
@@ -255,7 +271,9 @@ class X86Backend(ArchBackend):
     def _analyzeCondJmpInstruction(self, d, i, state):
         i_address, i_size, i_mnemonic, i_op_str = i
         state.addBlockToQueue(i_address + i_size)
-        jump_destination = d.getReferencedAddr(i_op_str)
+        # capstone always prints a bare "0x..." rel8/rel32 target here, which the queue and the
+        # code ref below already parsed with int(op_str, 16); one parse serves all three
+        jump_destination = int(i_op_str, 16)
         # case = "FALLTHROUGH"
         d.tailcall_analyzer.addJump(i_address, jump_destination)
         if jump_destination:
@@ -268,17 +286,17 @@ class X86Backend(ArchBackend):
                 pass
             else:
                 # case = "OFFSET-QUEUE"
-                state.addBlockToQueue(int(i_op_str, 16))
-            state.addCodeRef(i_address, int(i_op_str, 16), by_jump=True)
+                state.addBlockToQueue(jump_destination)
+            state.addCodeRef(i_address, jump_destination, by_jump=True)
         state.setBlockEndingInstruction(True)
 
     def _analyzeLoopInstruction(self, d, i, state):
         i_address, i_size, i_mnemonic, i_op_str = i
-        jump_destination = d.getReferencedAddr(i_op_str)
+        jump_destination = int(i_op_str, 16)
         if jump_destination:
             # loops are conditional branches: queue the taken edge as well
             state.addBlockToQueue(jump_destination)
-            state.addCodeRef(i_address, int(i_op_str, 16), by_jump=True)
+            state.addCodeRef(i_address, jump_destination, by_jump=True)
         # loops have two exits and should thus be handled as block ending instruction
         state.addBlockToQueue(i_address + i_size)
         state.setBlockEndingInstruction(True)
@@ -309,7 +327,7 @@ class X86Backend(ArchBackend):
             if dereferenced is not None:
                 self._handleApiJumpTarget(d, state, i_address, jump_destination, dereferenced)
         elif i_op_str.startswith("0x"):
-            jump_destination = d.getReferencedAddr(i_op_str)
+            jump_destination = int(i_op_str, 16)
             d.tailcall_analyzer.addJump(i_address, jump_destination)
             if jump_destination in d.disassembly.functions:
                 # case = "TAILCALL!"
@@ -327,8 +345,8 @@ class X86Backend(ArchBackend):
                     pass
                 else:
                     # case = "OFFSET-QUEUE"
-                    state.addBlockToQueue(int(i_op_str, 16))
-            state.addCodeRef(i_address, int(i_op_str, 16), by_jump=True)
+                    state.addBlockToQueue(jump_destination)
+            state.addCodeRef(i_address, jump_destination, by_jump=True)
         else:
             self._collectMemRegSlot(state, i_address, i_op_str)
             jumptable_targets = d.jumptable_analyzer.getJumpTargets(i, state)
@@ -410,23 +428,26 @@ class X86Backend(ArchBackend):
         i_address, i_size, i_mnemonic, i_op_str = i
         if previous_instruction is not None:
             previous_address = previous_instruction[0]
-            previous_mnemonic = previous_instruction[2].split(" ")[-1]
-            previous_op_str = previous_instruction[3].strip()
+            previous_mnemonic = previous_instruction[2]
+            if " " in previous_mnemonic:
+                previous_mnemonic = previous_mnemonic.rpartition(" ")[2]
         else:
             previous_address = None
             previous_mnemonic = None
-            previous_op_str = None
         # remove potential "bnd" prefix
-        i_mnemonic_noprefix = i_mnemonic.split(" ")[-1]
-        if i_mnemonic_noprefix in CALL_INS:
+        i_mnemonic_noprefix = i_mnemonic
+        if " " in i_mnemonic_noprefix:
+            i_mnemonic_noprefix = i_mnemonic_noprefix.rpartition(" ")[2]
+        i_kind = _INS_KIND.get(i_mnemonic_noprefix)
+        if i_kind == _KIND_CALL:
             self._analyzeCallInstruction(d, i, state)
-        elif i_mnemonic_noprefix in JMP_INS:
+        elif i_kind == _KIND_JMP:
             self._analyzeJmpInstruction(d, i, state)
-        elif i_mnemonic_noprefix in LOOP_INS:
+        elif i_kind == _KIND_LOOP:
             self._analyzeLoopInstruction(d, i, state)
-        elif i_mnemonic_noprefix in CJMP_INS:
+        elif i_kind == _KIND_CJMP:
             self._analyzeCondJmpInstruction(d, i, state)
-        elif i_mnemonic_noprefix.startswith("j"):
+        elif i_kind is None and i_mnemonic_noprefix.startswith("j"):
             LOGGER.error(
                 "unsupported jump @0x%08x (0x%08x): %s %s",
                 i_address,
@@ -435,7 +456,7 @@ class X86Backend(ArchBackend):
                 i_op_str,
             )
             # we do not analyze any potential exception handler (tricks), so treat breakpoints as exit condition
-        elif i_mnemonic_noprefix in RET_INS:
+        elif i_kind == _KIND_RET:
             self._analyzeEndInstruction(state)
             if LOGGER.isEnabledFor(logging.DEBUG):
                 LOGGER.debug(
@@ -443,7 +464,7 @@ class X86Backend(ArchBackend):
                     i_address,
                 )
             if previous_address is not None and previous_mnemonic == "push":
-                push_ret_destination = d.getReferencedAddr(previous_op_str)
+                push_ret_destination = d.getReferencedAddr(previous_instruction[3].strip())
                 if d.disassembly.isAddrWithinMemoryImage(push_ret_destination):
                     LOGGER.debug(
                         "  analyzeFunction() found push-return jump obfuscation: @0x%08x",
@@ -451,14 +472,14 @@ class X86Backend(ArchBackend):
                     )
                     state.addBlockToQueue(push_ret_destination)
                     state.addCodeRef(i_address, push_ret_destination, by_jump=True)
-        elif i_mnemonic_noprefix in _TRAP_TERMINATOR_INS:
+        elif i_kind == _KIND_TRAP:
             self._analyzeEndInstruction(state)
             if LOGGER.isEnabledFor(logging.DEBUG):
                 LOGGER.debug(
                     "  analyzeFunction() found ending instruction @0x%08x",
                     i_address,
                 )
-        elif i_mnemonic_noprefix in _SYSCALL_INS:
+        elif i_kind == _KIND_SYSCALL:
             syscall_number = self._resolveSyscallNumber(state.current_block, d.disassembly.binary_info.bitness)
             if syscall_number in SYSCALL_EXIT_NUMBERS:
                 self._analyzeEndInstruction(state)

--- a/src/smda/utility/BatchProcessor.py
+++ b/src/smda/utility/BatchProcessor.py
@@ -2,7 +2,8 @@ import json
 import logging
 import os
 import traceback
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
+from contextlib import ExitStack
 from multiprocessing import get_context
 
 from smda.Disassembler import Disassembler
@@ -10,6 +11,22 @@ from smda.SmdaConfig import SmdaConfig
 from smda.utility.common import computeReportIdentityHash
 
 LOGGER = logging.getLogger(__name__)
+
+DEFAULT_LARGE_INPUT_BYTES = 1 << 20
+# peak worker RSS observed for an analysis, expressed per byte of input
+LARGE_INPUT_RSS_FACTOR = 500
+MEMORY_BUDGET_FRACTION = 0.5
+
+
+def getMemoryBudget():
+    """Bytes of RSS the large-input partition may occupy, or None where the platform hides RAM size."""
+    sysconf = getattr(os, "sysconf", None)
+    if sysconf is None:
+        return None
+    try:
+        return int(sysconf("SC_PAGE_SIZE") * sysconf("SC_PHYS_PAGES") * MEMORY_BUDGET_FRACTION)
+    except (ValueError, OSError):
+        return None
 
 
 def getDefaultWorkerCount():
@@ -100,6 +117,80 @@ def collectInputFiles(paths, input_root=None):
     return sorted(collected)
 
 
+def _inputSize(path):
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def _largeWorkerCount(largest_input_bytes, task_count, worker_count, memory_budget):
+    budget = getMemoryBudget() if memory_budget is None else memory_budget
+    capacity = task_count
+    if budget:
+        capacity = budget // max(1, largest_input_bytes * LARGE_INPUT_RSS_FACTOR)
+    return max(1, min(worker_count, task_count, capacity))
+
+
+def _runPartitions(partitions):
+    """Drive the given (tasks, workers, max_tasks_per_child) pools, yielding summaries as they land.
+
+    Each pool holds at most twice its worker count of tasks in flight, so the parent's own
+    memory stays proportional to the workers rather than to the size of the corpus.
+    """
+    with ExitStack() as stack:
+        streams = []
+        for tasks, worker_count, max_tasks_per_child in partitions:
+            executor = stack.enter_context(
+                ProcessPoolExecutor(
+                    max_workers=worker_count,
+                    # spawn is the strictest context: it re-imports, which proves the task function is
+                    # importable and the payload picklable instead of relying on a forked address space
+                    mp_context=get_context("spawn"),
+                    initializer=_initWorker,
+                    initargs=(logging.getLogger().level,),
+                    max_tasks_per_child=max_tasks_per_child,
+                )
+            )
+            streams.append((executor, iter(tasks), set(), 2 * worker_count))
+
+        owners = {}
+        while True:
+            for executor, pending_tasks, in_flight, limit in streams:
+                while len(in_flight) < limit:
+                    task = next(pending_tasks, None)
+                    if task is None:
+                        break
+                    future = executor.submit(_analyzeOneFile, task)
+                    in_flight.add(future)
+                    owners[future] = (task, in_flight)
+            if not owners:
+                return
+            done, _ = wait(list(owners), return_when=FIRST_COMPLETED)
+            # wait() returns a set; order the batch by path so a rerun yields summaries identically
+            for future in sorted(done, key=lambda finished: owners[finished][0]["path"]):
+                task, in_flight = owners.pop(future)
+                in_flight.discard(future)
+                try:
+                    yield future.result()
+                except Exception as exc:
+                    # a worker that was OOM-killed or died inside capstone/LIEF surfaces here as
+                    # BrokenProcessPool instead of hanging the run
+                    LOGGER.error("Worker failed for %s: %r", task["path"], exc)
+                    yield {
+                        "path": task["path"],
+                        "report_stem": task["report_stem"],
+                        "status": "error",
+                        "output_path": None,
+                        "num_functions": 0,
+                        "num_instructions": 0,
+                        "report_hash": "",
+                        "execution_time": 0.0,
+                        "error": f"{type(exc).__name__}: {exc}",
+                        "report": None,
+                    }
+
+
 def disassembleParallel(
     paths,
     output_dir=None,
@@ -109,6 +200,9 @@ def disassembleParallel(
     max_tasks_per_child=None,
     return_reports=False,
     input_root=None,
+    collected=None,
+    large_input_bytes=DEFAULT_LARGE_INPUT_BYTES,
+    memory_budget=None,
 ):
     """Disassemble many files across processes, yielding one summary dict per completed file.
 
@@ -116,6 +210,11 @@ def disassembleParallel(
     exception: a nonzero SmdaConfig.TIMEOUT is wall-clock, so under oversubscription a slow
     sample can time out where a serial run finished. Pass timeout=0 for load-independent
     output.
+
+    Peak worker RSS scales with input size, so inputs of at least large_input_bytes are run on
+    a separate pool whose concurrency is capped by memory_budget (bytes, defaulting to a
+    fraction of physical RAM) and whose workers are recycled after every file. Pass an already
+    collected list of (path, report_stem) pairs to avoid walking the input tree twice.
 
     Reports are written in the worker and only a small summary is returned, because shipping
     whole reports back through the parent makes deserialization the bottleneck. Pass
@@ -126,58 +225,48 @@ def disassembleParallel(
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
 
-    collected = collectInputFiles(paths, input_root=input_root)
-    tasks = []
+    if collected is None:
+        collected = collectInputFiles(paths, input_root=input_root)
+    small_tasks = []
+    large_tasks = []
+    largest_input_bytes = 0
     for path, report_stem in collected:
         # resume is decided here, in the parent, so the set of finished reports is never
         # embedded into every task payload
         if resume and output_dir and os.path.exists(os.path.join(output_dir, report_stem + ".smda")):
             LOGGER.debug("Skipping %s, report already exists", path)
             continue
-        tasks.append(
-            {
-                "path": path,
-                "report_stem": report_stem,
-                "output_dir": output_dir,
-                "timeout": timeout,
-                "return_reports": return_reports,
-            }
-        )
+        task = {
+            "path": path,
+            "report_stem": report_stem,
+            "output_dir": output_dir,
+            "timeout": timeout,
+            "return_reports": return_reports,
+        }
+        size = _inputSize(path)
+        if size >= large_input_bytes:
+            large_tasks.append(task)
+            largest_input_bytes = max(largest_input_bytes, size)
+        else:
+            small_tasks.append(task)
 
-    if not tasks:
+    if not small_tasks and not large_tasks:
         return
 
     worker_count = workers if workers > 0 else getDefaultWorkerCount()
-    worker_count = max(1, min(worker_count, len(tasks)))
+    worker_count = max(1, min(worker_count, len(small_tasks) + len(large_tasks)))
 
-    with ProcessPoolExecutor(
-        max_workers=worker_count,
-        # spawn is the strictest context: it re-imports, which proves the task function is
-        # importable and the payload picklable instead of relying on a forked address space
-        mp_context=get_context("spawn"),
-        initializer=_initWorker,
-        initargs=(logging.getLogger().level,),
+    partitions = []
+    large_workers = 0
+    if large_tasks and worker_count > 1:
+        # the second pool must not push total concurrency past the requested worker count
+        reserved = 1 if small_tasks else 0
+        large_workers = _largeWorkerCount(largest_input_bytes, len(large_tasks), worker_count - reserved, memory_budget)
+        partitions.append((large_tasks, large_workers, 1))
+    else:
+        small_tasks = large_tasks + small_tasks
+    if small_tasks:
+        small_workers = max(1, min(worker_count - large_workers, len(small_tasks)))
         # None is the ProcessPoolExecutor default: a worker lives as long as the executor
-        max_tasks_per_child=max_tasks_per_child,
-    ) as executor:
-        futures = {executor.submit(_analyzeOneFile, task): task for task in tasks}
-        for future in as_completed(futures):
-            task = futures[future]
-            try:
-                yield future.result()
-            except Exception as exc:
-                # a worker that was OOM-killed or died inside capstone/LIEF surfaces here as
-                # BrokenProcessPool instead of hanging the run
-                LOGGER.error("Worker failed for %s: %r", task["path"], exc)
-                yield {
-                    "path": task["path"],
-                    "report_stem": task["report_stem"],
-                    "status": "error",
-                    "output_path": None,
-                    "num_functions": 0,
-                    "num_instructions": 0,
-                    "report_hash": "",
-                    "execution_time": 0.0,
-                    "error": f"{type(exc).__name__}: {exc}",
-                    "report": None,
-                }
+        partitions.append((small_tasks, small_workers, max_tasks_per_child))
+    yield from _runPartitions(partitions)

--- a/src/smda/utility/BatchProcessor.py
+++ b/src/smda/utility/BatchProcessor.py
@@ -8,7 +8,7 @@ from multiprocessing import get_context
 
 from smda.Disassembler import Disassembler
 from smda.SmdaConfig import SmdaConfig
-from smda.utility.common import computeReportIdentityHash
+from smda.utility.common import computeReportDictIdentityHash
 
 LOGGER = logging.getLogger(__name__)
 
@@ -80,11 +80,14 @@ def _analyzeOneFile(task):
         summary["num_functions"] = report.num_functions
         summary["num_instructions"] = report.num_instructions
         summary["execution_time"] = report.execution_time
-        summary["report_hash"] = computeReportIdentityHash(report)
+        # one toDict() serves both the identity hash and the file, instead of building the
+        # whole report dict twice
+        as_dict = report.toDict()
+        summary["report_hash"] = computeReportDictIdentityHash(as_dict)
         if task["output_dir"]:
             output_path = os.path.join(task["output_dir"], task["report_stem"] + ".smda")
             with open(output_path, "w", encoding="utf-8") as f_out:
-                json.dump(report.toDict(), f_out, indent=1, sort_keys=True)
+                f_out.write(json.dumps(as_dict, indent=1, sort_keys=True))
             summary["output_path"] = output_path
         if task["return_reports"]:
             summary["report"] = report

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -238,14 +238,17 @@ class ElfFileLoader:
                     rva + section.size,
                     section.virtual_address,
                 )
-                # potentially perform zero padding if we have less content than section size
-                content_to_be_mapped = bytearray(section.content)
-                if len(section.content) < section.size:
-                    content_to_be_mapped += b"\x00" * (section.size - len(section.content))
                 # clamp to the remaining capacity so both sides of the assignment have the same
                 # length and a section extending past the sized buffer cannot grow it
                 copy_size = min(section.size, max(0, len(mapped_binary) - rva))
-                mapped_binary[rva : rva + copy_size] = content_to_be_mapped[:copy_size]
+                content = section.content
+                if len(content) >= section.size:
+                    mapped_binary[rva : rva + copy_size] = content[:copy_size]
+                else:
+                    # potentially perform zero padding if we have less content than section size
+                    content_to_be_mapped = bytearray(content)
+                    content_to_be_mapped += b"\x00" * (section.size - len(content))
+                    mapped_binary[rva : rva + copy_size] = content_to_be_mapped[:copy_size]
 
     @staticmethod
     def mapBinary(binary, parsed=_NOT_PROVIDED):

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -1,7 +1,6 @@
 import contextlib
 import logging
 import sys
-from functools import lru_cache
 
 import lief
 
@@ -79,7 +78,6 @@ def align(v, alignment):
         return v + (alignment - remainder)
 
 
-@lru_cache(maxsize=16)
 def has_bogus_sections(elffile, base_addr=0):
     max_virtual_address = 0
     for section in elffile.sections:
@@ -88,7 +86,6 @@ def has_bogus_sections(elffile, base_addr=0):
     return (max_virtual_address - base_addr) > sys.maxsize
 
 
-@lru_cache(maxsize=16)
 def _calculate_base_address(elffile):
     base_addr = 0
     candidates = [0xFFFFFFFFFFFFFFFF]
@@ -113,12 +110,10 @@ def _calculate_base_address(elffile):
     return base_addr
 
 
-@lru_cache(maxsize=16)
 def _get_sorted_sections(elffile):
     return sorted(elffile.sections, key=lambda section: section.size, reverse=True)
 
 
-@lru_cache(maxsize=16)
 def _get_boundaries(elffile, base_addr=0):
     # find min and max virtual addresses.
     max_virtual_address = 0

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -1,6 +1,5 @@
 import logging
 import struct
-from functools import lru_cache
 
 from smda.SmdaConfig import SmdaConfig
 from smda.utility.common import mergeCodeAreas
@@ -86,17 +85,14 @@ def align(v, alignment):
         return v + (alignment - remainder)
 
 
-@lru_cache(maxsize=16)
 def _get_sorted_sections(macho_file):
     return sorted(macho_file.sections, key=lambda section: section.size, reverse=True)
 
 
-@lru_cache(maxsize=16)
 def _get_sorted_segments(macho_file):
     return sorted(macho_file.segments, key=lambda segment: segment.file_size, reverse=True)
 
 
-@lru_cache(maxsize=16)
 def _calculate_base_address(macho_file):
     base_addr = 0
     if not macho_file:
@@ -115,7 +111,6 @@ def _calculate_base_address(macho_file):
     return base_addr
 
 
-@lru_cache(maxsize=16)
 def _calculate_boundaries(macho_file):
     # find min and max virtual addresses.
     max_virtual_address = 0

--- a/src/smda/utility/common.py
+++ b/src/smda/utility/common.py
@@ -8,9 +8,12 @@ def computeReportIdentityHash(report, exclude=("timestamp", "execution_time")):
     Covers the CFG, per-function hashes, statistics, xrefs and xmetadata in one number, because
     all of them are serialized inside toDict().
     """
-    as_dict = report.toDict()
-    for field in exclude:
-        as_dict.pop(field, None)
+    return computeReportDictIdentityHash(report.toDict(), exclude=exclude)
+
+
+def computeReportDictIdentityHash(report_dict, exclude=("timestamp", "execution_time")):
+    """Same hash for a caller that already has the serialized dict and would else rebuild it."""
+    as_dict = {key: value for key, value in report_dict.items() if key not in exclude}
     serialized = json.dumps(as_dict, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 

--- a/tests/testAArch64Dataflow.py
+++ b/tests/testAArch64Dataflow.py
@@ -2,6 +2,7 @@ import unittest
 
 from capstone import CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN, Cs
 
+from smda.aarch64.AArch64Backend import _hasDataRefImmediate
 from smda.aarch64.dataflow import propagateConstants
 
 
@@ -115,6 +116,28 @@ class AArch64DataflowTestSuite(unittest.TestCase):
         constants = propagateConstants(instructions, _NoImageDisassembler())
 
         self.assertEqual(constants.get("x1"), 0x100)
+
+
+class DataRefImmediateGateTestSuite(unittest.TestCase):
+    """The gate that decides whether _recordDataRefs re-decodes an instruction for details."""
+
+    IN_IMAGE = lambda self, value: False  # noqa: E731
+
+    def test_operands_without_an_immediate_marker_are_rejected_outright(self):
+        self.assertFalse(_hasDataRefImmediate("x0, x1", 0x1000, 0x2000, self.IN_IMAGE))
+
+    def test_immediate_inside_the_image_and_outside_code_areas_is_accepted(self):
+        self.assertTrue(_hasDataRefImmediate("x0, #0x1500", 0x1000, 0x2000, self.IN_IMAGE))
+
+    def test_immediate_outside_the_image_is_rejected(self):
+        self.assertFalse(_hasDataRefImmediate("x0, #0x9000", 0x1000, 0x2000, self.IN_IMAGE))
+
+    def test_immediate_inside_a_code_area_is_rejected(self):
+        self.assertFalse(_hasDataRefImmediate("x0, #0x1500", 0x1000, 0x2000, lambda value: True))
+
+    def test_a_token_int_cannot_parse_is_skipped_rather_than_raising(self):
+        # base 0 rejects a leading zero, so "#08" reaches the ValueError arm
+        self.assertTrue(_hasDataRefImmediate("x0, #08, #0x1500", 0x1000, 0x2000, self.IN_IMAGE))
 
 
 if __name__ == "__main__":

--- a/tests/testBatchProcessor.py
+++ b/tests/testBatchProcessor.py
@@ -217,14 +217,20 @@ class TestPartitionDriver(unittest.TestCase):
 
 class TestLargePartitionSizing(unittest.TestCase):
     def test_budget_is_a_fraction_of_physical_memory(self):
-        self.assertGreater(getMemoryBudget(), 0)
+        # os.sysconf is POSIX-only; on Windows the budget is unknown by design and the
+        # worker count alone governs admission
+        if hasattr(os, "sysconf"):
+            self.assertGreater(getMemoryBudget(), 0)
+        else:
+            self.assertIsNone(getMemoryBudget())
 
     def test_budget_is_unknown_without_sysconf(self):
-        with mock.patch.object(os, "sysconf", None):
+        # create=True so this also runs where the attribute never existed
+        with mock.patch.object(os, "sysconf", None, create=True):
             self.assertIsNone(getMemoryBudget())
 
     def test_budget_is_unknown_when_sysconf_rejects_the_key(self):
-        with mock.patch.object(os, "sysconf", side_effect=ValueError):
+        with mock.patch.object(os, "sysconf", side_effect=ValueError, create=True):
             self.assertIsNone(getMemoryBudget())
 
     def test_budget_caps_concurrency_below_the_worker_count(self):

--- a/tests/testBatchProcessor.py
+++ b/tests/testBatchProcessor.py
@@ -3,15 +3,22 @@ import os
 import shutil
 import tempfile
 import unittest
+from concurrent.futures import Future
+from unittest import mock
 
 import pytest
 
 from smda.SmdaConfig import SmdaConfig
 from smda.utility.BatchProcessor import (
+    LARGE_INPUT_RSS_FACTOR,
+    _inputSize,
+    _largeWorkerCount,
+    _runPartitions,
     collectInputFiles,
     deriveReportStem,
     disassembleParallel,
     getDefaultWorkerCount,
+    getMemoryBudget,
 )
 
 pytestmark = pytest.mark.slow
@@ -116,6 +123,119 @@ class TestBatchProcessor(unittest.TestCase):
 
     def test_default_worker_count_is_positive(self):
         self.assertGreaterEqual(getDefaultWorkerCount(), 1)
+
+    def test_splitting_large_inputs_onto_their_own_pool_does_not_change_output(self):
+        _, pooled = self._run(workers=4)
+        _, split = self._run(workers=4, large_input_bytes=64 * 1024, memory_budget=1 << 30)
+        self.assertEqual(set(pooled), set(split))
+        for stem in pooled:
+            self.assertEqual(pooled[stem]["report_hash"], split[stem]["report_hash"], stem)
+
+    def test_a_single_worker_keeps_large_inputs_on_the_one_pool(self):
+        _, serial = self._run(workers=1)
+        _, split = self._run(workers=1, large_input_bytes=64 * 1024)
+        for stem in serial:
+            self.assertEqual(serial[stem]["report_hash"], split[stem]["report_hash"], stem)
+
+    def test_collected_pairs_are_reused_instead_of_rewalking_the_tree(self):
+        collected = collectInputFiles([self.input_root])
+        summaries = list(disassembleParallel([], workers=1, timeout=0, collected=collected[:1]))
+        self.assertEqual([collected[0][1]], [summary["report_stem"] for summary in summaries])
+
+    def test_vanished_input_is_sized_as_small(self):
+        self.assertEqual(0, _inputSize(os.path.join(self.tmp_dir, "does_not_exist")))
+
+
+class _ScriptedExecutor:
+    """Stands in for ProcessPoolExecutor so the parent-side wave loop can be driven without
+    spawning workers. A task whose path ends in 'boom' resolves to a raised exception."""
+
+    instances = []
+
+    def __init__(self, max_workers=None, **kwargs):
+        self.max_workers = max_workers
+        self.peak_in_flight = 0
+        self.submitted = []
+        _ScriptedExecutor.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def submit(self, _func, task):
+        self.submitted.append(task["path"])
+        future = Future()
+        if task["path"].endswith("boom"):
+            future.set_exception(RuntimeError("worker died"))
+        else:
+            future.set_result({"path": task["path"], "status": "ok"})
+        return future
+
+
+class TestPartitionDriver(unittest.TestCase):
+    def setUp(self):
+        _ScriptedExecutor.instances = []
+
+    @staticmethod
+    def _task(path):
+        return {"path": path, "report_stem": os.path.basename(path)}
+
+    def _run(self, paths, workers=2):
+        tasks = [self._task(path) for path in paths]
+        with mock.patch("smda.utility.BatchProcessor.ProcessPoolExecutor", _ScriptedExecutor):
+            return list(_runPartitions([(tasks, workers, None)]))
+
+    def test_a_dead_worker_becomes_an_error_summary_instead_of_aborting_the_run(self):
+        summaries = self._run(["/corpus/a", "/corpus/boom", "/corpus/b"])
+
+        by_path = {summary["path"]: summary for summary in summaries}
+        self.assertEqual({"/corpus/a", "/corpus/b", "/corpus/boom"}, set(by_path))
+        self.assertEqual("ok", by_path["/corpus/a"]["status"])
+        failed = by_path["/corpus/boom"]
+        self.assertEqual("error", failed["status"])
+        self.assertEqual("boom", failed["report_stem"])
+        self.assertEqual("RuntimeError: worker died", failed["error"])
+        self.assertIsNone(failed["report"])
+
+    def test_every_task_is_yielded_once_when_the_corpus_exceeds_the_in_flight_limit(self):
+        paths = [f"/corpus/{index:02d}" for index in range(20)]
+
+        summaries = self._run(paths, workers=2)
+
+        self.assertEqual(paths, sorted(summary["path"] for summary in summaries))
+        self.assertEqual(len(paths), len(summaries))
+
+    def test_a_batch_is_yielded_in_path_order(self):
+        paths = ["/corpus/c", "/corpus/a", "/corpus/b"]
+
+        summaries = self._run(paths, workers=8)
+
+        self.assertEqual(["/corpus/a", "/corpus/b", "/corpus/c"], [summary["path"] for summary in summaries])
+
+
+class TestLargePartitionSizing(unittest.TestCase):
+    def test_budget_is_a_fraction_of_physical_memory(self):
+        self.assertGreater(getMemoryBudget(), 0)
+
+    def test_budget_is_unknown_without_sysconf(self):
+        with mock.patch.object(os, "sysconf", None):
+            self.assertIsNone(getMemoryBudget())
+
+    def test_budget_is_unknown_when_sysconf_rejects_the_key(self):
+        with mock.patch.object(os, "sysconf", side_effect=ValueError):
+            self.assertIsNone(getMemoryBudget())
+
+    def test_budget_caps_concurrency_below_the_worker_count(self):
+        budget = 2 * (1 << 20) * LARGE_INPUT_RSS_FACTOR
+        self.assertEqual(2, _largeWorkerCount(1 << 20, 8, 10, budget))
+
+    def test_unknown_budget_leaves_the_worker_count_in_charge(self):
+        self.assertEqual(4, _largeWorkerCount(1 << 20, 8, 4, 0))
+
+    def test_one_worker_survives_an_unaffordable_input(self):
+        self.assertEqual(1, _largeWorkerCount(1 << 30, 8, 10, 1))
 
 
 class TestCollectInputFilesRoots(unittest.TestCase):

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -242,6 +242,48 @@ class TestCommonModels(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     SmdaFunction.fromDict(candidate)
 
+    def test_block_refs_are_resorted_when_a_handler_target_is_not_a_block_start(self):
+        from smda.DisassemblyResult import DisassemblyResult
+
+        disassembly = DisassemblyResult()
+        # one block at 0x200; the handler target at 0x100 belongs to no block, so it is
+        # appended as a new key and the sorted order has to be restored
+        disassembly.functions[0x200] = [[(0x200, 2, "nop", "", b"\x00\x00")]]
+        disassembly.function_metadata[0x200] = {
+            "try_ranges": [{"start_addr": 0x200, "end_addr": 0x202, "handlers": [{"target_addr": 0x100}]}]
+        }
+
+        block_refs = disassembly.getBlockRefs(0x200)
+
+        self.assertEqual([0x100, 0x200], list(block_refs))
+        self.assertEqual([], block_refs[0x100])
+        self.assertEqual([0x100], block_refs[0x200])
+
+    def test_block_refs_keep_seeded_order_when_no_handler_target_is_added(self):
+        from smda.DisassemblyResult import DisassemblyResult
+
+        disassembly = DisassemblyResult()
+        disassembly.functions[0x100] = [[(0x100, 2, "jmp", "0x200", b"\x00\x00")], [(0x200, 2, "ret", "", b"\x00\x00")]]
+        disassembly.code_refs_from[0x100] = {0x200}
+
+        block_refs = disassembly.getBlockRefs(0x100)
+
+        self.assertEqual([0x100, 0x200], list(block_refs))
+        self.assertEqual([0x200], block_refs[0x100])
+
+    def test_hash_sequences_fall_back_to_raw_bytes_without_an_escaper(self):
+        # an unsupported architecture leaves _escaper None; both sequences must still be emitted
+        function = SmdaFunction()
+        function.blocks = {
+            0x100: [SmdaInstruction([0x100, "5589e5", "push", "ebp"])],
+            0x200: [SmdaInstruction([0x200, "c3", "ret", ""])],
+        }
+        function._sorted_block_keys = [0x100, 0x200]
+
+        self.assertIsNone(function._escaper)
+        self.assertEqual(b"5589e5c3", function.getPicHashSequence(None))
+        self.assertEqual(b"5589e5c3", function.getOpcHashSequence())
+
     def test_function_hash_helpers_use_little_endian(self):
         function = SmdaFunction()
         function.pic_hash = 0x0102030405060708

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -7,13 +7,17 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.SmdaFunction import SmdaFunction
 from smda.common.SmdaReport import SmdaReport
 from smda.dalvik.DalvikOpcodeDecoder import (
+    _OPCODE_DECODE,
     OPCODES,
+    _null_resolve,
     decode_instruction,
+    decode_instruction_shallow,
     parse_code_item_header,
     read_sleb128,
     read_uleb128,
@@ -1133,6 +1137,28 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         self.assertIn(first_off + 16, found)
         self.assertIn(second_off + 16, found)
 
+    def test_orphan_scan_stops_at_the_decode_attempt_cap(self):
+        """The cap bounds work on adversarial data; it must actually cut the scan short."""
+        from smda.dalvik.DalvikDisassembler import DalvikDisassembler
+
+        code_item = build_code_item(bytes.fromhex("0e00"))
+        header = bytearray(build_dex_header(version=b"039", file_size=0x300, data_off=0x100, data_size=0x200))
+        raw = bytearray(0x300)
+        raw[:0x70] = header[:0x70]
+        for offset in (0x100, 0x120):
+            raw[offset : offset + len(code_item)] = code_item
+        struct.pack_into("<I", raw, 0x20, len(raw))
+        struct.pack_into("<I", raw, 0x68, 0x200)
+        struct.pack_into("<I", raw, 0x6C, 0x100)
+
+        disassembler = DalvikDisassembler(config)
+        uncapped = disassembler._discoverOrphanCodeItems(bytes(raw), known_code_offsets=set())
+        disassembler._MAX_ORPHAN_DECODE_ATTEMPTS = 1
+        capped = disassembler._discoverOrphanCodeItems(bytes(raw), known_code_offsets=set())
+
+        self.assertEqual(2, len(uncapped))
+        self.assertEqual(1, len(capped))
+
     def testOrphanWithSwitchPayloadAccepted(self):
         """An orphan body with packed-switch + payload must not be rejected."""
         from smda.dalvik.DalvikDisassembler import DalvikDisassembler
@@ -1318,6 +1344,54 @@ class DalvikAuditRegressionTestSuite(unittest.TestCase):
             disassembler._parseCallSiteItem(-1),
             {"offset": -1, "values": [], "display": "call_site@off=-1"},
         )
+
+
+class ShallowDecodeEquivalenceTestSuite(unittest.TestCase):
+    """The start sweep uses a shallow decode; it must accept and size exactly what the full
+    decode does, or recovered instruction starts move."""
+
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(os.path.dirname(__file__), "blockblast_classes_xored")
+        with open(path, "rb") as f_binary:
+            raw = f_binary.read()
+        cls.dex = bytes(byte ^ (index % 256) for index, byte in enumerate(raw))
+
+    def test_shallow_matches_full_decode_at_every_offset(self):
+        null_resolve = lambda ref_kind, ref_index: ""  # noqa: E731
+        payload_sites = 0
+        for index in range(len(self.dex)):
+            try:
+                full = decode_instruction(self.dex, index, null_resolve)
+            except ValueError:
+                with self.assertRaises(ValueError, msg=f"offset {index}"):
+                    decode_instruction_shallow(self.dex, index)
+                continue
+            self.assertEqual(
+                (full.size_bytes, full.payload_idx),
+                decode_instruction_shallow(self.dex, index),
+                f"offset {index}",
+            )
+            if full.payload_idx is not None:
+                payload_sites += 1
+        # the payload branch is the one place the shallow path still runs a format decoder
+        self.assertGreater(payload_sites, 0)
+
+
+class ShallowDecodeContractTestSuite(unittest.TestCase):
+    def test_the_sweep_resolver_resolves_nothing(self):
+        self.assertEqual("", _null_resolve("type", 0))
+
+    def test_a_format_without_a_decoder_is_rejected_by_both_decoders(self):
+        opcode, _decoder = _OPCODE_DECODE[0x0E]
+        bytecode = b"\x0e\x00\x00\x00"
+        patched = dict(_OPCODE_DECODE)
+        patched[0x0E] = (opcode, None)
+        with mock.patch.dict(_OPCODE_DECODE, patched, clear=True):
+            with self.assertRaises(ValueError):
+                decode_instruction_shallow(bytecode, 0)
+            with self.assertRaises(ValueError):
+                decode_instruction(bytecode, 0, _null_resolve)
 
 
 if __name__ == "__main__":

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -1112,6 +1112,27 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         found = disassembler._discoverOrphanCodeItems(bytes(raw), known_code_offsets=set())
         self.assertIn(orphan_header_off + 16, found)
 
+    def testSecondOrphanFoundAfterTheFirstClaimsItsRange(self):
+        """Accepting an orphan re-sorts the claimed intervals; the scan must keep finding later ones."""
+        from smda.dalvik.DalvikDisassembler import DalvikDisassembler
+
+        code_item = build_code_item(bytes.fromhex("0e00"))
+        header = bytearray(build_dex_header(version=b"039", file_size=0x300, data_off=0x100, data_size=0x200))
+        raw = bytearray(0x300)
+        raw[:0x70] = header[:0x70]
+        first_off, second_off = 0x100, 0x120
+        raw[first_off : first_off + len(code_item)] = code_item
+        raw[second_off : second_off + len(code_item)] = code_item
+        struct.pack_into("<I", raw, 0x20, len(raw))
+        struct.pack_into("<I", raw, 0x68, 0x200)
+        struct.pack_into("<I", raw, 0x6C, 0x100)
+
+        disassembler = DalvikDisassembler(config)
+        found = disassembler._discoverOrphanCodeItems(bytes(raw), known_code_offsets=set())
+
+        self.assertIn(first_off + 16, found)
+        self.assertIn(second_off + 16, found)
+
     def testOrphanWithSwitchPayloadAccepted(self):
         """An orphan body with packed-switch + payload must not be rejected."""
         from smda.dalvik.DalvikDisassembler import DalvikDisassembler

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -209,5 +209,29 @@ class DalvikRevertAnalysisTestSuite(unittest.TestCase):
         self.assertEqual(disassembly.thunk_functions, set())
 
 
+class CilBlockCollisionTestSuite(unittest.TestCase):
+    def test_fall_through_into_a_colliding_address_drops_the_code_ref(self):
+        state = CilFunctionAnalysisState(0x100, 0x100, None)
+        state.addInstruction(0x100, 2, "br", "", b"\x00\x00")
+        state.addInstruction(0x110, 1, "ret", "", b"\x00")
+        state.colliding_addresses.add(0x102)
+
+        self.assertIn((0x100, 0x102), state.code_refs)
+
+        blocks = state.getBlocks()
+
+        self.assertNotIn((0x100, 0x102), state.code_refs)
+        self.assertEqual([[0x100]], [[ins[0] for ins in block] for block in blocks])
+
+    def test_a_reference_to_the_next_instruction_alone_keeps_the_block_open(self):
+        state = CilFunctionAnalysisState(0x100, 0x100, None)
+        state.addInstruction(0x100, 2, "br", "", b"\x00\x00")
+        state.addInstruction(0x102, 1, "ret", "", b"\x00")
+
+        blocks = state.getBlocks()
+
+        self.assertEqual([[0x100, 0x102]], [[ins[0] for ins in block] for block in blocks])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -107,6 +107,8 @@ class _RecordingDisassembly:
         self.recursive_functions = set()
         self.leaf_functions = set()
         self.thunk_functions = set()
+        self.code_refs_from = {}
+        self.code_refs_to = {}
 
     def addCodeRefs(self, addr_from, addr_to):
         pass
@@ -207,6 +209,35 @@ class DalvikRevertAnalysisTestSuite(unittest.TestCase):
         self.assertEqual(disassembly.leaf_functions, set())
         self.assertEqual(disassembly.recursive_functions, set())
         self.assertEqual(disassembly.thunk_functions, set())
+
+
+class FunctionBorderTestSuite(unittest.TestCase):
+    """Instructions reach finalize in analysis order, which is not address order."""
+
+    def test_cil_borders_span_the_lowest_and_highest_instruction(self):
+        disassembly = _RecordingDisassembly()
+        state = CilFunctionAnalysisState(0x200, 0x200, disassembly)
+        state.addInstruction(0x200, 1, "nop", "", b"\x00")
+        state.addInstruction(0x100, 2, "nop", "", b"\x00\x00")
+        state.addInstruction(0x300, 4, "ret", "", b"\x2a")
+
+        state.finalizeAnalysis()
+
+        self.assertEqual((0x100, 0x304), disassembly.function_borders[0x200])
+
+    def test_dalvik_borders_span_the_lowest_and_highest_instruction(self):
+        disassembly = _RecordingDisassembly()
+        disassembly.function_metadata = {}
+        state = DalvikFunctionAnalysisState(0x200, disassembly)
+        state.label = "Lfoo;->bar()V"
+        state.addInstruction(0x200, 2, "nop", "", b"\x00\x00")
+        state.addInstruction(0x100, 2, "nop", "", b"\x00\x00")
+        state.addInstruction(0x300, 2, "return-void", "", b"\x0e\x00")
+        state.endBlock()
+
+        state._finalizeRegularAnalysis()
+
+        self.assertEqual((0x100, 0x302), disassembly.function_borders[0x200])
 
 
 class CilBlockCollisionTestSuite(unittest.TestCase):

--- a/tests/testGoSymbolProvider.py
+++ b/tests/testGoSymbolProvider.py
@@ -1,10 +1,42 @@
 import pathlib
+import random
 import struct
 import unittest
 from types import SimpleNamespace
 
+import lief
+
 from smda.common.BinaryInfo import BinaryInfo
-from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
+from smda.common.labelprovider.GoLabelProvider import (
+    _PCLNTAB_HEADER_RE,
+    GoSymbolProvider,
+    findPcLntabHeaderOffsets,
+)
+
+_ELF_PCLNTAB_OFFSET = 64
+
+
+def _build_elf_with_gopclntab(pclntab):
+    """Smallest ELF64 lief will parse that carries a named .gopclntab section."""
+    shstr = b"\x00.gopclntab\x00.shstrtab\x00"
+    ehsize, shent = 64, 64
+    pcl_off = ehsize
+    shstr_off = pcl_off + len(pclntab)
+    shoff = (shstr_off + len(shstr) + 7) & ~7
+    header = bytearray(ehsize)
+    header[0:4] = b"\x7fELF"
+    header[4], header[5], header[6] = 2, 1, 1
+    struct.pack_into("<HHIQQQIHHHHHH", header, 16, 2, 62, 1, 0, 0, shoff, 0, ehsize, 56, 0, shent, 3, 2)
+    out = bytearray(header) + pclntab + shstr
+    out += b"\x00" * (shoff - len(out))
+
+    def section(name_offset, section_type, offset, size, addr=0):
+        return struct.pack("<IIQQQQIIQQ", name_offset, section_type, 0, addr, offset, size, 0, 0, 1, 0)
+
+    out += section(0, 0, 0, 0)
+    out += section(shstr.index(b".gopclntab"), 1, pcl_off, len(pclntab), 0x400000)
+    out += section(shstr.index(b".shstrtab"), 3, shstr_off, len(shstr))
+    return bytes(out)
 
 
 def _build_truncated_pclntab_116_64():
@@ -319,6 +351,90 @@ class TestGoProviderCapabilities(unittest.TestCase):
         self.assertFalse(provider.isApiProvider())
         self.assertTrue(provider.isSymbolProvider())
         self.assertEqual(provider.getApi(0x401000), ("", ""))
+
+
+class PcLntabHeaderScanTestSuite(unittest.TestCase):
+    """The anchored scan must accept exactly the offsets the header pattern itself matches."""
+
+    @staticmethod
+    def _reference(data):
+        return [match.start() for match in _PCLNTAB_HEADER_RE.finditer(data)]
+
+    def test_both_endian_spellings_are_found(self):
+        little = b"\xfa\xff\xff\xff\x00\x00\x01\x08"
+        big = b"\xff\xff\xff\xfa\x00\x00\x01\x08"
+        for header in (little, big):
+            with self.subTest(header=header.hex()):
+                data = b"\x90" * 32 + header + b"\x90" * 32
+                self.assertEqual([32], findPcLntabHeaderOffsets(data))
+                self.assertEqual(self._reference(data), findPcLntabHeaderOffsets(data))
+
+    def test_a_bare_anchor_run_is_not_a_header(self):
+        # the literal anchor alone must not be accepted without the rest of the shape
+        data = b"\xff" * 64
+        self.assertEqual([], findPcLntabHeaderOffsets(data))
+        self.assertEqual(self._reference(data), findPcLntabHeaderOffsets(data))
+
+    def test_an_anchor_at_offset_zero_does_not_probe_before_the_buffer(self):
+        data = b"\xff\xff\xff\xfb\x00\x00\x02\x04"
+        self.assertEqual([0], findPcLntabHeaderOffsets(data))
+
+    def test_matches_the_pattern_on_the_bundled_go_corpus(self):
+        corpus = pathlib.Path(__file__).parent / "go_corpus"
+        checked = 0
+        for path in sorted(corpus.rglob("*")):
+            if not path.is_file():
+                continue
+            data = path.read_bytes()
+            self.assertEqual(self._reference(data), findPcLntabHeaderOffsets(data), str(path))
+            checked += 1
+        self.assertGreater(checked, 0)
+
+    def test_matches_the_pattern_on_adversarial_random_buffers(self):
+        rng = random.Random(1234)
+        alphabet = bytes([0x00, 0x01, 0x02, 0x04, 0x08, 0xF0, 0xF1, 0xFA, 0xFB, 0xFF])
+        for _ in range(2000):
+            data = bytes(rng.choice(alphabet) for _ in range(rng.randint(0, 40)))
+            self.assertEqual(self._reference(data), findPcLntabHeaderOffsets(data), data.hex())
+
+
+class PcLntabRejectionTestSuite(unittest.TestCase):
+    """Malformed headers must be rejected rather than parsed as Go metadata."""
+
+    def test_header_with_bad_padding_quantum_or_pointer_size_is_rejected(self):
+        provider = GoSymbolProvider(None)
+        for label, quantum, ptr, pad in (
+            ("padding", 1, 8, b"\x01\x00"),
+            ("quantum", 3, 8, b"\x00\x00"),
+            ("pointer size", 1, 6, b"\x00\x00"),
+        ):
+            with self.subTest(field=label):
+                buf = struct.pack("<I", 0xFFFFFFFA) + pad + bytes([quantum, ptr]) + b"\x00" * 32
+                self.assertIsNone(provider._readPcLntabHeader(buf, 0))
+
+    def test_a_32_bit_table_is_parsed_rather_than_rejected(self):
+        # pointer size 4 selects the 32-bit field widths for the whole table
+        buf = struct.pack("<I", 0xFFFFFFFB) + b"\x00\x00\x01\x04" + struct.pack("<I", 0) + b"\x00" * 64
+
+        self.assertEqual({}, GoSymbolProvider(None)._parse_pclntab(0, buf))
+
+    def test_unrecognized_bitness_marker_raises(self):
+        provider = GoSymbolProvider(None)
+        # valid version marker, but a pointer size that is neither 4 nor 8
+        buf = struct.pack("<I", 0xFFFFFFFA) + b"\x00\x00\x01\x06" + b"\x00" * 64
+        with self.assertRaises(ValueError):
+            provider._parse_pclntab(0, buf)
+
+    def test_elf_gopclntab_section_offset_is_preferred_over_the_scan(self):
+        header = struct.pack("<I", 0xFFFFFFFA) + b"\x00\x00\x01\x08"
+        data = _build_elf_with_gopclntab(header + b"\x00" * 64)
+        lief_elf = lief.parse(data)
+        binary_info = SimpleNamespace(binary=data, getLiefBinary=lambda: lief_elf)
+
+        provider = GoSymbolProvider(None)
+
+        # the section header names the table directly, so the whole-image scan is not needed
+        self.assertEqual(_ELF_PCLNTAB_OFFSET, provider.getPcLntabOffset(binary_info))
 
 
 if __name__ == "__main__":

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -1082,5 +1082,69 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertEqual(fc_manager.added_candidates, [align_addr])
 
 
+class _StubChainCandidateManager(FunctionCandidateManager):
+    """Drives locateStubChainCandidates without the init/queue machinery: the real block
+    regexes, address arithmetic and data_map bookkeeping run, only candidate creation is
+    recorded."""
+
+    BASE_ADDR = 0x400000
+
+    def __init__(self, binary):
+        self.bitness = 64
+        self._code_areas = []
+        self.candidates = {}
+        self.recovered = []
+        self.disassembly = SimpleNamespace(
+            binary_info=SimpleNamespace(binary=binary, base_addr=self.BASE_ADDR),
+            data_map=set(),
+        )
+
+    def ensureCandidate(self, addr):
+        self.recovered.append(addr)
+        return True
+
+
+class StubChainCandidateTestSuite(unittest.TestCase):
+    PAD = b"\x00" * 16
+
+    def _locate(self, chain):
+        manager = _StubChainCandidateManager(self.PAD + chain + self.PAD)
+        manager.locateStubChainCandidates()
+        return manager
+
+    def test_jmp_stub_chain_yields_one_candidate_per_entry(self):
+        chain = b"\xff\x25\x11\x22\x33\x44" + b"\xff\x25\x55\x66\x77\x88"
+
+        manager = self._locate(chain)
+
+        base = _StubChainCandidateManager.BASE_ADDR + len(self.PAD)
+        self.assertEqual([base, base + 6], manager.recovered)
+
+    def test_plt_chain_yields_one_candidate_per_entry_and_marks_the_interleaved_bytes(self):
+        entry = b"\xff\x25\x11\x22\x33\x44\x68\x00\x00\x00\x00\xe9\x00\x00\x00\x00"
+        chain = entry + entry
+
+        manager = self._locate(chain)
+
+        base = _StubChainCandidateManager.BASE_ADDR + len(self.PAD)
+        self.assertEqual([base, base + 16], manager.recovered)
+        self.assertTrue(set(range(base + 6, base + 16)).issubset(manager.disassembly.data_map))
+
+    def test_plt_sec_chain_yields_one_candidate_per_endbr64_guarded_entry(self):
+        entry = b"\xf3\x0f\x1e\xfa\xf2\xff\x25\x11\x22\x33\x44\x0f\x1f\x44\x00\x00"
+        chain = entry + entry
+
+        manager = self._locate(chain)
+
+        base = _StubChainCandidateManager.BASE_ADDR + len(self.PAD)
+        self.assertEqual([base, base + 16], manager.recovered)
+        self.assertTrue(set(range(base + 7, base + 12)).issubset(manager.disassembly.data_map))
+
+    def test_a_lone_stub_is_not_a_chain(self):
+        manager = self._locate(b"\xff\x25\x11\x22\x33\x44")
+
+        self.assertEqual([], manager.recovered)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -199,3 +199,21 @@ class TestJumpTableSignedness(unittest.TestCase):
             jumptable_size=4, off_jumptable=0x2000, alternative_base=None, bonus_offset=0
         )
         self.assertEqual(result, [0x1000])
+
+
+class X64BonusOffsetTestSuite(unittest.TestCase):
+    def test_bonus_offset_taken_from_the_first_matching_mov(self):
+        analyzer = _makeAnalyzer(bitness=64)
+        analyzer.disassembler.getReferencedAddr.return_value = 0x140
+        backtracked = [
+            ("ignored", 0, "lea", "rax, [rip + 0x10]"),
+            (0x2000, 7, "mov", "eax, dword ptr [rcx + rax*4 + 0x140]"),
+        ]
+
+        self.assertEqual(0x140, analyzer._getx64BonusOffset(backtracked))
+
+    def test_no_bonus_offset_without_a_matching_mov(self):
+        analyzer = _makeAnalyzer(bitness=64)
+        backtracked = [(0x2000, 3, "add", "rax, rcx")]
+
+        self.assertEqual(0, analyzer._getx64BonusOffset(backtracked))

--- a/tests/testLanguageAnalyzer.py
+++ b/tests/testLanguageAnalyzer.py
@@ -282,12 +282,50 @@ class TestLanguageAnalyzer(unittest.TestCase):
 
         with mock.patch.object(analyzer, "getDelphiObjects", return_value={0x1000: "TObject"}):
             self.assertEqual(analyzer.getDelphiScore(), 0.6)
+
+        analyzer = LanguageAnalyzer(_DummyDisassembly(b"TObject"))
         with mock.patch.object(
             analyzer,
             "getDelphiObjects",
             return_value={address: f"TObject{address}" for address in range(5)},
         ):
             self.assertEqual(analyzer.getDelphiScore(), 0.9)
+
+
+class TestLanguageEvidenceMemoization(unittest.TestCase):
+    def test_delphi_score_is_stable_between_identify_and_check_delphi(self):
+        delphi_string = b"\x00\x00\x01\x0aABCDEFGHIJ\x00"
+        analyzer = LanguageAnalyzer(_DummyDisassembly(delphi_string * 101))
+
+        identified = analyzer.identify()
+
+        self.assertEqual(analyzer.getDelphiScore(), identified["delphi"])
+        self.assertEqual(analyzer.checkDelphi(), identified["delphi"] > 0.5)
+
+    def test_cpp_symbol_score_is_stable_between_identify_and_rescore(self):
+        analyzer = LanguageAnalyzer(_DummyDisassembly(b"\x00" * 32, functions={}))
+        binary = SimpleNamespace(
+            exported_functions=[],
+            exported_symbols=[],
+            symtab_symbols=[SimpleNamespace(name=f"_ZN4test{index}barEv") for index in range(3)],
+            dynamic_symbols=[],
+            symbols=[],
+        )
+        with (
+            mock.patch.object(analyzer.disassembly.binary_info, "getLiefBinary", return_value=binary),
+            mock.patch("smda.common.LanguageAnalyzer.get_active_macho_binary", return_value=binary),
+        ):
+            identified = analyzer.identify()
+            rescored = analyzer.rescore(dict(identified), 100)
+
+        self.assertEqual(rescored["c++"], identified["c++"])
+        self.assertEqual(analyzer.getCppSymbolScore()[0], identified["c++"])
+
+    def test_empty_string_scan_is_not_repeated(self):
+        analyzer = LanguageAnalyzer(_DummyDisassembly(b"\x00" * 32))
+
+        self.assertEqual(analyzer.getStrings(), [])
+        self.assertIs(analyzer.getStrings(), analyzer.strings)
 
 
 class TestDelphiHeuristics(unittest.TestCase):

--- a/tests/testTarjan.py
+++ b/tests/testTarjan.py
@@ -25,6 +25,14 @@ class TarjanTestSuite(unittest.TestCase):
         sccs = tarjan.getResult()
         self.assertEqual(1001, len(sccs))
 
+    def testSingleNodeGraphsYieldOneComponent(self):
+        """SmdaFunction._calculateSccs returns [[key]] for these without running Tarjan."""
+        for graph in ({0x100: []}, {0x100: [0x100]}):
+            with self.subTest(graph=graph):
+                tarjan = Tarjan(graph)
+                tarjan.calculateScc()
+                self.assertEqual([[0x100]], tarjan.getResult())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> **Stacked on #228.** This branch is cut from `fix/upstream-issues-2026-08-09`, so GitHub currently shows that PR's commits here as well. **The 11 commits below are the ones this PR asks you to review** — everything else belongs to #228 (which itself stacks on #227) and will disappear from this diff once #228 merges. Merge order: #227, then #228, then this.

## Summary

A profile-driven pass over the disassembly pipeline. Every change is a pure performance change: recovered functions, blocks and instructions are unchanged, and `computeReportIdentityHash` is byte-identical on every binary tested.

Against the branch point, primitive calls across the eight benchmark fixtures drop **9,673,670 → 6,420,772 (-33.6%)**. Against `master`, the same suite is **-33.3% primitive calls and -25.8% wall time** with identical function counts on all eight fixtures.

## The 11 commits

| | commit | change |
|---|---|---|
| `a41116c` | `perf(dalvik)` | skip dead claimed intervals in the orphan `code_item` scan (a quadratic) |
| `028192c` | `perf(intel)` | give the stub-chain block patterns a literal prefix so sre can fast-search |
| `2342547` | `perf(common)` | memoize the Delphi and C++ language evidence scores |
| `13bb5b3` | `perf(common)` | hoist loop invariants out of the block derivation loop |
| `33bb1c2` | `perf(utility)` | run large inputs on a memory-capped worker pool |
| `11ac7d9` | `perf(common)` | cut per-instruction call overhead out of the CFG and report paths |
| `3495f35` | `perf(intel)` | dispatch instructions by table and precompile the escaper regexes |
| `2ac224c` | `perf(cil)` | share one metadata parse and cut per-operand and per-opcode overhead |
| `74530dd` | `perf(labels)` | anchor the language scans and build each report dict once |
| `c581c65` | `perf(labels)` | find the pclntab header by literal anchor instead of scanning every offset |
| `05d322d` | `perf(loaders)` | drop the LIEF-keyed caches and shallow-decode the Dalvik start sweep |

Each commit body carries its own measurement and the argument for why it cannot move output.

## Motivation

The hot regions were taken from a cProfile run over all backends rather than picked by inspection, and the work falls into four recurring shapes:

- **Per-instruction call overhead.** `analyzeFunction` called four one-line state accessors per instruction; `addCodeRef` used `dict.get` where `k in d` compiles to a single `CONTAINS_OP` with no call; `getBlocks` re-read the same attributes and recomputed `len(...) - 1` every iteration.
- **Regex patterns that cannot fast-search.** The stub-chain and pclntab patterns both begin with an alternation, so the engine entered the matcher at every offset of the mapped image. Rewriting them to start with a literal lets sre emit a prefix search.
- **Work computed and then discarded.** The Dalvik start sweep decoded every offset in full — operand strings, register lists, reference resolution — and used two fields. The CIL module was parsed twice per analysis, once by the symbol provider and once by the disassembler.
- **A cache that cost more than the work.** Eight loader helpers were memoized with `lru_cache` keyed on a LIEF object. LIEF's `__hash__` is a deep visitor: measured on a real ELF, hashing costs 0.259 ms while the cached work — sorting the section list — costs 0.056 ms. Every cache *hit* was ~4.6x more expensive than recomputing.

## Changed behavior

None intended, and none observed. `DisassemblyResult.addCodeRefs` and `SmdaInstruction.getEscapedBinary` stay in place as public API; only the hot paths stop routing through them.

The one deliberate widening is in `BatchProcessor`: inputs at or above a size threshold now run on a separate pool whose concurrency is capped by a memory budget derived from physical RAM, with workers recycled per file. Peak worker RSS scales with input size, so a corpus mixing multi-megabyte binaries with small ones previously sized its whole pool for the worst case.

## Validation

Output identity, all at the default configuration:

- **8 benchmark fixtures** (intel, AArch64, Dalvik, CIL): identical `report_hash`, `num_functions`, `num_instructions`, `num_blocks`, and per-function block/instruction map.
- **251 real binaries** (the bundled malpedia corpus, 264 samples of which 251 analyse): **276,793 functions / 13,023,531 instructions / 2,220,554 basic blocks, zero delta, zero hash mismatches.** The 13 that do not analyse fail identically on both sides.
- **An 8.1 MB Go PE**: byte-identical report (8,687 functions), 23.1 s → 19.8 s.

Ground-truth accuracy, branch point vs this branch, identical to four decimals on every row:

| corpus | n | PPV | TPR | F1 |
|---|---|---|---|---|
| Plohmann malpedia:itw | 57 | 92.9279 | 98.4626 | 95.2799 |
| Bao msvc10-64 (O1+O2) | 34 | 99.1987 | 99.6863 | 99.4397 |
| Bao msvc10-32 (O1+O2) | 34 | 92.2314 | 99.1319 | 95.4390 |
| Bao_Dumped 64 (O1+O2) | 28 | 99.1068 | 97.6134 | 98.3496 |
| Bao_Dumped 32 (O1+O2) | 28 | 91.2758 | 98.8967 | 94.7985 |

Per-fixture speedup against `master`, same benchmark driver run against both trees:

| fixture | primitive calls | wall time |
|---|---|---|
| cutwail | 2,419,558 → 1,513,272 (-37.5%) | 250.9 → 219.7 ms |
| aarch64_static | 2,291,421 → 1,725,333 (-24.7%) | 248.0 → 194.2 ms |
| blockblast | 1,426,062 → 1,048,428 (-26.5%) | 204.0 → 121.1 ms |
| asprox | 1,153,625 → 709,086 (-38.5%) | 98.6 → 83.7 ms |
| njrat | 1,103,337 → 628,933 (-43.0%) | 65.7 → 46.4 ms |
| bashlite | 767,054 → 484,483 (-36.8%) | 144.0 → 82.7 ms |
| komplex | 461,157 → 309,611 (-32.9%) | 48.8 → 38.4 ms |
| **total** | **9,624,022 → 6,420,740 (-33.3%)** | **1060.7 → 786.7 ms (-25.8%)** |

Batch memory, measured on two binaries of 8.1 MB and 7.4 MB at two workers: aggregate peak child RSS **3.39 GiB → 2.55 GiB (-24.8%)** for +0.9% wall time, which is noise. A single 8.1 MB analysis peaks at ~2.5 GB, so an uncapped pool of ten workers can reach ~25 GB.

Gates:

```bash
python -m pytest tests/ -q          # 1143 passed, 1 skipped, 1473 subtests
python -m ruff check .              # clean
python -m ruff format --check .     # 223 files already formatted
python -m ty check src/smda/ fuzzing/ profiling/ .github/workflows/scripts/   # exit 0, no new errors
diff-cover coverage.xml --compare-branch=origin/master --fail-under=100       # 100%, 1137 lines
```

## Notes for review

Two rewrites are equivalences rather than refactors, and both are pinned by tests rather than argued:

- **pclntab scan.** Candidates are located by the literal `\xff\xff\xff` both alternatives share and then confirmed with the *same compiled pattern*, so the accepted set is identical by construction. Two matches of that pattern cannot overlap, so the non-overlapping `finditer` this replaces could not have returned a different count either — which matters because the caller only accepts a table when the scan yields exactly one hit. Checked against the old scan on a real 8.1 MB Go PE, 271 real binaries, and 4,000 randomized buffers.
- **Dalvik shallow decode.** The sweep's decoder performs the same three validity checks in the same order; where an opcode declares a payload the real format decoder still produces the target, gated on the opcode table's own `payload_kind` rather than a hardcoded format list. Equivalence is asserted over **all 247,668 offsets** of the bundled DEX — same accepted offsets, same size and payload, raising on exactly the same offsets — and that check is kept as a test.

`binweight` is serialized inside the report hash, so the report-materialization commit keeps it a float with a bit-identical value; that is deliberate and is why the sum is taken over raw byte lengths rather than halved hex lengths.

Diff coverage is 100%, which required covering several pre-existing branches this work touched: the ELF `.gopclntab` lookup, malformed-header rejection, the 32-bit pclntab path, the orphan decode-attempt cap, and the PLT and `.plt.sec` stub-chain shapes that no bundled fixture exercises.

## Not included

Three candidates from the same profile were deliberately left out, listed here so they are not mistaken for oversights:

- **An interval-based replacement for the byte-granular `code_map` / `ins2fn` indexes.** The surface is wide, and it should not land without an end-to-end CPU win demonstrated against the dict baseline rather than lower memory alone.
- **Switching the `DisassemblyResult` reference containers from sets to tuples.** A tuple iterates in insertion order where a set iterates in hash order, and report identity here is order-sensitive.
- **Releasing the byte maps before report materialization.** This measured only -1.7% peak RSS at 8 MB scale against -16% on the small fixtures, because freeing a dict returns memory to Python's allocator pools rather than to the OS. It also breaks post-analysis introspection through the retained `Disassembler.disassembly` handle, which an existing test relies on.
