### PR TITLE
fix(core): read the stored header only when it is this format's own

### DIFF
--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -95,8 +95,17 @@ class ElfSynthesizer(BinarySynthesizer):
     def _getBitness(self):
         return 64 if self.report.bitness == 64 else 32
 
+    def _hasElfHeader(self, min_length):
+        """True only when the stored header is long enough AND is itself an ELF header.
+
+        A report keeps the header of the binary it came from, whatever format that was, so
+        reading these fields off a PE or Mach-O header yields whatever those bytes happen to
+        hold -- an e_type of 0xb8, say, which is not a defined ELF type at all.
+        """
+        return self._hasHeader(min_length) and bytes(self.report.xheader[0:4]) == b"\x7fELF"
+
     def _getMachine(self):
-        if self._hasHeader(0x14):
+        if self._hasElfHeader(0x14):
             machine = struct.unpack("<H", self.report.xheader[0x12:0x14])[0]
             if machine:
                 return machine
@@ -380,9 +389,9 @@ class ElfSynthesizer(BinarySynthesizer):
         ehdr[4] = 2 if is_64 else 1
         ehdr[5] = 1
         ehdr[6] = 1
-        if self._hasHeader(16):
+        if self._hasElfHeader(16):
             ehdr[7:16] = self.report.xheader[7:16]
-        e_type = struct.unpack("<H", self.report.xheader[16:18])[0] if self._hasHeader(18) else ET_EXEC
+        e_type = struct.unpack("<H", self.report.xheader[16:18])[0] if self._hasElfHeader(18) else ET_EXEC
         machine = self._getMachine()
         entry = 0
         if self.report.oep:

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -98,14 +98,25 @@ class MachoSynthesizer(BinarySynthesizer):
             self._warn("Mach-O synthesis from sections failed (%s), falling back to minimal layout", exc)
             return self._synthesizeMinimal(offsets)
 
+    def _hasMachoHeader(self, min_length):
+        """True only when the stored header is long enough AND is itself a Mach-O header.
+
+        A report keeps the header of the binary it came from, whatever format that was, so
+        reading these fields off a PE or ELF header yields whatever those bytes happen to hold.
+        """
+        if not self._hasHeader(min_length):
+            return False
+        magic = struct.unpack("<I", self.report.xheader[0:4])[0]
+        return magic in (MH_MAGIC, MH_CIGAM, MH_MAGIC_64, MH_CIGAM_64)
+
     def _is64(self):
-        if self._hasHeader(4):
+        if self._hasMachoHeader(4):
             magic = struct.unpack("<I", self.report.xheader[0:4])[0]
             return magic in (MH_MAGIC_64, MH_CIGAM_64)
         return self.report.bitness != 32
 
     def _getCpuType(self):
-        if self._hasHeader(8):
+        if self._hasMachoHeader(8):
             cpu_type = struct.unpack("<I", self.report.xheader[4:8])[0]
             if cpu_type:
                 return cpu_type
@@ -114,12 +125,12 @@ class MachoSynthesizer(BinarySynthesizer):
         return CPU_TYPE_X86_64 if self._is64() else CPU_TYPE_I386
 
     def _getCpuSubtype(self):
-        if self._hasHeader(12):
+        if self._hasMachoHeader(12):
             return struct.unpack("<I", self.report.xheader[8:12])[0]
         return 0
 
     def _getFiletype(self):
-        if self._hasHeader(16):
+        if self._hasMachoHeader(16):
             return struct.unpack("<I", self.report.xheader[12:16])[0]
         return MH_EXECUTE
 

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import struct
+import types
 import unittest
 from pathlib import Path
 
@@ -608,3 +609,80 @@ class SynthesisLayoutTestSuite(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SynthesisForeignHeaderTestSuite(unittest.TestCase):
+    """A report keeps the header of the binary it came from. A synthesizer must only read its
+    own format's fields out of it, or it decodes whatever those bytes happen to hold."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # a PE-origin report based above 4 GiB: a 32-bit Mach-O cannot express its addresses
+        cls.pe_origin = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_load_xored_fixture("rust_pe_gnu_xored"))
+
+    def test_a_pe_header_does_not_make_a_64_bit_report_a_32_bit_macho(self):
+        blob = bytes(self.pe_origin.synthesizeBinary(output_format=FORMAT_MACHO))
+
+        self.assertEqual(struct.unpack("<I", blob[:4])[0], 0xFEEDFACF)
+
+    def test_a_pe_header_does_not_supply_the_macho_cpu_type(self):
+        blob = bytes(self.pe_origin.synthesizeBinary(output_format=FORMAT_MACHO))
+
+        # CPU_TYPE_X86_64, derived from the report, not bytes 4:8 of an MZ header
+        self.assertEqual(struct.unpack("<I", blob[4:8])[0], 0x01000007)
+
+    def test_addresses_above_four_gib_survive_the_macho_round_trip(self):
+        parsed = lief.parse(list(bytes(self.pe_origin.synthesizeBinary(output_format=FORMAT_MACHO))))
+
+        lost = 0
+        for function in self.pe_origin.getFunctions():
+            for block in function.getBlocks():
+                for instruction in block.getInstructions():
+                    expected = bytes.fromhex(instruction.bytes)
+                    try:
+                        got = bytes(parsed.get_content_from_virtual_address(instruction.offset, len(expected)))
+                    except Exception:
+                        got = b""
+                    lost += got != expected
+        self.assertEqual(lost, 0)
+
+    def test_a_real_macho_header_still_selects_the_word_size(self):
+        from smda.synthesis.MachoSynthesizer import MachoSynthesizer
+
+        synthesizer = MachoSynthesizer.__new__(MachoSynthesizer)
+        # a 32-bit Mach-O header must still win over a report claiming 64-bit
+        synthesizer.report = types.SimpleNamespace(
+            xheader=struct.pack("<I", 0xFEEDFACE) + b"\x00" * 0x40, bitness=64, architecture="intel"
+        )
+        self.assertFalse(synthesizer._is64())
+
+        synthesizer.report.xheader = struct.pack("<I", 0xFEEDFACF) + b"\x00" * 0x40
+        self.assertTrue(synthesizer._is64())
+
+    def test_a_foreign_header_falls_back_to_the_report_bitness(self):
+        from smda.synthesis.MachoSynthesizer import MachoSynthesizer
+
+        synthesizer = MachoSynthesizer.__new__(MachoSynthesizer)
+        synthesizer.report = types.SimpleNamespace(xheader=b"MZ" + b"\x90" * 0x40, bitness=64, architecture="intel")
+        self.assertTrue(synthesizer._is64())
+
+        synthesizer.report.bitness = 32
+        self.assertFalse(synthesizer._is64())
+
+    def test_a_pe_header_does_not_reach_the_synthesized_elf_identity(self):
+        blob = bytes(self.pe_origin.synthesizeBinary(output_format=FORMAT_ELF))
+        e_type = struct.unpack("<H", blob[16:18])[0]
+
+        self.assertEqual(blob[7:16], b"\x00" * 9)  # EI_PAD must be zero
+        self.assertEqual(e_type, 2)  # ET_EXEC, not whatever bytes 16:18 of an MZ header hold
+
+    def test_a_real_elf_header_still_supplies_the_identity(self):
+        from smda.synthesis.ElfSynthesizer import ElfSynthesizer
+
+        synthesizer = ElfSynthesizer.__new__(ElfSynthesizer)
+        synthesizer.report = types.SimpleNamespace(
+            xheader=b"\x7fELF" + bytes(range(4, 0x14)) + b"\x00" * 0x20, bitness=64, architecture="intel"
+        )
+        self.assertTrue(synthesizer._hasElfHeader(0x14))
+        self.assertEqual(synthesizer._getMachine(), struct.unpack("<H", bytes(range(4, 0x14))[0x0E:0x10])[0])


### PR DESCRIPTION
Fixes #235.

## Cause

A report keeps the header of the binary it came from, whatever format that was, and `_hasHeader()` only checks that one exists and is long enough. The Mach-O and ELF synthesizers read their own header fields out of it regardless, so a report from another format decodes whatever those bytes happen to hold.

For Mach-O this is not cosmetic. `_is64()` reads bytes 0:4 as a Mach-O magic; a PE report's `MZ` header is not `MH_MAGIC_64`, so it answers `False` and the correct `report.bitness` fallback on the next line is never reached. A 64-bit report is then written as a 32-bit Mach-O and every address is truncated mod 2³². `rust_pe_gnu` is based at `0x140000000`, so all 154207 of its instructions land at `0x40000000` and none can be read back. `_getCpuType()` has the same shape and stamped `CPU_TYPE_I386`, taken from bytes 4:8 of the DOS header, onto an x86-64 report.

## The ELF sibling, found while sweeping the class

The same defect is present in `ElfSynthesizer`, milder because it does not corrupt addresses: `e_ident[7:16]` was copied from a foreign header and `e_type` read from its bytes 16:18. Measured on `master`, a PE-origin report produces `e_type = 0xb8` and a Mach-O-origin one `e_type = 0x17` — neither is a defined ELF type — with a non-zero `EI_PAD` that the spec requires to be zero. Both are fixed here, since it is one bug class rather than two.

`PeSynthesizer` needs no change: it parses the stored header with lief first and falls back to a minimal header when that fails, which is the behaviour the other two were missing. `MachoSynthesizer._parseSegments` already validated the magic the same way — the four accessor methods simply did not.

## Measured

| fixture | origin | base | Mach-O before | Mach-O after |
|---|---|---|---|---|
| `rust_pe_gnu` | PE | `0x140000000` | **0 / 154207** | **154207 / 154207** |
| `cutwail` | PE | `0x4000000` | 1611 / 1611 | 1611 / 1611 |
| `komplex` | Mach-O | `0x100000000` | 4912 / 4914 | 4912 / 4914 |

Round-trip loop from #232, against `master` at `5ad5504`. Every bundled fixture was swept in all three formats and `rust_pe_gnu`'s Mach-O column is the only one that moves.

`cutwail` shows the fallback behaving: it is also PE-origin, and it correctly stays a 32-bit Mach-O because its report says `bitness = 32`. `komplex` is unchanged at 4912/4914 because that is the separate #232 defect, fixed in #234 — the two PRs are independent and touch different files.

## Validation

Full suite green (1,188 passed, 1 skipped), `ruff check`, `ruff format --check` and `ty` clean with zero errors, diff coverage 100%.

Seven regression tests, six of which fail on `master`: the emitted magic for a PE-origin 64-bit report, the CPU type not coming from DOS-header bytes, the round-trip above 4 GiB, a real Mach-O header still selecting the word size in both directions, a foreign header falling back to `report.bitness` in both directions, the ELF identity not inheriting foreign bytes, and a real ELF header still supplying it.
