### PR TITLE
ci: skip the PR title check for Dependabot

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   validate-pr-title:
     name: Validate PR title
+    # Dependabot titles its PRs with a deps/deps-dev scope that this list does not allow,
+    # and its titles are not editable by a maintainer without closing the PR.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check Conventional Commit format


### PR DESCRIPTION
Dependabot titles its PRs `build(deps-dev): bump X from A to B`. The scope `deps-dev` is not in the allowed list, and a maintainer cannot edit a Dependabot title without closing the PR — so `Validate PR title` fails on every one of them. #242 merged with that check red, as did the two before it.

This skips the check for `dependabot[bot]` and nothing else. Titles from every other author are validated exactly as before.

## Scope reduced

This PR previously also bumped the `ty` pin from `0.0.68` to `0.0.70` and carried the two `binweight: float = 0` annotations that the version's new `unsound-*` rules wanted. That half is dropped: #241 has since taken the pin to `0.0.69` through Dependabot's own cadence, which is what made this branch conflict, and pinning is better left to that cadence than to a hand-written bump that goes stale between review rounds. The two annotations are correct on their own and belong with whichever bump lands next.

What remains is the three-line CI change, rebased onto current master and conflict-free.
