### PR TITLE
fix(core): announce a timed-out analysis instead of returning quietly

### DIFF
--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -43,6 +43,7 @@ class Disassembler:
         self._start_time = None
         self._timeout = 0
         self._last_timeout_log_second = -1
+        self._timeout_reported = False
         # cache the last DisassemblyResult
         self.disassembly = None
 
@@ -81,6 +82,14 @@ class Disassembler:
         time_diff = datetime.datetime.now(datetime.timezone.utc) - start_time
         elapsed_seconds = int(time_diff.total_seconds())
         if elapsed_seconds >= self._timeout:
+            if not self._timeout_reported:
+                self._timeout_reported = True
+                LOGGER.warning(
+                    "Analysis stopped after %ds by the configured timeout (%ds): the report is "
+                    'incomplete, its function set is a lower bound, and its status is "timeout".',
+                    elapsed_seconds,
+                    self._timeout,
+                )
             LOGGER.debug("Current analysis callback time %s", time_diff)
             return True
         # Log on 30s bucket transitions (not exact-second boundaries) so the message
@@ -268,6 +277,7 @@ class Disassembler:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
+        self._timeout_reported = False
         self._ensureHashes(binary_info)
         if self.disassembler:
             self.disassembly = self.disassembler.analyzeBuffer(binary_info, self._callbackAnalysisTimeout)

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -588,4 +588,7 @@ class SmdaReport:
             return f"{duration} -> {self.message}"
         arch_str = f"{self.architecture}.{self.bitness}bit" if self.bitness else self.architecture
         base_addr = f"0x{self.base_addr:08x}" if self.base_addr is not None else "0x????????"
-        return f"{duration} -> (architecture: {arch_str}, base_addr: {base_addr}): {len(self.xcfg)} functions"
+        incomplete = " -- INCOMPLETE, analysis hit the timeout" if self.status == "timeout" else ""
+        return (
+            f"{duration} -> (architecture: {arch_str}, base_addr: {base_addr}): {len(self.xcfg)} functions{incomplete}"
+        )

--- a/tests/testDisassemblerReuse.py
+++ b/tests/testDisassemblerReuse.py
@@ -1,3 +1,5 @@
+import datetime
+import logging
 import unittest
 
 from smda.Disassembler import Disassembler
@@ -20,6 +22,54 @@ class TestDisassemblerReuse(unittest.TestCase):
 
         second = d.disassembleBuffer(self.ARM, 0x400000, bitness=64, architecture="arm")
         self.assertEqual(second.status, "error")
+
+
+class TestAnalysisTimeoutIsAnnounced(unittest.TestCase):
+    """A timed-out run returns a partial report that otherwise looks like a complete one, so the
+    stop has to be announced once at default log level rather than only at debug level."""
+
+    def setUp(self):
+        # several test modules call logging.disable(CRITICAL) at import time, and that is
+        # process-global, so assertLogs sees nothing in a full-suite run unless it is lifted
+        previously_disabled = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previously_disabled)
+
+    def _expiredDisassembler(self):
+        disassembler = Disassembler()
+        disassembler._timeout = 10
+        disassembler._start_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=30)
+        return disassembler
+
+    def test_the_stop_is_reported_once_however_often_the_callback_runs(self):
+        disassembler = self._expiredDisassembler()
+
+        with self.assertLogs("smda.Disassembler", level="WARNING") as logged:
+            self.assertTrue(disassembler._callbackAnalysisTimeout())
+            self.assertTrue(disassembler._callbackAnalysisTimeout())
+
+        self.assertEqual(len(logged.output), 1)
+        self.assertIn("incomplete", logged.output[0])
+
+    def test_a_run_within_its_budget_reports_nothing(self):
+        disassembler = Disassembler()
+        disassembler._timeout = 300
+        disassembler._start_time = datetime.datetime.now(datetime.timezone.utc)
+
+        with self.assertNoLogs("smda.Disassembler", level="WARNING"):
+            self.assertFalse(disassembler._callbackAnalysisTimeout())
+
+    def test_a_reused_instance_reports_the_next_run_too(self):
+        disassembler = self._expiredDisassembler()
+        with self.assertLogs("smda.Disassembler", level="WARNING"):
+            self.assertTrue(disassembler._callbackAnalysisTimeout())
+
+        disassembler.disassembleBuffer(TestDisassemblerReuse.X86, 0x400000, bitness=64, architecture="intel")
+        disassembler._timeout = 10
+        disassembler._start_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=30)
+
+        with self.assertLogs("smda.Disassembler", level="WARNING"):
+            self.assertTrue(disassembler._callbackAnalysisTimeout())
 
 
 if __name__ == "__main__":

--- a/tests/testPartialObjectFormatting.py
+++ b/tests/testPartialObjectFormatting.py
@@ -29,6 +29,12 @@ class TestPartialObjectFormatting(unittest.TestCase):
         report.message = "boom"
         self.assertIn("boom", str(report))
 
+    def test_report_str_marks_a_timed_out_analysis(self):
+        report = SmdaReport()
+        self.assertNotIn("INCOMPLETE", str(report))
+        report.status = "timeout"
+        self.assertIn("INCOMPLETE", str(report))
+
     def test_pic_hash_helpers_tolerate_missing_hash(self):
         function = SmdaFunction()
         self.assertIsNone(function.getPicHashAsLong())


### PR DESCRIPTION
## Summary

Follow-up to #248, from the discussion on that PR: the timeout fix removes one cause of a truncated run, but a truncated run still reads like a complete one. This makes the stop visible.

A run stopped by the timeout returns a report that looks like any other — analysis simply ends early, every recovered function is genuine, and nothing at default log level says the result is partial. The only signal is the `status` field, which a caller has to go looking for.

That matters more than a usual "partial result" case, because the surviving functions are biased rather than randomly missing. Analysis stops after the call-reference pass, so what remains is the call-reachable population — which silently excludes anything reached only through the unwinder or a table, exception cleanup funclets being the obvious class. A measurement taken over such a report is plausible, self-consistent and wrong: in the case reported on #248 an "0.8% of functions are EH funclets" result became 29.2% once the budget was raised.

## What changed

- One `WARNING` when the analysis is cut short, emitted on the timeout callback that every backend polls — so it covers the recursive, CIL, Dalvik and IDA paths alike. It fires once per run, not once per poll, and resets per run so a reused `Disassembler` instance still reports its next truncated analysis.
- `SmdaReport.__str__` marks a timed-out report as incomplete, which is what `analyze.py` prints.

`status`, `message` and the serialized schema are unchanged, so nothing downstream has to adapt.

## Validation

- `python -m pytest tests/ -q` → 1185 passed, 1 skipped, 1480 subtests
- `ruff check .`, `ruff format --check .` → clean
- `make typecheck` → exit 0, no new errors
- `diff-cover coverage.xml --compare-branch=upstream/master --fail-under=100` → 7/7 changed lines covered
- The three new tests fail on pre-fix code. They lift the process-global `logging.disable(CRITICAL)` that several test modules install at import time and restore it afterwards, otherwise `assertLogs` cannot observe anything in a full-suite run.

Refs: #247
