### PR TITLE
fix(labels): decode non-ASCII identifiers in Rust v0 symbols

### DIFF
--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -101,7 +101,7 @@ class Ident:
         self.out[i] = c
         return True
 
-    def punycode_decode(self) -> Optional[None]:
+    def punycode_decode(self) -> Optional[bool]:
         count = 0
         punycode_bytes = self.punycode
         try:
@@ -151,10 +151,12 @@ class Ident:
             n += i // lent
             i %= lent
 
-            try:
-                c = chr(n)
-            except (ValueError, OverflowError):
+            # mirror char::from_u32: a scalar value, so no surrogate and nothing past the
+            # last code point. chr() accepts surrogates, and a name carrying one cannot be
+            # encoded as UTF-8 by whoever consumes the report.
+            if not 0 <= n <= 0x10FFFF or 0xD800 <= n <= 0xDFFF:
                 return None
+            c = chr(n)
 
             if not self.insert(i, c):
                 return None
@@ -163,7 +165,7 @@ class Ident:
             try:
                 punycode_bytes[count]
             except IndexError:
-                return
+                return True
 
             delta = delta // damp
             damp = 2

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -11,6 +11,7 @@ from smda.common.labelprovider.rust_demangler import demangle
 from smda.common.labelprovider.rust_demangler.rust import TypeNotFoundError
 from smda.common.labelprovider.rust_demangler.rust_legacy import LegacyDemangler, UnableToLegacyDemangle
 from smda.common.labelprovider.rust_demangler.rust_v0 import (
+    Ident,
     Parser,
     Printer,
     UnableTov0Demangle,
@@ -112,6 +113,28 @@ class TestRustDemangler(unittest.TestCase):
     def test_v0_unnamed_closure_has_no_stray_colon(self):
         # unnamed closures/shims must render as {closure#N}, not {closure:#N}
         self.assertEqual(demangle("_RNCNvC8rustc_v01fs_0"), "rustc_v0::f::{closure#1}")
+
+    def test_v0_non_ascii_identifier_is_decoded(self):
+        # the decode itself always worked; its success was reported as None,
+        # which is what every failure path returns, so the caller fell back
+        name = "_RNqCs4fqI2P2rA04_11utf8_identsu30____7hkackfecea1cbdathfdh9hlq6y"
+        self.assertEqual(demangle(name), "utf8_idents::საჭმელად_გემრიელი_სადილი")
+        self.assertNotIn("punycode{", demangle(name))
+
+    def test_v0_punycode_never_decodes_to_a_surrogate(self):
+        # chr() accepts 0xD800-0xDFFF where Rust's char::from_u32 refuses; a name carrying
+        # one cannot be encoded as UTF-8 by whoever consumes the report
+        name = "_RNvCu4_ib9b4main"
+
+        demangled = demangle(name)
+
+        self.assertNotIn("\ud800", demangled)
+        demangled.encode("utf-8")
+
+    def test_v0_undecodable_punycode_still_falls_back_to_the_raw_form(self):
+        ident = Ident("", "!not-punycode!")
+        ident.display()
+        self.assertEqual(ident.disp, "punycode{!not-punycode!}")
 
     def test_v0_empty_const_hex_nibbles_raise_demangler_error(self):
         # `Kh_` (u8 const with zero hex nibbles) previously escaped as a bare

--- a/tests/test_fuzz_rust_demangler.py
+++ b/tests/test_fuzz_rust_demangler.py
@@ -26,6 +26,9 @@ def test_rust_demangler_never_hangs(s):
     """
     try:
         result = demangle(s)
+        # a demangled name is handed to consumers as text; a lone surrogate would make it
+        # unencodable, so the demangler must never produce one
+        result.encode("utf-8")
     except (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDemangle):
         return
     except RecursionError:


### PR DESCRIPTION
Fixes #251.

A Rust v0 symbol carrying a punycode-encoded identifier came back with a placeholder where the identifier should be:

```
_RNqCs4fqI2P2rA04_11utf8_identsu30____7hkackfecea1cbdathfdh9hlq6y

before : utf8_idents::punycode{__-7hkackfecea1cbdathfdh9hlq6y}
after  : utf8_idents::საჭმელად_გემრიელი_სადილი
```

That is worse than leaving the symbol mangled, because the reported name matches neither the mangled spelling nor the real one, so it cannot be looked up either way.

## Root cause

The decoder was never broken. Running it on that identifier fills its output buffer with the correct text — the failure is purely in how it reports having done so.

`punycode_decode()` leaves its loop through a bare `return` when the input is exhausted, which yields `None`. Each of its seven failure paths also returns `None`. `try_small_punycode_decode()` then tests `if r is None` and cannot distinguish a completed decode from a rejected one, so every decode — successful or not — took the placeholder branch in `Ident.display()`.

The `-> Optional[None]` annotation says the same thing in the signature: the function had no way to express success.

The fix is to return `True` on completion and widen the annotation. A decode that genuinely fails still falls back to the placeholder, which now has its own test so the fallback is not lost to a later simplification.

## A second defect the fix made reachable

While every decode was being discarded, a second divergence from the reference was unobservable: the code point is built with `chr()`, which accepts the surrogate range `U+D800..U+DFFF`, where Rust's `char::from_u32` refuses it. `_RNvCu4_ib9b4main` decoded to a name holding a lone surrogate, and such a name cannot be encoded as UTF-8 by whatever consumes the report — `SmdaReport` itself survives because `json.dumps` escapes it, but the name is handed to every downstream consumer as a `str`.

Non-scalar values are now rejected explicitly, and the fuzz target encodes every result it gets so the class stays closed rather than resting on this one case.

## Scope of the sweep

The class is *a success path returning the value the failure paths use as their sentinel*. An AST pass over `src/smda/**` for functions mixing a bare `return` with an explicit `return None` finds no other instance, and no other `Optional[None]` annotation remains in the tree.

## Validation

Cross-checked against the 18 mangled symbols in `rustc-demangle` 0.1.28's own test corpus:

| | before | after |
|---|---|---|
| match exactly | 8 | **9** |
| raise, keeping the mangled name | 9 | 9 |
| disagree | 1 | **0** |

The nine that raise are the `#[splat]` grammar, which this port does not implement; raising is the safe outcome there, since the caller then keeps the name the binary gave it.

Separately, on 147 real `_R` symbols read out of a rust-lld/MSVC x64 image, 146 match the reference byte for byte and the remaining one is the unrelated ABI spacing bug fixed in #249 — nothing regressed here.

```
python -m pytest tests/ -q                  1184 passed, 1 skipped
make lint                                   clean
make typecheck                              exit 0, no new diagnostics
```

Independent of #249; the two touch different parts of the same file and both are needed for the output to match the reference exactly.

