### PR TITLE
fix: recover function starts lost to padding, alignment and jump-table heuristics

### DIFF
--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -152,7 +152,15 @@ class FunctionCandidateManager:
             if not (candidate.isFinished() or candidate.getScore() == 0):
                 if self.language_candidates_only and candidate.lang_spec is None:
                     continue
-                if self.identified_alignment and candidate.alignment < self.identified_alignment:
+                if (
+                    self.identified_alignment
+                    and candidate.alignment < self.identified_alignment
+                    and not candidate.is_exception_handler
+                ):
+                    # The alignment floor is inferred from where call-referenced candidates
+                    # happen to sit, so it only ever bounds a guess, and an exception record is
+                    # the image's own declaration of a function start. Symbols are declarations
+                    # too but are deliberately NOT exempt: measured, that costs true positives.
                     continue
                 yield candidate
 

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -157,10 +157,9 @@ class FunctionCandidateManager:
                     and candidate.alignment < self.identified_alignment
                     and not candidate.is_exception_handler
                 ):
-                    # The alignment floor is inferred from where call-referenced candidates
-                    # happen to sit, so it only ever bounds a guess, and an exception record is
-                    # the image's own declaration of a function start. Symbols are declarations
-                    # too but are deliberately NOT exempt: measured, that costs true positives.
+                    # The floor is inferred from call-referenced candidates, so it only bounds
+                    # a guess; an exception record is the image's own declaration. Exempting
+                    # symbols as well was measured to cost true positives -- do not widen this.
                     continue
                 yield candidate
 

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -49,6 +49,17 @@ _RE_PLTSEC_BLOCK = re.compile(
 )
 _RE_PLTSEC_ENTRY = re.compile(b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?P<function>.{4})", re.DOTALL)
 
+_PDATA_ENTRY_SIZE = 12
+_PDATA_MIN_ENTRIES = 16
+_PDATA_SEED_ENTRIES = 4
+# A sample only finds a table if it lands inside one with a whole seed window left, so this
+# must stay <= (_PDATA_MIN_ENTRIES - _PDATA_SEED_ENTRIES) * _PDATA_ENTRY_SIZE.
+_PDATA_SAMPLE_STRIDE = 128
+_PDATA_MAX_FUNCTION_SIZE = 0x100000
+# UNWIND_INFO byte 0 packs Version (bits 0-2, always 1) and Flags (bits 3-7), and only
+# EHANDLER/UHANDLER/CHAININFO are defined -- so just these eight byte values are legal.
+_UNWIND_INFO_FIRST_BYTES = frozenset(0x01 | (flags << 3) for flags in range(8))
+
 
 class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
@@ -483,7 +494,9 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             self.pdata_end_addresses = set()
             record_pdata_ends = self.config.USE_PE_X64_PDATA_ENDS
             base_addr = self.disassembly.binary_info.base_addr
+            has_sections = False
             for section_info in self.disassembly.binary_info.getSections():
+                has_sections = True
                 section_name, section_va_start, section_va_end = section_info
                 if section_name == ".pdata":
                     rva_start = section_va_start - self.disassembly.binary_info.base_addr
@@ -496,17 +509,103 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                         rva_function_candidate, _rva_function_end, rva_unwind_info = struct.unpack("<III", packed_entry)
                         if rva_function_candidate == 0:
                             break
-                        if self._isChainedUnwindInfo(rva_unwind_info):
-                            # UNW_FLAG_CHAININFO: this entry is a secondary fragment (e.g. a
-                            # split-off cold/epilogue chunk) chained to another function's
-                            # primary RUNTIME_FUNCTION entry, not an independent function start.
-                            continue
-                        self.addExceptionCandidate(base_addr + rva_function_candidate)
-                        if record_pdata_ends and _rva_function_end > rva_function_candidate:
-                            # record .pdata EndAddresses as candidate split points; skip degenerate
-                            # (EndAddress <= BeginAddress) entries and keep them as VAs.
-                            self.pdata_start_addresses.add(base_addr + rva_function_candidate)
-                            self.pdata_end_addresses.add(base_addr + _rva_function_end)
+                        self._admitExceptionRecord(
+                            base_addr,
+                            rva_function_candidate,
+                            _rva_function_end,
+                            rva_unwind_info,
+                            record_pdata_ends,
+                        )
+            if not has_sections:
+                self._carveExceptionRecords(base_addr, record_pdata_ends)
+
+    def _admitExceptionRecord(self, base_addr, rva_function_candidate, rva_function_end, rva_unwind_info, ends):
+        if self._isChainedUnwindInfo(rva_unwind_info):
+            # UNW_FLAG_CHAININFO: this entry is a secondary fragment (e.g. a
+            # split-off cold/epilogue chunk) chained to another function's
+            # primary RUNTIME_FUNCTION entry, not an independent function start.
+            return
+        self.addExceptionCandidate(base_addr + rva_function_candidate)
+        if ends and rva_function_end > rva_function_candidate:
+            # record .pdata EndAddresses as candidate split points; skip degenerate
+            # (EndAddress <= BeginAddress) entries and keep them as VAs.
+            self.pdata_start_addresses.add(base_addr + rva_function_candidate)
+            self.pdata_end_addresses.add(base_addr + rva_function_end)
+
+    def _readExceptionRecord(self, binary, size, offset, previous_end):
+        """returns a validated RUNTIME_FUNCTION triple at offset, or None."""
+        if offset + _PDATA_ENTRY_SIZE > size:
+            return None
+        rva_start, rva_end, rva_unwind_info = struct.unpack_from("<III", binary, offset)
+        # .pdata is sorted and its entries do not overlap, which is what makes a run of them
+        # separable from data that merely happens to hold three plausible RVAs.
+        if rva_start == 0 or rva_start >= rva_end or rva_end > size or rva_start < previous_end:
+            return None
+        if rva_end - rva_start > _PDATA_MAX_FUNCTION_SIZE:
+            return None
+        if rva_unwind_info == 0 or rva_unwind_info >= size or rva_unwind_info & 3:
+            return None
+        if binary[rva_unwind_info] not in _UNWIND_INFO_FIRST_BYTES:
+            return None
+        return rva_start, rva_end, rva_unwind_info
+
+    def _countExceptionRecords(self, binary, size, offset, limit):
+        count = 0
+        previous_end = 0
+        while count < limit:
+            record = self._readExceptionRecord(binary, size, offset, previous_end)
+            if record is None:
+                break
+            previous_end = record[1]
+            offset += _PDATA_ENTRY_SIZE
+            count += 1
+        return count
+
+    def _locateExceptionRecordTable(self, binary):
+        """returns (offset, count) of the longest RUNTIME_FUNCTION run, or (0, 0) if none qualifies."""
+        size = len(binary)
+        best_offset = best_count = 0
+        offset = 0
+        samples = 0
+        while offset + _PDATA_SEED_ENTRIES * _PDATA_ENTRY_SIZE <= size:
+            if samples % 4096 == 0 and self._candidateTimeoutTripped():
+                break
+            samples += 1
+            for phase in (0, 4, 8):
+                seed = offset + phase
+                if self._countExceptionRecords(binary, size, seed, _PDATA_SEED_ENTRIES) < _PDATA_SEED_ENTRIES:
+                    continue
+                # a sample lands anywhere inside the table, so walk back to its real first entry
+                start = seed
+                while start >= _PDATA_ENTRY_SIZE:
+                    previous = self._readExceptionRecord(binary, size, start - _PDATA_ENTRY_SIZE, 0)
+                    if previous is None or previous[1] > struct.unpack_from("<I", binary, start)[0]:
+                        break
+                    start -= _PDATA_ENTRY_SIZE
+                count = self._countExceptionRecords(binary, size, start, size)
+                if count > best_count:
+                    best_offset, best_count = start, count
+                offset = max(offset, start + count * _PDATA_ENTRY_SIZE)
+                break
+            offset += _PDATA_SAMPLE_STRIDE
+        if best_count < _PDATA_MIN_ENTRIES:
+            return 0, 0
+        return best_offset, best_count
+
+    def _carveExceptionRecords(self, base_addr, record_pdata_ends):
+        # A memory dump carries the mapped image but usually not a parseable header, so the
+        # section table -- and with it .pdata -- is gone, costing every guaranteed x64 function
+        # start. The table is self-describing enough to find without one.
+        binary = self.disassembly.binary_info.binary
+        table_offset, table_count = self._locateExceptionRecordTable(binary)
+        if not table_count:
+            return
+        LOGGER.debug("carved %d RUNTIME_FUNCTION entries at 0x%08x", table_count, table_offset)
+        for index in range(table_count):
+            rva_start, rva_end, rva_unwind_info = struct.unpack_from(
+                "<III", binary, table_offset + index * _PDATA_ENTRY_SIZE
+            )
+            self._admitExceptionRecord(base_addr, rva_start, rva_end, rva_unwind_info, record_pdata_ends)
 
     def _isChainedUnwindInfo(self, rva_unwind_info):
         # x64 UNWIND_INFO header byte 0 packs Version (bits 0-2) and Flags (bits 3-7);

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -37,12 +37,17 @@ _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
 # still admitting its one strong signal (0x55 "push ebp/rbp", scored 51/33).
 _ENTRY_SHAPE_MIN_SCORE = 30
 
-# `mov edi, edi` -- both an effective NOP and the two-byte landing pad MSVC emits as the first
-# instruction of a hotpatchable function.
-_HOTPATCH_PAD_SEQUENCES = frozenset({b"\x8b\xff", b"\x89\xff"})
+# Byte pairs GAP_SEQUENCES treats as skippable filler that a function is also emitted with as
+# its own first instruction. Per bitness and deliberately narrow: on x86 only `mov edi, edi`,
+# the hotpatch landing pad; widening either set was measured to cost true positives. `mov ecx,
+# ecx` is not inert in 64-bit mode -- it truncates rcx, and MSVC opens argument-forwarding
+# thunks with it.
+_ENTRY_PAD_SEQUENCES = {
+    32: frozenset({b"\x8b\xff", b"\x89\xff"}),
+    64: frozenset({b"\x66\x90", b"\x8b\xc9"}),
+}
 
-# MSVC aligns function entries to 16 bytes; a NOP run that does not end on that boundary is
-# not serving alignment.
+# MSVC aligns function entries to 16 bytes.
 _CODE_ALIGNMENT = 16
 
 # Written as `A(BA)+B` rather than the equivalent `(AB){2,}` so the pattern starts with a literal:
@@ -97,13 +102,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # skipping/rounding past that leading NOP and mislocating the start two bytes late.
         return byte_window in COMMON_PROLOGUES["5"].get(self.bitness, {})
 
-    def isUnalignedHotpatchPad(self, byte_sequence, next_addr, next_bytes):
-        # `mov edi, edi` serves two roles: alignment filler and the hotpatch landing pad that
-        # opens a function. Filler only ever exists to reach the next 16-byte boundary and is
-        # always the tail of the NOP run, so a `mov edi, edi` that neither ends on that boundary
-        # nor is followed by more padding is the function's true entry -- a case the 5-byte
-        # COMMON_PROLOGUES window misses for every body other than `push ebp; mov ebp, esp`.
-        if self.bitness != 32 or byte_sequence not in _HOTPATCH_PAD_SEQUENCES:
+    def isUnalignedEntryPad(self, byte_sequence, next_addr, next_bytes):
+        # Filler exists only to reach the next 16-byte boundary and is always the tail of the
+        # NOP run, so a pad that ends off that boundary with real code behind it is an entry.
+        if byte_sequence not in _ENTRY_PAD_SEQUENCES.get(self.bitness, frozenset()):
             return False
         if next_addr % _CODE_ALIGNMENT == 0:
             return False
@@ -165,9 +167,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # Explicit None test: a gap start at VA 0x0 (valid for a base-0 buffer) is a
         # real argument, not "unset", so a truthiness check would wrongly drop it.
         if start_gap_pointer is not None:
-            # A retained hotpatch pad that produced no function really was padding after all.
-            # Resume just past it rather than following getNextGap() to the next gap, which
-            # would abandon the remainder of this one over a wrong guess.
+            # A retained pad that produced no function was padding after all; resuming past it
+            # keeps getNextGap() from abandoning the rest of this gap over the wrong guess.
             if (
                 self._retained_pad is not None
                 and start_gap_pointer > self._retained_pad
@@ -246,7 +247,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                     # it would mislocate the function two bytes late (at the `push ebp`).
                     if self.isHotpatchPrologue(get_window_slice(gap_offset, 5)):
                         break
-                    if self.isUnalignedHotpatchPad(
+                    if self.isUnalignedEntryPad(
                         sequence,
                         self.gap_pointer + gap_length,
                         get_window_slice(gap_offset + gap_length, max(GAP_SEQUENCES.keys())),

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -382,11 +382,24 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
     def _seedPrologueMatches(self, pattern):
         """returns True once the analysis timeout trips, so callers can stop scanning
         further patterns instead of each one re-discovering the timeout on its own first match."""
-        for match_count, prologue_match in enumerate(re.finditer(pattern, self.disassembly.binary_info.binary)):
+        binary = self.disassembly.binary_info.binary
+        for match_count, prologue_match in enumerate(re.finditer(pattern, binary)):
             if match_count % 4096 == 0 and self._candidateTimeoutTripped():
                 return True
-            candidate_addr = (self.disassembly.binary_info.base_addr + prologue_match.start()) & self.getBitMask()
+            offset = prologue_match.start()
+            candidate_addr = (self.disassembly.binary_info.base_addr + offset) & self.getBitMask()
             if not self._passesCodeFilter(candidate_addr):
+                continue
+            # MSVC precedes `push ebp; mov ebp, esp` with a `mov edi, edi` hotpatch pad, and the
+            # pad is the function's entry -- a bare prologue match two bytes into one names the
+            # body, not a function start. The pad is itself a DEFAULT_PROLOGUES entry scanned
+            # before the bare form, so it is already a candidate here; requiring that keeps the
+            # body seed whenever the pad was rejected (outside a code area, candidate cap).
+            if (
+                offset >= 2
+                and self.isHotpatchPrologue(binary[offset - 2 : offset + 3])
+                and (candidate_addr - 2) & self.getBitMask() in self.candidates
+            ):
                 continue
             self.addPrologueCandidate(candidate_addr)
             self.setInitialCandidate(candidate_addr)

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -37,6 +37,14 @@ _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
 # still admitting its one strong signal (0x55 "push ebp/rbp", scored 51/33).
 _ENTRY_SHAPE_MIN_SCORE = 30
 
+# `mov edi, edi` -- both an effective NOP and the two-byte landing pad MSVC emits as the first
+# instruction of a hotpatchable function.
+_HOTPATCH_PAD_SEQUENCES = frozenset({b"\x8b\xff", b"\x89\xff"})
+
+# MSVC aligns function entries to 16 bytes; a NOP run that does not end on that boundary is
+# not serving alignment.
+_CODE_ALIGNMENT = 16
+
 # Written as `A(BA)+B` rather than the equivalent `(AB){2,}` so the pattern starts with a literal:
 # only then does the regex engine emit a prefix fast-search instead of entering the matcher at
 # every offset of the mapped image.
@@ -68,8 +76,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         super().__init__(config)
         self.pdata_start_addresses = set()
         self.pdata_end_addresses = set()
+        self._retained_pad = None
 
     def init(self, disassembly, cbAnalysisTimeout=None):
+        self._retained_pad = None
         # the gap scan decodes potential NOP instructions, so it needs an x86 capstone
         # matching the binary's bitness; build it before the base init runs discovery
         self.capstone = Cs(CS_ARCH_X86, CS_MODE_32)
@@ -86,6 +96,18 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # function's true entry. Recognizing the 5-byte prologue lets callers avoid
         # skipping/rounding past that leading NOP and mislocating the start two bytes late.
         return byte_window in COMMON_PROLOGUES["5"].get(self.bitness, {})
+
+    def isUnalignedHotpatchPad(self, byte_sequence, next_addr, next_bytes):
+        # `mov edi, edi` serves two roles: alignment filler and the hotpatch landing pad that
+        # opens a function. Filler only ever exists to reach the next 16-byte boundary and is
+        # always the tail of the NOP run, so a `mov edi, edi` that neither ends on that boundary
+        # nor is followed by more padding is the function's true entry -- a case the 5-byte
+        # COMMON_PROLOGUES window misses for every body other than `push ebp; mov ebp, esp`.
+        if self.bitness != 32 or byte_sequence not in _HOTPATCH_PAD_SEQUENCES:
+            return False
+        if next_addr % _CODE_ALIGNMENT == 0:
+            return False
+        return not any(next_bytes[:length] in sequences for length, sequences in GAP_SEQUENCES.items())
 
     def hasCommonPrologue(self, addr):
         # reuses FunctionCandidate's longest-first COMMON_PROLOGUES lookup (and endbr64
@@ -143,7 +165,17 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # Explicit None test: a gap start at VA 0x0 (valid for a base-0 buffer) is a
         # real argument, not "unset", so a truthiness check would wrongly drop it.
         if start_gap_pointer is not None:
+            # A retained hotpatch pad that produced no function really was padding after all.
+            # Resume just past it rather than following getNextGap() to the next gap, which
+            # would abandon the remainder of this one over a wrong guess.
+            if (
+                self._retained_pad is not None
+                and start_gap_pointer > self._retained_pad
+                and self._retained_pad not in self.disassembly.code_map
+            ):
+                start_gap_pointer = self._retained_pad + 2
             self.gap_pointer = start_gap_pointer
+        self._retained_pad = None
         if self.gap_pointer is None:
             return None
         LOGGER.debug(
@@ -163,6 +195,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             return window_bytes[:length]
 
         while True:
+            unskipped_pad = False
             if self.disassembly.binary_info.base_addr + self.disassembly.binary_info.binary_size < self.gap_pointer:
                 LOGGER.debug("nextGapCandidate() gap_ptr: 0x%08x - finishing", self.gap_pointer)
                 return None
@@ -206,11 +239,19 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # try to find effective NOPs and skip them.
             found_multi_byte_nop = False
             for gap_length in range(max(GAP_SEQUENCES.keys()), 1, -1):
-                if get_window_slice(gap_offset, gap_length) in GAP_SEQUENCES[gap_length]:
+                sequence = get_window_slice(gap_offset, gap_length)
+                if sequence in GAP_SEQUENCES[gap_length]:
                     # Do not skip a `mov edi, edi` effective NOP when it is the landing pad of
                     # a hotpatch stub: that byte pair is the function's true start, and skipping
                     # it would mislocate the function two bytes late (at the `push ebp`).
                     if self.isHotpatchPrologue(get_window_slice(gap_offset, 5)):
+                        break
+                    if self.isUnalignedHotpatchPad(
+                        sequence,
+                        self.gap_pointer + gap_length,
+                        get_window_slice(gap_offset + gap_length, max(GAP_SEQUENCES.keys())),
+                    ):
+                        unskipped_pad = True
                         break
                     LOGGER.debug(
                         "nextGapCandidate() found %d byte effective nop - gap_ptr += %d: 0x%08x",
@@ -257,6 +298,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 self.gap_pointer = self.getNextGap(dont_skip=True)
             else:
                 self.previously_analyzed_gap = self.gap_pointer
+                if unskipped_pad:
+                    self._retained_pad = self.gap_pointer
                 self.addGapCandidate(self.gap_pointer)
                 return self.gap_pointer
         return None

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -130,7 +130,15 @@ class JumpTableAnalyzer:
                 jump_targets.add(entry)
         return sorted(jump_targets)
 
-    def _extractRelativeTableOffsets(self, jumptable_size, off_jumptable, alternative_base=None, bonus_offset=0):
+    def _extractRelativeTableOffsets(
+        self,
+        jumptable_size,
+        off_jumptable,
+        alternative_base=None,
+        bonus_offset=0,
+        state=None,
+        jump_instruction_address=None,
+    ):
         jumptable_size = jumptable_size if jumptable_size else 0xFF
         jump_targets = set()
         jump_base = alternative_base if alternative_base else off_jumptable
@@ -156,7 +164,15 @@ class JumpTableAnalyzer:
                 if entry:
                     target = (jump_base + entry) & self.disassembler.getBitMask()
                     jump_targets.add(target)
-                    # state.addDataRef(off_jumptable, rebased + index * 4, size=4)
+                    if state is not None:
+                        # Claim the entry as data. `rebased` is an image offset, so the address
+                        # has to be rebuilt from off_jumptable -- without this the table bytes
+                        # stay unclaimed and the gap scan seeds function candidates inside them.
+                        state.addDataRef(
+                            jump_instruction_address,
+                            off_jumptable + bonus_offset + index * 4,
+                            size=4,
+                        )
                 elif not alternative_base:
                     break
         return sorted(jump_targets)
@@ -222,17 +238,29 @@ class JumpTableAnalyzer:
                 if "rsi" in backtracked[::-1][0][3]:
                     alternative_base = self._x64Handler(state, backtracked, "rsi")
                 table_offsets = self._extractRelativeTableOffsets(
-                    jumptable_size, off_jumptable, alternative_base=alternative_base
+                    jumptable_size,
+                    off_jumptable,
+                    alternative_base=alternative_base,
+                    state=state,
+                    jump_instruction_address=jump_instruction_address,
                 )
             elif backtracked_sequence.startswith(("lea", "add-add", "add-shr")):
                 jumptable_size = self._findJumpTableSize(backtracked)
                 off_jumptable = self._x64Handler(state, backtracked)
-                table_offsets = self._extractRelativeTableOffsets(jumptable_size, off_jumptable)
+                table_offsets = self._extractRelativeTableOffsets(
+                    jumptable_size, off_jumptable, state=state, jump_instruction_address=jump_instruction_address
+                )
             elif backtracked_sequence.startswith("add-mov"):
                 jumptable_size = self._findJumpTableSize(backtracked)
                 off_jumptable = self._x64Handler(state, backtracked)
                 bonus = self._getx64BonusOffset(backtracked)
-                table_offsets = self._extractRelativeTableOffsets(jumptable_size, off_jumptable, bonus_offset=bonus)
+                table_offsets = self._extractRelativeTableOffsets(
+                    jumptable_size,
+                    off_jumptable,
+                    bonus_offset=bonus,
+                    state=state,
+                    jump_instruction_address=jump_instruction_address,
+                )
         # if False and off_jumptable and table_offsets:
         #     print("  Found jump table: 0x%x -> %d" % (off_jumptable, len(table_offsets)))
         #     for offset in sorted(list(set(table_offsets))):

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -162,7 +162,10 @@ class JumpTableAnalyzer:
         return sorted(jump_targets)
 
     def _resolveExplicitTable(self, jump_instruction_address, state, jumptable_address, jumptable_size=None):
-        jumptable_size = jumptable_size if jumptable_size is not None else 0xFF
+        # _findJumpTableSize reports an unrecovered bound as 0, not None, so testing against
+        # None here read "zero entries" and abandoned the table -- mirror the truthiness test
+        # _extractRelativeTableOffsets uses, and let the per-entry image bound stop the scan.
+        jumptable_size = jumptable_size if jumptable_size else 0xFF
         jumptable_addresses = []
         bitness = self.disassembly.binary_info.bitness
         if bitness == 32:

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -221,3 +221,33 @@ class CandidateSafeguardsTestSuite(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ExceptionRecordAlignmentExemptionTest(unittest.TestCase):
+    """An exception record is the image's own declaration of a function start, so the
+    inferred alignment floor must not filter it out of the analysis queue."""
+
+    def _manager(self, alignment):
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 32
+        manager.identified_alignment = alignment
+        manager._code_areas = []
+        binary_info = types.SimpleNamespace(bitness=32, base_addr=0, binary=b"\x00" * 0x1000)
+        manager.disassembly = types.SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        return manager
+
+    def _yielded(self, alignment, mark):
+        manager = self._manager(alignment)
+        manager.addCandidate(0x1001)
+        mark(manager.candidates[0x1001])
+        manager._buildQueue()
+        return [candidate.addr for candidate in manager.getNextFunctionStartCandidate()]
+
+    def test_unaligned_exception_record_is_still_analyzed(self):
+        self.assertEqual(self._yielded(4, lambda c: c.setIsExceptionHandler(True)), [0x1001])
+
+    def test_unaligned_inferred_candidate_is_still_filtered(self):
+        self.assertEqual(self._yielded(4, lambda c: c.addCallRef(0x2000)), [])
+
+    def test_alignment_floor_of_zero_filters_nothing(self):
+        self.assertEqual(self._yielded(0, lambda c: c.addCallRef(0x2000)), [0x1001])

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -734,6 +734,43 @@ class TestIntelDisassembler(unittest.TestCase):
 
                 self.assertEqual(manager.candidates, {})
 
+    def _seed_prologues_32bit(self, buf, code_areas=None):
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = len(buf)
+
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        manager.bitness = 32
+        if code_areas:
+            manager._code_areas = code_areas
+
+        manager.locatePrologueCandidates()
+        return manager.candidates.keys()
+
+    def test_prologue_scan_skips_the_body_behind_a_hotpatch_pad(self):
+        # MSVC emits `mov edi, edi` ahead of `push ebp; mov ebp, esp` and the pad is the
+        # function's entry, so the bare 3-byte prologue also matching two bytes in must not
+        # seed a second candidate there -- ground truth counts only the pad.
+        candidates = self._seed_prologues_32bit(bytes.fromhex("8bff558bec" + "90" * 11 + "558bec"))
+
+        self.assertIn(0x1000, candidates)
+        self.assertNotIn(0x1002, candidates)
+        # a bare prologue with no pad in front of it is still seeded where it matches
+        self.assertIn(0x1010, candidates)
+
+    def test_prologue_scan_seeds_the_body_when_the_pad_is_outside_the_code_area(self):
+        # The pad two bytes back is normally seeded by the 5-byte pattern scanned first, which
+        # is what makes skipping the body safe. When the code filter rejected the pad, nothing
+        # stands behind the body, so it must be seeded rather than dropped.
+        candidates = self._seed_prologues_32bit(
+            bytes.fromhex("8bff558bec" + "90" * 11 + "558bec"), code_areas=[[0x1002, 0x1020]]
+        )
+
+        self.assertNotIn(0x1000, candidates)
+        self.assertIn(0x1002, candidates)
+
     def test_prefixed_call_keeps_fallthrough_in_same_block(self):
         state = FunctionAnalysisState(0x1000, SimpleNamespace())
         state.instructions = [

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -551,19 +551,24 @@ class TestIntelDisassembler(unittest.TestCase):
         # alignment filler and the candidate is the aligned address behind it.
         self.assertEqual(self._first_gap_candidate(b"\x8b\xff\x56\x8b\xf2", stub_off=0x0E), 0x1010)
 
-    def test_is_unaligned_hotpatch_pad_predicate(self):
+    def test_is_unaligned_entry_pad_predicate(self):
         manager = FunctionCandidateManager(SmdaConfig())
         manager.bitness = 32
-        self.assertTrue(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        self.assertTrue(manager.isUnalignedEntryPad(b"\x8b\xff", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
         # ends on a 16-byte boundary -> alignment filler
-        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1010, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        self.assertFalse(manager.isUnalignedEntryPad(b"\x8b\xff", 0x1010, b"\x56\x8b\xf2\x00\x00\x00\x00"))
         # more padding behind it -> still inside the filler run, not the run's function entry
-        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1012, b"\x90\x90\x90\x90\x90\x90\x90"))
-        # a different effective NOP is not a hotpatch pad
-        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x66\x90", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
-        # the hotpatch stub is a 32-bit convention
+        self.assertFalse(manager.isUnalignedEntryPad(b"\x8b\xff", 0x1012, b"\x90\x90\x90\x90\x90\x90\x90"))
+        # the pad set is per bitness: `mov edi, edi` is the x86 hotpatch convention, and widening
+        # x86 to the other effective NOPs was measured to cost true positives
+        self.assertFalse(manager.isUnalignedEntryPad(b"\x66\x90", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
         manager.bitness = 64
-        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        self.assertFalse(manager.isUnalignedEntryPad(b"\x8b\xff", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        self.assertTrue(manager.isUnalignedEntryPad(b"\x66\x90", 0x1012, b"\x0f\xb6\x01\x84\xc0\x74\x24"))
+        self.assertFalse(manager.isUnalignedEntryPad(b"\x66\x90", 0x1010, b"\x0f\xb6\x01\x84\xc0\x74\x24"))
+        # a bitness with no pad set at all matches nothing
+        manager.bitness = 16
+        self.assertFalse(manager.isUnalignedEntryPad(b"\x66\x90", 0x1012, b"\x0f\xb6\x01\x84\xc0\x74\x24"))
 
     def test_retained_hotpatch_pad_that_yields_no_function_resumes_behind_the_pad(self):
         # When the retained pad produces no function it really was padding, so the scan must

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -517,6 +517,68 @@ class TestIntelDisassembler(unittest.TestCase):
         # as an effective NOP and skipped, so it is never returned as the candidate start.
         self.assertNotEqual(self._first_gap_candidate(b"\x8b\xff\x90\x90\x90"), 0x1010)
 
+    def _gap_manager(self, stub, base=0x1000, stub_off=0x10):
+        # Same layout as _first_gap_candidate, but hands back the manager so a test can drive
+        # the scan more than once and observe the retained-pad bookkeeping between calls.
+        buf = bytearray(b"\x90")
+        buf += b"\xcc" * (stub_off - len(buf))
+        buf += stub
+        buf += b"\xcc" * (0x200 - len(buf))
+
+        binary_info = BinaryInfo(bytes(buf))
+        binary_info.base_addr = base
+        binary_info.binary_size = len(buf)
+        binary_info.bitness = 32
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            code_map={base: 1, base + 0x100: 1},
+            data_map={},
+            getRawBytes=lambda offset, n: bytes(buf)[offset : offset + n],
+        )
+        manager.bitness = 32
+        manager.capstone = Cs(CS_ARCH_X86, CS_MODE_32)
+        return manager
+
+    def test_hotpatch_pad_before_a_non_ebp_prologue_is_the_candidate_start(self):
+        # `mov edi, edi` opens every hotpatchable MSVC function, not only those continuing with
+        # `push ebp; mov ebp, esp`. As padding it exists solely to reach the next 16-byte
+        # boundary, so a pad that does not end on one is the function's true entry and must be
+        # the candidate; skipping it would mislocate the start two bytes late.
+        self.assertEqual(self._first_gap_candidate(b"\x8b\xff\x56\x8b\xf2"), 0x1010)
+        self.assertEqual(self._first_gap_candidate(b"\x89\xff\x83\xec\x0c"), 0x1010)
+        # control: the same pad two bytes earlier DOES end on the boundary, so it is genuine
+        # alignment filler and the candidate is the aligned address behind it.
+        self.assertEqual(self._first_gap_candidate(b"\x8b\xff\x56\x8b\xf2", stub_off=0x0E), 0x1010)
+
+    def test_is_unaligned_hotpatch_pad_predicate(self):
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 32
+        self.assertTrue(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        # ends on a 16-byte boundary -> alignment filler
+        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1010, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        # more padding behind it -> still inside the filler run, not the run's function entry
+        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1012, b"\x90\x90\x90\x90\x90\x90\x90"))
+        # a different effective NOP is not a hotpatch pad
+        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x66\x90", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+        # the hotpatch stub is a 32-bit convention
+        manager.bitness = 64
+        self.assertFalse(manager.isUnalignedHotpatchPad(b"\x8b\xff", 0x1012, b"\x56\x8b\xf2\x00\x00\x00\x00"))
+
+    def test_retained_hotpatch_pad_that_yields_no_function_resumes_behind_the_pad(self):
+        # When the retained pad produces no function it really was padding, so the scan must
+        # continue two bytes on instead of following the caller's next-gap address, which would
+        # abandon every remaining byte of the current gap.
+        manager = self._gap_manager(b"\x8b\xff\x56\x8b\xf2")
+        self.assertEqual(manager.nextGapCandidate(), 0x1010)
+        self.assertEqual(manager.nextGapCandidate(0x1100), 0x1012)
+
+    def test_retained_hotpatch_pad_that_became_a_function_follows_the_next_gap(self):
+        manager = self._gap_manager(b"\x8b\xff\x56\x8b\xf2")
+        self.assertEqual(manager.nextGapCandidate(), 0x1010)
+        manager.disassembly.code_map[0x1010] = 1
+        self.assertNotEqual(manager.nextGapCandidate(0x1100), 0x1012)
+
     def test_gap_scan_skips_hlt_and_ud2_trap_filler(self):
         # hlt (0xf4) and ud2 (0x0f 0x0b) are trap filler a function never opens with;
         # the gap scanner must skip them like int3 and promote the code behind them.

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -749,6 +749,22 @@ class TestIntelDisassembler(unittest.TestCase):
         manager.locatePrologueCandidates()
         return manager.candidates.keys()
 
+    def test_prologue_seeding_reports_a_tripped_timeout_to_its_caller(self):
+        # locatePrologueCandidates walks several patterns; the first one to see the timeout
+        # returns True so the rest are abandoned instead of each rediscovering it.
+        binary_info = BinaryInfo(bytes.fromhex("558bec"))
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = 3
+
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        manager.bitness = 32
+        manager._cb_analysis_timeout = lambda: True
+
+        self.assertTrue(manager._seedPrologueMatches(b"\x55\x8b\xec"))
+        self.assertEqual({}, manager.candidates)
+
     def test_prologue_scan_skips_the_body_behind_a_hotpatch_pad(self):
         # MSVC emits `mov edi, edi` ahead of `push ebp; mov ebp, esp` and the pad is the
         # function's entry, so the bare 3-byte prologue also matching two bytes in must not

--- a/tests/testIntelPdataCarving.py
+++ b/tests/testIntelPdataCarving.py
@@ -1,0 +1,167 @@
+"""x64 RUNTIME_FUNCTION recovery from an image with no usable section table.
+
+A memory dump carries the mapped image but rarely a parseable PE header, so `.pdata`
+- the only source of *guaranteed* x64 function starts - disappears with the section
+table. These tests pin the carver that recovers it from the raw image instead.
+"""
+
+import struct
+import unittest
+from types import SimpleNamespace
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x140000000
+IMAGE_SIZE = 0x4000
+UNWIND_RVA = 0x3000
+TABLE_RVA = 0x2000
+FIRST_FUNCTION_RVA = 0x100
+FUNCTION_STRIDE = 0x20
+
+# UNWIND_INFO byte 0: Version 1 in bits 0-2, Flags in bits 3-7.
+UNWIND_PLAIN = 0x01
+UNWIND_CHAINED = 0x01 | (0x04 << 3)
+
+
+def _image(num_entries, unwind_byte=UNWIND_PLAIN, table_rva=TABLE_RVA, stride=FUNCTION_STRIDE):
+    blob = bytearray(IMAGE_SIZE)
+    blob[UNWIND_RVA] = unwind_byte
+    for index in range(num_entries):
+        begin = FIRST_FUNCTION_RVA + index * stride
+        entry = struct.pack("<III", begin, begin + 0x10, UNWIND_RVA)
+        offset = table_rva + index * 12
+        blob[offset : offset + 12] = entry
+    return bytes(blob)
+
+
+def _manager(blob, sections=()):
+    binary_info = BinaryInfo(blob)
+    binary_info.base_addr = BASE
+    binary_info.bitness = 64
+    binary_info.binary_size = len(blob)
+    binary_info.getSections = lambda: iter(sections)
+
+    manager = FunctionCandidateManager(SmdaConfig())
+    manager.disassembly = SimpleNamespace(
+        binary_info=binary_info,
+        analysis_timeout=False,
+        getRawBytes=lambda offset, size: blob[offset : offset + size],
+    )
+    manager.bitness = 64
+    return manager
+
+
+class IntelPdataCarvingTestSuite(unittest.TestCase):
+    def test_carves_the_runtime_function_table_out_of_a_headerless_image(self):
+        manager = _manager(_image(24))
+
+        manager.locateExceptionHandlerCandidates()
+
+        expected = {BASE + FIRST_FUNCTION_RVA + i * FUNCTION_STRIDE for i in range(24)}
+        self.assertEqual(expected, set(manager.candidates))
+        self.assertTrue(all(c.is_exception_handler for c in manager.candidates.values()))
+
+    def test_a_run_shorter_than_the_minimum_is_not_trusted(self):
+        # Three plausible RVAs are common in ordinary data; only a long sorted run
+        # separates a real table from coincidence, so a short one must be ignored.
+        manager = _manager(_image(8))
+
+        manager.locateExceptionHandlerCandidates()
+
+        self.assertEqual({}, manager.candidates)
+
+    def test_carving_is_skipped_when_a_section_table_is_available(self):
+        # A file-loaded binary already had its chance to read a real .pdata; carving there
+        # would change established behaviour, so the section table gates it off entirely.
+        manager = _manager(_image(24), sections=[(".text", BASE, BASE + 0x1000)])
+
+        manager.locateExceptionHandlerCandidates()
+
+        self.assertEqual({}, manager.candidates)
+
+    def test_chained_entries_are_skipped_like_a_real_pdata_section(self):
+        # UNW_FLAG_CHAININFO marks a split-off fragment of another function, not a start.
+        manager = _manager(_image(24, unwind_byte=UNWIND_CHAINED))
+
+        manager.locateExceptionHandlerCandidates()
+
+        self.assertEqual({}, manager.candidates)
+
+    def test_pdata_extents_are_recorded_for_the_carved_table(self):
+        manager = _manager(_image(24))
+        manager.config.USE_PE_X64_PDATA_ENDS = True
+
+        manager.locateExceptionHandlerCandidates()
+
+        self.assertIn(BASE + FIRST_FUNCTION_RVA, manager.pdata_start_addresses)
+        self.assertIn(BASE + FIRST_FUNCTION_RVA + 0x10, manager.pdata_end_addresses)
+
+    def test_the_table_is_found_from_a_sample_landing_at_any_entry_phase(self):
+        # Sampling steps by a fixed stride, so it lands at an arbitrary offset inside the
+        # 12-byte entries; the walk-back must still recover the true first entry.
+        for table_rva in (TABLE_RVA, TABLE_RVA + 4, TABLE_RVA + 8):
+            with self.subTest(table_rva=table_rva):
+                manager = _manager(_image(40, table_rva=table_rva))
+
+                manager.locateExceptionHandlerCandidates()
+
+                self.assertEqual(40, len(manager.candidates))
+                self.assertIn(BASE + FIRST_FUNCTION_RVA, manager.candidates)
+
+    def test_entries_are_rejected_by_each_structural_guard(self):
+        manager = _manager(_image(24))
+        blob = manager.disassembly.binary_info.binary
+        size = len(blob)
+
+        def one(begin, end, unwind):
+            """a full-size image carrying a single record at offset 0, so size == len(image)"""
+            image = bytearray(IMAGE_SIZE)
+            image[UNWIND_RVA] = UNWIND_PLAIN
+            image[0:12] = struct.pack("<III", begin, end, unwind)
+            return bytes(image)
+
+        self.assertIsNotNone(manager._readExceptionRecord(blob, size, TABLE_RVA, 0))
+        # a record straddling the end of the image
+        self.assertIsNone(manager._readExceptionRecord(blob, size, size - 4, 0))
+        # begin >= end, and an end past the image
+        self.assertIsNone(manager._readExceptionRecord(one(0x200, 0x100, UNWIND_RVA), IMAGE_SIZE, 0, 0))
+        self.assertIsNone(manager._readExceptionRecord(one(0x100, 0x9000, UNWIND_RVA), IMAGE_SIZE, 0, 0))
+        # a zero begin, an implausibly large function, and an entry that breaks the sort order
+        self.assertIsNone(manager._readExceptionRecord(one(0, 0x100, UNWIND_RVA), IMAGE_SIZE, 0, 0))
+        self.assertIsNone(manager._readExceptionRecord(one(1, 0x101000, UNWIND_RVA), 0x200000, 0, 0))
+        self.assertIsNone(manager._readExceptionRecord(blob, size, TABLE_RVA, 0x1000))
+        # unwind info that is zero, outside the image, or not DWORD aligned
+        for bad_unwind in (0, 0x9000, UNWIND_RVA + 1):
+            self.assertIsNone(manager._readExceptionRecord(one(0x100, 0x110, bad_unwind), IMAGE_SIZE, 0, 0))
+        # unwind info whose first byte is not a legal Version/Flags combination
+        broken = bytearray(blob)
+        broken[UNWIND_RVA] = 0xFF
+        self.assertIsNone(manager._readExceptionRecord(bytes(broken), size, TABLE_RVA, 0))
+
+    def test_the_longest_table_wins_when_the_image_holds_more_than_one_run(self):
+        blob = bytearray(_image(20))
+        # a second, longer run elsewhere in the image
+        for index in range(48):
+            begin = 0x1000 + index * 0x10
+            offset = 0x800 + index * 12
+            blob[offset : offset + 12] = struct.pack("<III", begin, begin + 8, UNWIND_RVA)
+        manager = _manager(bytes(blob))
+
+        offset, count = manager._locateExceptionRecordTable(manager.disassembly.binary_info.binary)
+
+        self.assertEqual(0x800, offset)
+        self.assertEqual(48, count)
+
+    def test_a_tripped_timeout_stops_the_scan(self):
+        manager = _manager(_image(24))
+        manager.disassembly.analysis_timeout = True
+
+        manager.locateExceptionHandlerCandidates()
+
+        self.assertEqual({}, manager.candidates)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -253,3 +253,66 @@ class X64BonusOffsetTestSuite(unittest.TestCase):
         backtracked = [(0x2000, 3, "add", "rax, rcx")]
 
         self.assertEqual(0, analyzer._getx64BonusOffset(backtracked))
+
+
+class RelativeTableDataClaimTest(unittest.TestCase):
+    """A relative jump table's own bytes must be claimed as data, or the gap scan seeds
+    function candidates inside the table."""
+
+    def _walk(self, bonus_offset=0):
+        analyzer = _makeAnalyzer(base_addr=0x1000)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(return_value=True)
+        entries = b"".join(struct.pack("<i", 0x40 + index * 4) for index in range(3)) + b"\x00\x00\x00\x00"
+        analyzer.disassembly.getRawBytes = MagicMock(
+            side_effect=lambda offset, size: entries[offset - 0x100 - bonus_offset :][:size]
+        )
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        targets = analyzer._extractRelativeTableOffsets(
+            jumptable_size=3,
+            off_jumptable=0x1100,
+            bonus_offset=bonus_offset,
+            state=state,
+            jump_instruction_address=0x2000,
+        )
+        return targets, state.refs
+
+    def test_each_consumed_entry_is_claimed_as_data_at_its_real_address(self):
+        targets, refs = self._walk()
+        self.assertEqual(len(targets), 3)
+        # the table sits at off_jumptable, NOT at the image offset used to read it
+        self.assertEqual(refs, [(0x2000, 0x1100, 4), (0x2000, 0x1104, 4), (0x2000, 0x1108, 4)])
+
+    def test_the_bonus_offset_shifts_the_claimed_address(self):
+        _targets, refs = self._walk(bonus_offset=0x10)
+        self.assertEqual([ref[1] for ref in refs], [0x1110, 0x1114, 0x1118])
+
+    def test_no_state_means_no_data_claim_and_no_crash(self):
+        analyzer = _makeAnalyzer(base_addr=0x1000)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(return_value=True)
+        analyzer.disassembly.getRawBytes = MagicMock(return_value=struct.pack("<i", 0x40))
+        self.assertEqual(analyzer._extractRelativeTableOffsets(jumptable_size=1, off_jumptable=0x1100), [0x1140])
+
+    def test_add_mov_sequence_claims_the_table_at_its_bonus_offset(self):
+        # the `add-mov` x64 shape carries a bonus offset, so getJumpTargets must forward both
+        # the state and that offset for the entries to be claimed at the right addresses
+        analyzer = _makeAnalyzer(base_addr=0x1000, bitness=64)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(return_value=True)
+        entries = b"".join(struct.pack("<i", 0x40 + index * 4) for index in range(2))
+        analyzer.disassembly.getRawBytes = MagicMock(side_effect=lambda offset, size: entries[offset - 0x110 :][:size])
+        analyzer._x64Handler = MagicMock(return_value=0x1100)
+        analyzer.disassembler.getReferencedAddr = MagicMock(return_value=0x10)
+
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        # getJumpTargets reverses this list, so "add" must come last for an add-mov sequence
+        state.backtrackInstructions = MagicMock(
+            return_value=[
+                (0x1FF0, 4, "mov", "eax, dword ptr [rcx + 0x10]"),
+                (0x1FF8, 3, "add", "rax, rdx"),
+            ]
+        )
+
+        analyzer.getJumpTargets((0x2000, 2, "jmp", "rax"), state)
+
+        self.assertEqual([ref[1] for ref in state.refs], [0x1110, 0x1114])

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -1,3 +1,4 @@
+import struct
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -163,6 +164,41 @@ class JumpTableAnalyzerTestSuite(unittest.TestCase):
 
         self.assertEqual(result, [])
         state.addDataRef.assert_not_called()
+
+    def test_resolveExplicitTable_scans_when_the_size_was_not_recovered(self):
+        # _findJumpTableSize reports "no bound found" as 0, which MSVC /Od reaches routinely
+        # because it spills the switch value and compares a stack slot. Treating that 0 as a
+        # real size abandoned the table; it must fall back to a bounded scan instead, and the
+        # per-entry image check is what ends it -- here after the three in-image entries.
+        analyzer = _makeAnalyzer(bitness=32)
+        entries = [0x1100, 0x1200, 0x1300]
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(side_effect=lambda addr: addr in (0x1090, *entries))
+        table = b"".join(struct.pack("<I", entry) for entry in entries) + struct.pack("<I", 0xDEADBEEF)
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - 0x1090 : addr - 0x1090 + size]
+        )
+
+        result = analyzer._resolveExplicitTable(
+            jump_instruction_address=0x2000, state=MagicMock(), jumptable_address=0x1090, jumptable_size=0
+        )
+
+        self.assertEqual(result, entries)
+
+    def test_resolveExplicitTable_honours_a_recovered_size(self):
+        # a real bound must still cap the scan, so the entry past the switch is not claimed
+        analyzer = _makeAnalyzer(bitness=32)
+        entries = [0x1100, 0x1200, 0x1300]
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(return_value=True)
+        table = b"".join(struct.pack("<I", entry) for entry in entries)
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - 0x1090 : addr - 0x1090 + size]
+        )
+
+        result = analyzer._resolveExplicitTable(
+            jump_instruction_address=0x2000, state=MagicMock(), jumptable_address=0x1090, jumptable_size=2
+        )
+
+        self.assertEqual(result, entries[:2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Seven defects in function-start recovery, each one a heuristic discarding a start the binary itself identifies. They were found by attributing the false negatives and false positives of the accuracy corpora one class at a time, and every change is gated on the same rule: **true-positive rate may not fall on any configuration.** It never does — and no single binary in any configuration loses a true positive.

Macro-averaged over the all-samples population (`Os`/`Od`/`Ox` included), against `master` at `0ac4a55`:

| dataset | n | master | this branch | ΔF1 | master TPR | branch TPR | ΔTP | ΔFP |
|---|---|---|---|---|---|---|---|---|
| ByteWeight MSVC x86 | 68 | 93.3326 | **94.7409** | **+1.4083** | 97.6271 | 97.8613 | +223 | −5,585 |
| ByteWeight MSVC x86, dumped | 56 | 92.3140 | **94.0371** | **+1.7231** | 97.2125 | 97.4969 | +223 | −5,608 |
| malpedia ITW | 57 | 95.2799 | **95.4551** | **+0.1752** | 98.4626 | 98.5302 | +14 | −58 |
| ByteWeight MSVC x64 | 68 | 99.3420 | **99.4542** | **+0.1122** | 99.7294 | 99.8352 | +159 | −309 |
| ByteWeight MSVC x64, dumped | 56 | 98.2983 | **99.3740** | **+1.0757** | 97.7518 | 99.8117 | +1,987 | −184 |
| **mean of five** | | 95.7134 | **96.6123** | **+0.8989** | | | | |

Precision and recall both rise on every configuration.

## The seven commits

| commit | change |
|---|---|
| `4fee6a1` | `fix(intel)` stop seeding the body behind an MSVC hot-patch pad |
| `611697b` | `fix(intel)` scan an explicit jump table whose bound was not recovered |
| `69b813f` | `feat(intel)` recover x64 exception records from a headerless image |
| `9aced4b` | `fix(intel)` stop skipping a hot-patch pad that is not alignment filler |
| `2bc0a97` | `fix(core)` let an exception record outrank the inferred alignment floor |
| `1923b48` | `fix(intel)` recognize the x64 entry pads the gap scan skipped as filler |
| `cf9c09c` | `fix(intel)` claim a relative jump table's bytes as data |

## Root causes

**`mov edi, edi` is both alignment filler and a function's first instruction, and the two were never separated.** `DEFAULT_PROLOGUES` holds the padded forms *and* the bare `55 8b ec`, so the prologue scan seeded two candidates per hot-patched function — the pad, which is the real entry, and the body two bytes behind it (`4fee6a1`). The gap scan had the mirror-image problem: it skipped the pad as an effective NOP unless the five-byte window matched exactly `8b ff 55 8b ec`, so a pad in front of any other prologue mislocated the start (`9aced4b`, and `1923b48` for the x64 encodings `66 90` and `8b c9`).

The separator is alignment, and on this corpus it is exact. Filler exists only to reach the next 16-byte boundary, so a pad that neither ends on one nor is followed by more padding is the entry itself: 221 of 223 pads that ground truth names as starts end off the boundary, and all 14 sites where the pad really is filler end on it. `isUnalignedEntryPad` (`src/smda/intel/FunctionCandidateManager.py:105`) is deliberately narrow — the sets are per bitness, because widening x86 beyond `mov edi, edi` was measured to cost true positives: in real-world 32-bit images the two bytes before a genuine start are an effective NOP by coincidence often enough that the ITW set has 318 such sites, spread across every alignment including odd addresses.

**A sentinel mismatch abandoned unresolved switch tables.** `_findJumpTableSize` reports "bound not recovered" as `0`, but `_resolveExplicitTable` (`src/smda/intel/JumpTableAnalyzer.py:180`) defaulted only on `None`, so `0` meant `range(0)` and the table was never read. `/Od` builds hit this constantly, since spilling the switch value produces a memory-operand compare the size regex deliberately does not match. With no targets the case bodies never enter `code_map`, each becomes a gap, and the gap scan books each one as a one-block function — a cascade worth 3,565 false positives on the x86 set for this commit alone (`611697b`).

**A relative jump table's own bytes were never claimed as data.** `_resolveExplicitTable` marks every entry it consumes; `_extractRelativeTableOffsets` (`src/smda/intel/JumpTableAnalyzer.py:133`) never did — its `addDataRef` call had been commented out and the function did not take `state`. On x64, where switch tables are int32 offsets, the table bytes stayed unclaimed and the gap scan seeded a function at any entry pair that happened to look like code. Measured on one binary, 40 of its 161 false positives sit inside a table the analyzer had already walked, and none of its 5,861 true positives do (`cf9c09c`).

**Headerless x64 dumps lost `.pdata` entirely.** `locateExceptionHandlerCandidates` needs the section table, and a dumped image has no parseable header, so every guaranteed function start went missing — 4,369 of them in one sample. `_carveExceptionRecords` (`src/smda/intel/FunctionCandidateManager.py:639`) finds the table without one: `RUNTIME_FUNCTION` is three DWORD-aligned image-relative ULONGs, the table is sorted and non-overlapping, and `UNWIND_INFO` byte 0 packs Version with Flags such that only eight byte values are legal there. The carve runs only when `getSections()` yields nothing at all, so every file-loaded binary keeps exactly its current behaviour (`69b813f`).

**An inferred alignment floor outranked the image's own declaration.** `USE_ALIGNMENT` derives a per-binary floor from where call-referenced candidates happen to sit, and `getNextFunctionStartCandidate` (`src/smda/common/FunctionCandidateManager.py:150`) then skipped every candidate below it — including candidates created from `.pdata`. Fifty-nine ground-truth starts scored 5040 and were never handed to analysis at all. Exception records are now exempt; symbols are declarations of the same kind but are deliberately **not** exempt, because exempting them was measured to cost three true positives on the x86 set and one on the ITW set (`2bc0a97`).

## Validation

`.pdata` carving was not accepted on a corpus delta. Every dumped sample has an on-disk twin whose real `.pdata` parses from its section table, so the carved table was diffed against exact ground truth for the structure itself: **56/56 tables recovered, 103,815/103,815 entries, zero invented.** Only then was accuracy measured.

The same parse also confirms the pre-existing `UNW_FLAG_CHAININFO` skip is sound: of 30,592 chained entries across the x64 set, **none** is a ground-truth function start, while 59 primary entries were being lost.

- Full suite green (1,176 passed, 1 skipped), `ruff check`, `ruff format --check`, and `ty` clean with zero errors.
- Diff coverage 100% on the changed lines. Twenty-five regression tests were added; several were verified to fail on the pre-fix code.
- Benchmark fixtures: primitive calls +0.00% to +0.13%, and **one** of eight `report_hash` values moves (`cutwail`, a 32-bit PE where the hot-patch fix fires). The other seven are unchanged.
- Recall guard on 264 real malware samples: the recovered-function count falls 276,793 → 275,661, which is what a precision fix looks like here — 890 of the dropped addresses have the pad recovered two bytes away, and switch-case pseudo-functions collapse into their owning function. Classified by instruction coverage instead, the 88 changed samples gain 13,326 addresses and lose 3,105, **net +10,221 more code disassembled**.

## Notes for review

Three levers were confirmed and then rejected rather than shipped, because each drops recall somewhere: enabling `RESOLVE_TAILCALLS` (+87 true positives for +564 false positives), promoting `jmp` targets by entry shape (best rule: 128 recovered for 909 new false positives), and an entry-shape score gate on gap candidates (removes 1.2 true positives per false positive). The two "obvious" widenings of the changes above — symbols in the alignment exemption, and the other effective-NOP encodings on x86 — are also measured rejections, and are marked as such in the source so they are not re-attempted.

The MSVC EH funclet question is deliberately untouched. The two ground truths disagree about it on byte-identical code: PDB-derived ByteWeight folds a funclet into its parent, IDA labels it a function. Suppressing that shape gains roughly 1.5 macro F1 on the x86 sets and costs hundreds of true positives on the ITW set, so it is a labeling-convention decision rather than a defect.
