### PR TITLE
fix(labels): stop Delphi method-table walks at the first unreadable entry

### DIFF
--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -366,6 +366,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
         function_offset = dynamic_offset + 2 + (2 * table_length)
         for _ in range(table_length):
             method_addr = self._read_ptr(function_offset, self._ptr_size)
+            if method_addr is None:
+                break
             if method_addr and self._binary_info.isInCodeAreas(method_addr):
                 function_offsets.add(method_addr)
             function_offset += self._ptr_size

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -596,7 +596,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
             me_addr = self._read_ptr(me_ref_offset)
 
             if me_addr is None:
-                continue
+                break
 
             me_offset = self._addr_to_offset(me_addr)
             method_info = self._extract_method_info(me_offset)

--- a/tests/testDelphiPythiaProvider.py
+++ b/tests/testDelphiPythiaProvider.py
@@ -189,5 +189,55 @@ class TestDelphiReSymNegativeOffsets(unittest.TestCase):
         self.assertIsNone(parser._extract_method_info(-1))
 
 
+class TestDelphiTableWalksStopAtTheImageEdge(unittest.TestCase):
+    """Both walks take their entry count from a 16-bit field in the image, so a corrupt or
+    hostile table declares up to 65535 entries. The read offset only grows, so the first
+    unreadable entry means every later one is unreadable too: the walk has to stop there
+    instead of running out the declared count."""
+
+    def test_dynamic_method_walk_stops_at_the_image_edge(self):
+        provider = DelphiPythiaProvider.__new__(DelphiPythiaProvider)
+        provider._base_addr = 0x400000
+        provider._bitness = 32
+        provider._binary_info = SimpleNamespace(isInCodeAreas=lambda addr: True)
+        table_length = 0xFFFF
+        # the pointer array follows the 2-byte count plus one word per declared entry
+        pointers_offset = 2 + 2 * table_length
+        binary = bytearray(pointers_offset + 8)
+        binary[0:2] = struct.pack("<H", table_length)
+        binary[pointers_offset : pointers_offset + 8] = struct.pack("<II", 0x401000, 0x402000)
+        provider._binary = bytes(binary)
+        reads = []
+        read_ptr = provider._read_ptr
+        provider._read_ptr = lambda offset, ptr_size: reads.append(offset) or read_ptr(offset, ptr_size)
+        class_info = SimpleNamespace(dynamic_table_addr=provider._base_addr)
+        function_offsets = set()
+
+        provider._extract_dynamic_methods(class_info, function_offsets)
+
+        self.assertEqual(function_offsets, {0x401000, 0x402000})
+        self.assertEqual(len(reads), 3)
+
+    def test_method_definition_table_walk_stops_at_the_image_edge(self):
+        provider = DelphiReSymProvider.__new__(DelphiReSymProvider)
+        provider._base_addr = 0x400000
+        provider._settings = SimpleNamespace(ptr_size=4, jump_dist=0)
+        entry_stride = provider._settings.ptr_size + 4
+        binary = bytearray(4 + 2 * entry_stride)
+        binary[2:4] = struct.pack("<H", 0xFFFF)
+        binary[4:8] = struct.pack("<I", 0x401000)
+        binary[4 + entry_stride : 8 + entry_stride] = struct.pack("<I", 0x402000)
+        provider._binary = bytes(binary)
+        provider._extract_method_info = lambda offset: {"offset": offset}
+        reads = []
+        read_ptr = provider._read_ptr
+        provider._read_ptr = lambda offset: reads.append(offset) or read_ptr(offset)
+
+        methods = provider._parse_mdt(0)
+
+        self.assertEqual(methods, [{"offset": 0x1000}, {"offset": 0x2000}])
+        self.assertEqual(len(reads), 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -247,6 +247,59 @@ class TestJumpTableSignedness(unittest.TestCase):
         self.assertEqual(result, [0x1000])
 
 
+class BogusTableBoundTestSuite(unittest.TestCase):
+    """_findJumpTableSize takes the first `cmp reg, imm` from the backtrack window, so an
+    unrelated compare becomes the entry count: a 32-bit float classification (`cmp ecx,
+    0x7f800000`, the IEEE-754 infinity pattern) sitting a few instructions ahead of a switch
+    yields a bound of 0x7f800001 entries. Both table readers must therefore stop at the first
+    unreadable entry -- the read offset only grows, so every later entry is unreadable too, and
+    continuing instead of stopping spends billions of iterations recovering nothing."""
+
+    BOGUS_SIZE = 0x7F800000 + 1
+    # a stopping scan reads one entry past the last in-image one; anything beyond that is the
+    # runaway, and this bound keeps the pre-fix behaviour a fast failure rather than a hang
+    CALL_BUDGET = 16
+
+    def test_direct_table_scan_stops_at_the_image_edge(self):
+        analyzer = _makeAnalyzer(base_addr=0x1000, binary_size=0x100)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(side_effect=lambda addr: 0x1000 <= addr < 0x1100)
+        table = struct.pack("<II", 0x1010, 0x1020)
+        calls = []
+
+        def getBytes(addr, size):
+            calls.append(addr)
+            self.assertLessEqual(len(calls), self.CALL_BUDGET, "table scan did not stop at the image edge")
+            if not 0x1000 <= addr < 0x1100:
+                return None
+            return table[addr - 0x10F8 : addr - 0x10F8 + size]
+
+        analyzer.disassembly.getBytes = getBytes
+
+        result = analyzer._extractDirectTableOffsets(jumptable_size=self.BOGUS_SIZE, off_jumptable=0x10F8)
+
+        self.assertEqual(result, [0x1010, 0x1020])
+
+    def test_relative_table_scan_stops_at_the_buffer_end(self):
+        # getRawBytes slices the mapped image, so a read past its end comes back short
+        # rather than as None -- the same runaway with a different failure shape.
+        analyzer = _makeAnalyzer(base_addr=0x1000, binary_size=0x100)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(side_effect=lambda addr: 0x1000 <= addr < 0x1100)
+        # the switch bodies precede the table here, so the relative entries are negative
+        table = struct.pack("<ii", -0x98, -0x88)
+        calls = []
+
+        def getRawBytes(offset, size):
+            calls.append(offset)
+            self.assertLessEqual(len(calls), self.CALL_BUDGET, "table scan did not stop at the buffer end")
+            return table[offset - 0xF8 : offset - 0xF8 + size]
+
+        analyzer.disassembly.getRawBytes = getRawBytes
+
+        result = analyzer._extractRelativeTableOffsets(jumptable_size=self.BOGUS_SIZE, off_jumptable=0x10F8)
+
+        self.assertEqual(result, [0x1060, 0x1070])
+
+
 class X64BonusOffsetTestSuite(unittest.TestCase):
     def test_bonus_offset_taken_from_the_first_matching_mov(self):
         analyzer = _makeAnalyzer(bitness=64)


### PR DESCRIPTION
Rebased onto 802e627 to clear a merge conflict, and the conflict turned out to be informative: half of what this PR proposed had already landed by another route, so that half is now dropped and only the part that is still missing remains.

## What the rebase resolved

The original PR changed two `continue`s to `break`s in `JumpTableAnalyzer` and two more in the Delphi walks. #285's jump-table rewrite reached the same conclusion for the intel half independently, and did it better: the short-read stop is there at the entry read, and the `rebased < 0` check was hoisted out of the loop into an early `return` rather than being tested once per declared entry, which is right because the condition is loop-invariant.

Both conflicts were resolved in favour of master. `src/smda/intel/JumpTableAnalyzer.py` is now byte-identical to master, and this PR makes no intel source change at all.

## What is left, and why it is still needed

The Delphi half is unchanged on master:

- `DelphiPythiaProvider._extract_dynamic_methods` reads a method pointer and never checks for `None`, so an unreadable entry falls through to `function_offset += self._ptr_size` and the walk continues to its declared `table_length`. The two neighbouring walks in the same file already stop on exactly this condition, so this site is the odd one out rather than a deliberate choice.
- `DelphiReSymProvider` skips an unreadable method-entry pointer and keeps going, walking the whole declared table when the first failure already establishes the table is not there.

Same root cause as the intel half: a declared table length comes from the binary, so treating an unreadable entry as skippable spends that length as an iteration count.

## Tests

The intel tests are kept even though the intel fix is gone. They pass against master's implementation unmodified, and nothing on master pins the behaviour today, so they turn a property two separate changes arrived at independently into one a later refactor cannot quietly undo. Their commit is now `test(intel)` rather than `fix(intel)`, since it no longer changes any source.

| test | pins |
| --- | --- |
| `test_direct_table_scan_stops_at_the_image_edge` | direct scan stops at the image edge |
| `test_relative_table_scan_stops_at_the_buffer_end` | relative scan stops at the end of the buffer |
| `test_dynamic_method_walk_stops_at_the_image_edge` | Pythia dynamic-method walk stops |
| `test_method_definition_table_walk_stops_at_the_image_edge` | Pythia method-definition walk stops |

## Validation

| command | result |
| --- | --- |
| `ruff check .` | clean |
| `ruff format --check .` | 246 files already formatted |
| `make typecheck` | exit 0 |
| full test suite | 1791 passed, 1 skipped, 2579 subtests |
| diff coverage vs master | 100%, 3/3 lines |
