### PR TITLE
fix(core): plant a block that overflows its section instead of dropping it

### DIFF
--- a/src/smda/synthesis/BinarySynthesizer.py
+++ b/src/smda/synthesis/BinarySynthesizer.py
@@ -81,6 +81,58 @@ class BinarySynthesizer:
         extent_end = max(self._functionExtentEnd(self.report.xcfg[offset]) for offset in offsets)
         return va_start, align_up(max(extent_end, max(offsets) + 1), end_alignment)
 
+    def _growSectionForOverflow(self, sections, section, block_end):
+        """Extends an executable section's end towards block_end, stopping at the next section.
+
+        Recovered code can run past the end of the section it starts in: a call at the tail of
+        __text whose fall-through lands in the padding before __stubs is still part of the
+        function, and the byte is still inside the mapped image, just not inside any section.
+        Growth is capped at the following section's start, so it only ever claims address space
+        no other section describes.
+        """
+        successors = [other["va_start"] for other in sections if other["va_start"] > section["va_start"]]
+        limit = min(successors) if successors else block_end
+        new_end = min(block_end, limit)
+        if new_end <= section["va_end"]:
+            return
+        section["raw"].extend(self._nopFill(new_end - section["va_end"]))
+        section["va_end"] = new_end
+
+    def _plantFunctionChunks(self, sections, offsets):
+        """Plants every block of every function into the executable sections covering it.
+
+        Blocks are written per overlapping range rather than all-or-nothing: a block that runs
+        one byte past its section would otherwise be dropped whole, taking the instructions that
+        do fit with it.
+        """
+        ordered = sorted(sections, key=lambda section: section["va_start"])
+        executable = [section for section in ordered if section["executable"] and section["raw"] is not None]
+        for offset in offsets:
+            for block_offset, chunk in self._iterFunctionChunks(self.report.xcfg[offset]):
+                block_end = block_offset + len(chunk)
+                for section in executable:
+                    if section["va_start"] <= block_offset < section["va_end"] < block_end:
+                        self._growSectionForOverflow(ordered, section, block_end)
+                        break
+                planted = 0
+                for section in executable:
+                    start = max(block_offset, section["va_start"])
+                    end = min(block_end, section["va_end"])
+                    if start >= end:
+                        continue
+                    section["raw"][start - section["va_start"] : end - section["va_start"]] = chunk[
+                        start - block_offset : end - block_offset
+                    ]
+                    planted += end - start
+                if planted < len(chunk):
+                    self._warn(
+                        "block 0x%x of function 0x%x: %d of %d bytes fit no executable section",
+                        block_offset,
+                        offset,
+                        len(chunk) - planted,
+                        len(chunk),
+                    )
+
     def _nopPadding(self):
         return AARCH64_NOP if self.report.architecture == "aarch64" else INTEL_NOP
 

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -170,19 +170,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
             sections.sort(key=lambda section: section["va_start"])
 
-        for offset in offsets:
-            for block_offset, chunk in self._iterFunctionChunks(self.report.xcfg[offset]):
-                for section in sections:
-                    if (
-                        section["executable"]
-                        and section["va_start"] <= block_offset
-                        and block_offset + len(chunk) <= section["va_end"]
-                    ):
-                        start = block_offset - section["va_start"]
-                        section["raw"][start : start + len(chunk)] = chunk
-                        break
-                else:
-                    self._warn("block 0x%x of function 0x%x fits no executable section, skipped", block_offset, offset)
+        self._plantFunctionChunks(sections, offsets)
 
         if with_strings:
             for data_addr, content in self._iterStringRefs():

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -362,19 +362,7 @@ class MachoSynthesizer(BinarySynthesizer):
             else:
                 section["raw"] = bytearray(size)
 
-        for offset in offsets:
-            for block_offset, chunk in self._iterFunctionChunks(self.report.xcfg[offset]):
-                for section in sections:
-                    if (
-                        section["executable"]
-                        and section["va_start"] <= block_offset
-                        and block_offset + len(chunk) <= section["va_end"]
-                    ):
-                        start = block_offset - section["va_start"]
-                        section["raw"][start : start + len(chunk)] = chunk
-                        break
-                else:
-                    self._warn("block 0x%x of function 0x%x fits no executable section, skipped", block_offset, offset)
+        self._plantFunctionChunks(sections, offsets)
 
         if with_strings:
             for data_addr, content in self._iterStringRefs():

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import struct
+import types
 import unittest
 from pathlib import Path
 
@@ -608,3 +609,112 @@ class SynthesisLayoutTestSuite(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SynthesisSectionOverflowTestSuite(unittest.TestCase):
+    """Recovered code can run past the end of the section it starts in — a call at the tail of
+    __text whose fall-through lands in the padding before __stubs. Planting must not drop the
+    whole block over the byte that overflows."""
+
+    def _sections(self, va_start, va_end, next_start=None):
+        sections = [
+            {
+                "name": ".text",
+                "va_start": va_start,
+                "va_end": va_end,
+                "executable": True,
+                "raw": bytearray(b"\x90" * (va_end - va_start)),
+            }
+        ]
+        if next_start is not None:
+            sections.append(
+                {
+                    "name": ".next",
+                    "va_start": next_start,
+                    "va_end": next_start + 0x10,
+                    "executable": True,
+                    "raw": bytearray(b"\x90" * 0x10),
+                }
+            )
+        return sections
+
+    def _synthesizer(self, chunks):
+        from smda.synthesis.BinarySynthesizer import BinarySynthesizer
+
+        synthesizer = BinarySynthesizer.__new__(BinarySynthesizer)
+        synthesizer.report = types.SimpleNamespace(architecture="intel", xcfg={0x1000: object()})
+        synthesizer.warnings = []
+        synthesizer._iterFunctionChunks = staticmethod(lambda _function: iter(chunks))
+        return synthesizer
+
+    def test_a_block_overflowing_its_section_grows_it_into_unclaimed_space(self):
+        # the block needs one byte past .text, and nothing else claims it
+        sections = self._sections(0x1000, 0x1005)
+        synthesizer = self._synthesizer([(0x1000, b"\xe8\x01\x02\x03\x04\x90")])
+
+        synthesizer._plantFunctionChunks(sections, [0x1000])
+
+        self.assertEqual(sections[0]["va_end"], 0x1006)
+        self.assertEqual(bytes(sections[0]["raw"]), b"\xe8\x01\x02\x03\x04\x90")
+        self.assertEqual(synthesizer.warnings, [])
+
+    def test_growth_stops_at_the_next_section_and_the_fitting_bytes_are_still_planted(self):
+        # .next starts immediately, so the overflowing byte has nowhere to go; the five bytes
+        # that do fit must still be planted rather than dropped with the block
+        sections = self._sections(0x1000, 0x1005, next_start=0x1005)
+        synthesizer = self._synthesizer([(0x1000, b"\xe8\x01\x02\x03\x04\xcc")])
+
+        synthesizer._plantFunctionChunks(sections, [0x1000])
+
+        self.assertEqual(sections[0]["va_end"], 0x1005)
+        self.assertEqual(bytes(sections[0]["raw"]), b"\xe8\x01\x02\x03\x04")
+        # the tail lands in the neighbouring executable section, which does cover it
+        self.assertEqual(bytes(sections[1]["raw"][:1]), b"\xcc")
+        self.assertEqual(synthesizer.warnings, [])
+
+    def test_growth_takes_only_the_overflow_not_the_whole_gap(self):
+        sections = self._sections(0x1000, 0x1005, next_start=0x2000)
+        synthesizer = self._synthesizer([(0x1000, b"\xe8\x01\x02\x03\x04\x90")])
+
+        synthesizer._plantFunctionChunks(sections, [0x1000])
+
+        self.assertEqual(sections[0]["va_end"], 0x1006)
+        self.assertEqual(synthesizer.warnings, [])
+
+    def test_a_block_in_a_gap_between_sections_is_reported(self):
+        # nothing to grow: the block starts inside no section at all
+        sections = self._sections(0x1000, 0x1005, next_start=0x2000)
+        synthesizer = self._synthesizer([(0x1500, b"\xe8\x01\x02\x03\x04")])
+
+        synthesizer._plantFunctionChunks(sections, [0x1000])
+
+        self.assertEqual(sections[0]["va_end"], 0x1005)
+        self.assertEqual(len(synthesizer.warnings), 1)
+        self.assertIn("fit no executable section", synthesizer.warnings[0])
+
+    def test_a_block_below_its_section_is_clipped_not_wrapped(self):
+        sections = self._sections(0x1000, 0x1010)
+        synthesizer = self._synthesizer([(0x0FFE, b"\xaa\xbb\xcc")])
+
+        synthesizer._plantFunctionChunks(sections, [0x1000])
+
+        self.assertEqual(bytes(sections[0]["raw"][:1]), b"\xcc")
+        self.assertEqual(bytes(sections[0]["raw"][1:2]), b"\x90")
+        self.assertEqual(len(synthesizer.warnings), 1)
+
+    def test_komplex_round_trips_every_instruction_in_all_three_formats(self):
+        report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_load_xored_fixture("komplex_xored"))
+        for output_format in (FORMAT_PE, FORMAT_ELF, FORMAT_MACHO):
+            parsed = lief.parse(list(bytes(report.synthesizeBinary(output_format=output_format))))
+            corrupt = []
+            for function in report.getFunctions():
+                for block in function.getBlocks():
+                    for instruction in block.getInstructions():
+                        expected = bytes.fromhex(instruction.bytes)
+                        try:
+                            got = bytes(parsed.get_content_from_virtual_address(instruction.offset, len(expected)))
+                        except Exception:
+                            got = b""
+                        if got != expected:
+                            corrupt.append(hex(instruction.offset))
+            self.assertEqual(corrupt, [], f"{output_format} lost {len(corrupt)} instructions")


### PR DESCRIPTION
Fixes #232.

## Which side was wrong

Neither, as it turns out — the report describes the layout correctly and the planting logic is what drops the bytes.

The two instructions are the last block of the function at `0x100006db0`: a `call` at `0x100006ee0` and the `nop` it falls through to at `0x100006ee5`. `komplex`'s `__text` ends at `0x100006ee5` and `__stubs` begins at `0x100006ee6`, so the call sits **entirely inside** `__text` while the nop lands in the single byte of padding between the two sections. Checked against the fixture's own Mach-O headers with lief, the report's section list matches exactly — `__text` `0x1000012b0`+`0x5c35`, `__stubs` at `0x100006ee6` — so nothing is misdescribed. Recovery simply followed a fall-through one byte past the end of a section, and that byte is still inside the mapped `__TEXT` segment.

What loses them is that planting was all-or-nothing per block:

```python
if section["executable"] and section["va_start"] <= block_offset and block_offset + len(chunk) <= section["va_end"]:
```

The block is both instructions, six bytes, `0x100006ee0`–`0x100006ee6`. One byte past `__text` fails the test, so the whole block is skipped — taking the five-byte call that fits perfectly with it. The `9090909090` the reproducer reads back at `0x100006ee0` is the synthesizer's own NOP fill, never overwritten.

Your instinct about the shared layout code was right, with a wrinkle: the loop is not in `BinarySynthesizer`, it is **byte-identical copies** of it in `ElfSynthesizer` and `MachoSynthesizer`, which is exactly why both formats lose the same two. PE never had the problem because it ignores the report's section list and builds one `.text` spanning `min_rva` to `align_up(max_rva)` across every function extent.

## The change

Blocks are now planted **per overlapping range** rather than whole, so bytes that fit are written even when the block crosses a boundary. A section whose block runs past its end **grows to cover it**, capped at the following section's start, so growth only ever claims address space no other section describes — for `komplex` that is exactly the one padding byte between `__text` and `__stubs`. Bytes that still land nowhere are reported with a count rather than the block vanishing.

The shared version lives in `BinarySynthesizer` and replaces both copies. PE is untouched.

## Validation

Every bundled fixture round-tripped through all three formats, before and after:

| fixture | format | before | after |
|---|---|---|---|
| `komplex` | ELF | 4912 / 4914 | **4914 / 4914** |
| `komplex` | Mach-O | 4912 / 4914 | **4914 / 4914** |
| `komplex` | PE | 4914 / 4914 | 4914 / 4914 |

**Every other fixture is byte-identical before and after** — `cutwail`, `bashlite`, `mirai_i386`, `mirai_x64`, `aarch64_static`, `aarch64_switch_macho_O0`, `pe_export_label_test`, `rust_pe_gnu`. The ELF synthesizer now emits no warning at all for `komplex`, where it previously reported `block 0x100006ee0 of function 0x100006db0 fits no executable section, skipped`.

Full suite green (1,187 passed, 1 skipped), `ruff check`, `ruff format --check` and `ty` clean with zero errors, diff coverage 100%. Benchmark fixtures unchanged to 0.000% of primitive calls with no `report_hash` moving, as expected — synthesis is not on the disassembly path.

Six regression tests, all verified to fail on `master`: the overflow growth, growth capped at a neighbouring section with the fitting bytes still planted, growth taking only the overflow rather than the whole gap, a block starting in a gap being reported, a block below its section being clipped rather than wrapping to the end of the buffer, and the `komplex` end-to-end round-trip in all three formats.

## Unrelated observations from the sweep

Worth separate issues rather than folding in here, all pre-existing and untouched by this change:

- PE synthesis reads back fewer instructions than ELF/Mach-O on several fixtures — `aarch64_static` 18963/19881, `bashlite` 7733/8767, `mirai_i386` 13365/14758, `mirai_x64` 11762/12564 — while ELF and Mach-O are 100% on all four.
- `rust_pe_gnu` round-trips fully through PE and ELF but reads back 0/154207 through Mach-O.
- `synthesizeBinary` raises `ValueError` for reports whose architecture did not resolve (the non-x86 `mirai_*` fixtures, `asprox`).

Happy to file those separately if useful.
