### PR TITLE
fix(dalvik): decide from what an object is, not from text about it

### DIFF
--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -230,9 +230,13 @@ class DexReferenceResolver:
             if name:
                 return self._normalizeTypeString(name)
             with contextlib.suppress(Exception):
-                normalized = self._normalizeTypeString(str(value))
-                if normalized and not normalized.startswith("<lief."):
-                    return normalized
+                # guard before normalizing, as the outer fallback does: normalization
+                # rewrites dots to slashes, so it strips the very prefix this tests for
+                raw_value_string = str(value)
+                if not raw_value_string.startswith("<"):
+                    normalized = self._normalizeTypeString(raw_value_string)
+                    if normalized:
+                        return normalized
         name = self._safeAttr(type_obj, "name", None)
         if name:
             return self._normalizeTypeString(name)
@@ -1333,9 +1337,10 @@ class DalvikDisassembler:
                 metadata["heuristics"].append("unreachable-code-surface")
 
         # Prefer a clean orphan label over formatMethod's fallback for synthetic methods.
-        orphan_name = getattr(method, "name", None)
-        if orphan_name and str(orphan_name).startswith("orphan_code_item@"):
-            state.label = orphan_name
+        # A DEX method name is arbitrary UTF-8, so ask what the object is rather than
+        # matching the name this class writes.
+        if isinstance(method, _OrphanCodeItemMethod):
+            state.label = method.name
         else:
             state.label = resolver.formatMethod(method)
         # Drop internal dedupe set before finalizing (not part of public metadata).

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -866,6 +866,70 @@ class DalvikDisassemblerTestSuite(unittest.TestCase):
         self.assertEqual(resolver.formatRef("call_site", 0), cs_display)
         self.assertEqual(resolver.formatRef("method_handle", 0), mh_display)
 
+    def testAnOrphanLabelIsChosenByTypeNotByName(self):
+        """A DEX method name is arbitrary UTF-8, so it cannot decide what the object is."""
+        from smda.dalvik.DalvikDisassembler import DalvikDisassembler, _OrphanCodeItemMethod
+
+        code_item = build_code_item(bytes.fromhex("0e00"))
+
+        def label_for(method):
+            disassembler = DalvikDisassembler(config)
+            disassembler.disassembly = DisassemblyResult()
+            binary_info = BinaryInfo(code_item)
+            binary_info.raw_data = code_item
+            binary_info.architecture = "dalvik"
+            disassembler.disassembly.binary_info = binary_info
+            return disassembler.analyzeFunction(None, SyntheticDalvikResolver(), method).label
+
+        genuine = _OrphanCodeItemMethod(0x10)
+        self.assertEqual(label_for(genuine), "orphan_code_item@0x10")
+
+        impostor = SyntheticDalvikMethod()
+        impostor.name = genuine.name
+        self.assertEqual(label_for(impostor), "LSynthetic;->method()V")
+
+    def testAnUnreadableTypeObjectIsNotLaunderedIntoADescriptor(self):
+        """A lief object repr must not reach a report field dressed as a type descriptor."""
+        from smda.dalvik.DalvikDisassembler import DexReferenceResolver
+
+        class _EmptyDex:
+            strings = []
+            methods = []
+            fields = []
+            types = []
+            prototypes = []
+            classes = []
+
+        class _UnreadableValue:
+            # neither fullname nor name, so the str() fallback is what answers
+            def __str__(self):
+                return "<lief.DEX.Type object at 0x7f0000000000>"
+
+        class _UnreadableType:
+            def __init__(self):
+                self.value = _UnreadableValue()
+
+        class _ReadableValue:
+            def __str__(self):
+                return "java.lang.String"
+
+        class _ReadableType:
+            def __init__(self):
+                self.value = _ReadableValue()
+
+        resolver = DexReferenceResolver(_EmptyDex(), raw_data=b"")
+        # both are held for the whole test: _formatType caches by id(), so a temporary that
+        # dies before the next one is built can hand its address to it
+        unreadable, readable = _UnreadableType(), _ReadableType()
+        # normalization rewrites dots to slashes, so testing its output for the "<lief."
+        # prefix cannot see one: "L<lief/DEX/Type object at 0x...>;" passes that test
+        self.assertEqual(
+            resolver._normalizeTypeString("<lief.DEX.Type object at 0x7f00>"), "L<lief/DEX/Type object at 0x7f00>;"
+        )
+        self.assertEqual(resolver._formatType(unreadable), "<_UnreadableType>")
+        # a value that really does spell a type still reads through the same fallback
+        self.assertEqual(resolver._formatType(readable), "Ljava/lang/String;")
+
     def testEncodedValueExtensionRulesPerAosp(self):
         """encoded_value: byte/short/int/long sign-extend, char zero-extends, float/double right-zero-extend."""
         from smda.dalvik.DalvikDisassembler import DexReferenceResolver


### PR DESCRIPTION
Two places in the Dalvik backend asked a string what it was, where the string could answer wrongly. Both were found by sweeping the tree for the class after fixing an instance of it elsewhere (#255), and neither is reachable from the demangling work that surfaced them — they are pre-existing and independent, so they are here rather than folded into that stack.

## A type object's repr can reach a report field dressed as a type descriptor

`DexReferenceResolver._formatType` falls back to `str(value)` when a type object exposes neither `fullname` nor `name`. That fallback normalized the string **first** and then tested the result for a `<lief.` prefix, to reject an object repr. But normalization is exactly what rewrites dots to slashes and wraps the result as `L...;`, so it strips the prefix the test looks for:

| | value |
|---|---|
| raw | `<lief.DEX.Type object at 0x7f0000000000>` |
| normalized | `L<lief/DEX/Type object at 0x7f0000000000>;` |
| guard `startswith("<lief.")` | **False** |

So the guard never fires, and a raw object repr — carrying a heap address — reaches a report's type field looking like a legitimate descriptor. The fallback ten lines below in the same method already gets this right, testing the raw string before normalizing and carrying a comment explaining why. This one now does the same.

## A real method may be named like a synthetic one

A code item discovered in a gap gets a synthetic method object whose name this module writes as `orphan_code_item@0x...`. The label was then chosen by matching that prefix back off the name. A DEX method name is arbitrary UTF-8 with no format restriction, so a real method can carry the same string, and one that did would keep the raw name instead of the class-and-prototype spelling `formatMethod` builds. The producer already knows the fact — the object's type — so the label follows from `isinstance` rather than from the text.

## The class, since it is worth naming

*A semantic decision made by inspecting text this codebase itself produced, instead of being told the fact by whatever produced it.* The sweep separated these from the many `startswith` tests that inspect genuinely external input — capstone mnemonics, raw mangled names, PDB string-table fields — which are not in the class.

A fourth hit — `PeSynthesizer._parseOrdinal` reading back the `"#N"` the import parsers write for an unresolvable ordinal — was triaged here as needing a report-schema change, and so left alone. **That was wrong, and it is fixed in #261**: the information to settle it already exists on both sides, since an ordinal is a `WORD` and the parsers only write `"#N"` when no table resolves it. No schema change was needed.

Also checked and found sound: `_formatType` caches by `id()`, which is only safe if every type object reaching it outlives the cache. lief interns its wrappers (`m.cls is m.cls` holds, and 200 transient accesses across the bundled fixture produce 2 distinct ids), so the existing comment's premise is correct. It does bite synthetic objects in tests, which is why the new test holds its two fixtures for its whole body — worth knowing before writing another one.

## Validation

Both new tests fail on the pre-fix tree and pass after it.

| check | result |
|---|---|
| full test suite | 1183 passed, 1 skipped, 1480 subtests |
| lint and format check | clean |
| type check | exit 0, no new diagnostics |
| diff coverage against master | 100% (7/7 changed lines) |

