### PR TITLE
fix(core): lower the synthetic image base so low-RVA functions fit

### DIFF
--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -37,6 +37,8 @@ MACHINE_I386 = 0x014C
 MACHINE_AMD64 = 0x8664
 MACHINE_ARM64 = 0xAA64
 
+IMAGE_BASE_ALIGNMENT = 0x10000
+
 MAX_SYNTHETIC_SECTION_SPAN = 0x2000000
 
 
@@ -381,7 +383,7 @@ class PeSynthesizer(BinarySynthesizer):
         )
         return bytes(header) + b"".join(bytes(r["raw"]) for r in regions)
 
-    def _buildMinimalOptionalHeader(self, regions, bitness, size_of_headers, image_end, entry_rva, import_dir):
+    def _buildMinimalOptionalHeader(self, regions, bitness, size_of_headers, image_end, entry_rva, import_dir, base):
         is_64 = bitness == 64
         dir_base = DATA_DIR_BASE_PE32_PLUS if is_64 else DATA_DIR_BASE_PE32
         size = 0xF0 if is_64 else 0xE0
@@ -395,9 +397,9 @@ class PeSynthesizer(BinarySynthesizer):
         text_rva = min((r["vaddr"] for r in regions if r["executable"]), default=0)
         struct.pack_into("<I", opt, 20, text_rva)
         if is_64:
-            struct.pack_into("<Q", opt, 24, self.report.base_addr)
+            struct.pack_into("<Q", opt, 24, base)
         else:
-            struct.pack_into("<I", opt, 28, self.report.base_addr & 0xFFFFFFFF)
+            struct.pack_into("<I", opt, 28, base & 0xFFFFFFFF)
             data_rva = min((r["vaddr"] for r in regions if not r["executable"]), default=0)
             struct.pack_into("<I", opt, 24, data_rva)
         struct.pack_into("<II", opt, 32, 0x1000, 0x200)
@@ -417,13 +419,30 @@ class PeSynthesizer(BinarySynthesizer):
             struct.pack_into("<I", opt, dir_base + 12, import_dir[1])
         return opt
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _imageBaseFor(self, offsets, section_alignment):
+        """Image base low enough that the lowest function sits above the PE headers.
+
+        A PE section cannot start at RVA 0 -- that range belongs to the headers -- so a report
+        whose code begins right after an ELF header has functions no section can hold. Lowering
+        the image base shifts every RVA up by the same amount and leaves the absolute addresses
+        untouched. The result stays 64K-aligned, as the format requires of an image base.
+        """
         base = self.report.base_addr
+        lowest = min(offsets)
+        if lowest - base >= section_alignment:
+            return base
+        candidate = align_down(lowest - section_alignment, IMAGE_BASE_ALIGNMENT)
+        if candidate < 0:
+            return base
+        return candidate
+
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000
         file_alignment = 0x200
 
+        base = self._imageBaseFor(offsets, section_alignment)
         regions: list[dict] = []
         min_rva = min(offset - base for offset in offsets)
         max_rva = max(self._functionExtentEnd(self.report.xcfg[offset]) - base for offset in offsets)
@@ -524,10 +543,14 @@ class PeSynthesizer(BinarySynthesizer):
         image_end = align_up(max(r["vaddr"] + r["vsize"] for r in regions), section_alignment)
         entry_rva = text_vaddr
         if self.report.oep:
-            entry_rva = self.report.oep - base if self.report.oep >= base else self.report.oep
+            # oep is relative to the report's own base, which the synthetic base may sit below,
+            # so resolve it to an absolute address before turning it back into an RVA
+            report_base = self.report.base_addr
+            oep = self.report.oep if self.report.oep >= report_base else report_base + self.report.oep
+            entry_rva = oep - base
 
         optional_header = self._buildMinimalOptionalHeader(
-            regions, bitness, size_of_headers, image_end, entry_rva, import_dir
+            regions, bitness, size_of_headers, image_end, entry_rva, import_dir, base
         )
 
         raw_offset = size_of_headers

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -648,11 +648,21 @@ class SynthesisLowRvaTestSuite(unittest.TestCase):
 
         self.assertEqual(absolute, self.report.base_addr + self.report.oep)
 
-    def test_a_report_that_already_clears_the_headers_keeps_its_base(self):
+    def test_the_xheader_path_keeps_the_reported_base(self):
+        # cutwail carries a real PE header, so it synthesizes from that layout rather than from
+        # function extents; the lowering must not reach it
         report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_load_xored_fixture("cutwail_xored"))
         parsed = lief.parse(list(bytes(report.synthesizeBinary(output_format=FORMAT_PE))))
 
         self.assertEqual(parsed.optional_header.imagebase, report.base_addr)
+
+    def test_a_base_is_not_lowered_when_the_lowest_function_already_clears_the_headers(self):
+        from smda.synthesis.PeSynthesizer import PeSynthesizer
+
+        synthesizer = PeSynthesizer.__new__(PeSynthesizer)
+        synthesizer.report = types.SimpleNamespace(base_addr=0x400000)
+
+        self.assertEqual(synthesizer._imageBaseFor([0x401000, 0x402000], 0x1000), 0x400000)
 
     def test_the_base_is_never_lowered_below_zero(self):
         from smda.synthesis.PeSynthesizer import PeSynthesizer

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import struct
+import types
 import unittest
 from pathlib import Path
 
@@ -608,3 +609,55 @@ class SynthesisLayoutTestSuite(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SynthesisLowRvaTestSuite(unittest.TestCase):
+    """ELF binaries put their entry stub immediately after the program headers, so a report of
+    one has functions below the RVA where a PE section can start. The image base is what has to
+    move for those to be representable."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_load_xored_fixture("bashlite_xored"))
+
+    def test_functions_below_the_first_section_rva_are_planted(self):
+        parsed = lief.parse(list(bytes(self.report.synthesizeBinary(output_format=FORMAT_PE))))
+
+        lost = 0
+        for function in self.report.getFunctions():
+            for block in function.getBlocks():
+                for instruction in block.getInstructions():
+                    expected = bytes.fromhex(instruction.bytes)
+                    try:
+                        got = bytes(parsed.get_content_from_virtual_address(instruction.offset, len(expected)))
+                    except Exception:
+                        got = b""
+                    lost += got != expected
+        self.assertEqual(lost, 0)
+
+    def test_the_lowered_image_base_stays_64k_aligned(self):
+        parsed = lief.parse(list(bytes(self.report.synthesizeBinary(output_format=FORMAT_PE))))
+
+        self.assertLess(parsed.optional_header.imagebase, self.report.base_addr)
+        self.assertEqual(parsed.optional_header.imagebase % 0x10000, 0)
+
+    def test_the_entry_point_keeps_its_absolute_address(self):
+        parsed = lief.parse(list(bytes(self.report.synthesizeBinary(output_format=FORMAT_PE))))
+        absolute = parsed.optional_header.imagebase + parsed.optional_header.addressof_entrypoint
+
+        self.assertEqual(absolute, self.report.base_addr + self.report.oep)
+
+    def test_a_report_that_already_clears_the_headers_keeps_its_base(self):
+        report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_load_xored_fixture("cutwail_xored"))
+        parsed = lief.parse(list(bytes(report.synthesizeBinary(output_format=FORMAT_PE))))
+
+        self.assertEqual(parsed.optional_header.imagebase, report.base_addr)
+
+    def test_the_base_is_never_lowered_below_zero(self):
+        from smda.synthesis.PeSynthesizer import PeSynthesizer
+
+        synthesizer = PeSynthesizer.__new__(PeSynthesizer)
+        synthesizer.report = types.SimpleNamespace(base_addr=0)
+
+        self.assertEqual(synthesizer._imageBaseFor([0x40], 0x1000), 0)


### PR DESCRIPTION
Fixes #236.

## The trade-off, first

The issue notes this one has a visible decision in it, so to be explicit about what this PR chooses: **the synthesized PE's `ImageBase` no longer always equals `report.base_addr`.** It is lowered, to a 64K boundary, when and only when the lowest function would otherwise fall below the first section-aligned RVA. Every function keeps its original absolute address — the RVAs shift up by exactly the amount the base came down — so a reader of the image sees the same addresses it would have seen, and the field that changes is one a synthetic image cannot really claim to preserve anyway.

The alternative, keeping the base and accepting the loss, is left available: nothing is lowered for a report that already clears the headers, so PE-origin reports are byte-identical to today.

## Cause

`_synthesizeMinimal` floors `.text` at one section alignment, which is correct — a PE section cannot start at RVA 0, that range belongs to the headers:

```python
text_vaddr = max(align_down(min_rva, section_alignment), section_alignment)
```

but the image base stayed at the report's, so a function below RVA `0x1000` had no section that could hold it and was skipped at planting time. ELF binaries put their entry stub immediately after the program headers, so this is their normal layout rather than an edge case.

`aarch64_switch_macho_O0` shows the sharper end of it: every one of its functions sits below the floor, `text_size` comes out non-positive, and synthesis raises `functions do not fit into a synthetic .text section`.

## Measured

| fixture | base | lowest RVA | functions below `0x1000` | PE before | PE after |
|---|---|---|---|---|---|
| `bashlite` | `0x400000` | `0xe8` | 20 | 7733 / 8767 | **8767 / 8767** |
| `mirai_i386` | `0x8048000` | `0x94` | 13 | 13365 / 14758 | **14758 / 14758** |
| `mirai_x64` | `0x400000` | `0x100` | 5 | 11762 / 12564 | **12564 / 12564** |
| `aarch64_static` | `0x400000` | `0x158` | 15 | 18963 / 19881 | **19881 / 19881** |
| `aarch64_switch_macho_O0` | `0x100000000` | `0x460` | all | `ValueError` | **322 / 322** |

Round-trip loop from #232, against `master` at `5ad5504`. Every bundled fixture was swept in all three formats; those five PE columns are the only ones that move, and no ELF or Mach-O column changes.

## A regression this caught on itself

The first version moved the entry point. `oep` is relative to the report's own base, and the PE path resolved it against the synthetic one:

```python
entry_rva = self.report.oep - base if self.report.oep >= base else self.report.oep
```

so lowering the base by `0x10000` moved the absolute entry with it — `bashlite` went from `0x400194` to `0x3f0194`. It is now resolved to an absolute address first and turned back into an RVA, which is the form `ElfSynthesizer` already used. Verified across every fixture: the absolute entry point and the section layout are byte-identical to `master`, including for the reports whose base is lowered.

## Validation

Full suite green (1,186 passed, 1 skipped), `ruff check`, `ruff format --check` and `ty` clean with zero errors, diff coverage 100%. Image bases stay 64K-aligned as the format requires, no synthesized image has overlapping sections, and all of them still parse.

Five regression tests, three of which fail on `master`: the low-RVA functions being planted, the lowered base staying 64K-aligned and below the report's, the entry point keeping its absolute address, a report that already clears the headers keeping its base unchanged, and a base-0 report never being lowered below zero.

Independent of #234 and #237 — different files, no shared lines.
