### PR TITLE
fix(core): keep an import named like an ordinal from becoming one

### DIFF
--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -3,6 +3,7 @@ import struct
 import lief
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
+from smda.common.labelprovider.OrdinalHelper import OrdinalHelper
 from smda.synthesis.BinarySynthesizer import BinarySynthesizer, align_down, align_up
 from smda.utility.lief_helper import safe_lief_parse
 
@@ -97,10 +98,23 @@ class PeSynthesizer(BinarySynthesizer):
                     break
 
     @staticmethod
-    def _parseOrdinal(name):
-        if name.startswith("#") and name[1:].isdigit():
-            return int(name[1:])
-        return None
+    def _parseOrdinal(dll_name, name):
+        """The ordinal a name stands for, or None when the name is the import's own.
+
+        A PE imports by name or by ordinal, and the report keeps only the string, so
+        "#5" is ambiguous on its own. Two things settle it. An ordinal is a WORD, so a
+        larger number never came from an import table. And the import parsers write
+        "#N" only for an ordinal no table resolves, so a name that does resolve cannot
+        have come from them either. Both are real imports spelled that way, and writing
+        one as an ordinal would rename it on the way back - or, past a WORD, truncate it
+        into a different import entirely.
+        """
+        if not (name.startswith("#") and name[1:].isdigit()):
+            return None
+        ordinal = int(name[1:])
+        if ordinal > 0xFFFF or OrdinalHelper.resolveOrdinal(dll_name, ordinal):
+            return None
+        return ordinal
 
     def _buildImportTables(self, import_rvas, ptr_size):
         """Groups imports by DLL and builds descriptor/hint/dll-name blobs.
@@ -126,7 +140,7 @@ class PeSynthesizer(BinarySynthesizer):
             dll_str_offsets[dll_name] = len(dll_strs)
             dll_strs += dll_name.encode("ascii", errors="replace") + b"\x00"
             for _rva, func in funcs:
-                if self._parseOrdinal(func) is not None:
+                if self._parseOrdinal(dll_name, func) is not None:
                     continue
                 if (dll_name, func) in hint_offsets:
                     continue
@@ -149,11 +163,12 @@ class PeSynthesizer(BinarySynthesizer):
     def _writeThunks(self, regions, import_rvas, dll_funcs, sec_vaddr, hint_off, hint_offsets, ptr_size):
         ordinal_flag = 1 << (ptr_size * 8 - 1)
         for rva, (dll, func) in import_rvas.items():
-            ordinal = self._parseOrdinal(func)
+            dll_key = dll or "unknown.dll"
+            ordinal = self._parseOrdinal(dll_key, func)
             if ordinal is not None:
                 thunk_value = ordinal_flag | ordinal
             else:
-                thunk_value = sec_vaddr + hint_off + hint_offsets[(dll or "unknown.dll", func)]
+                thunk_value = sec_vaddr + hint_off + hint_offsets[(dll_key, func)]
             if not self._writeThunkAt(regions, rva, thunk_value, ptr_size):
                 self._warn("import thunk 0x%x (%s.%s) outside all sections", rva, dll, func)
 

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -251,6 +251,29 @@ class SmdaSynthesisTestSuite(unittest.TestCase):
         synthesized_names = {entry.name for imported in parsed.imports for entry in imported.entries if entry.name}
         assert {"AAASynthFuncA", "AAASynthFuncB"} <= synthesized_names
 
+    def testAnImportNamedLikeAnOrdinalIsNotRewrittenIntoOne(self):
+        """A PE imports by name or by ordinal; the report keeps only the string."""
+        report = SmdaReport.fromDict(self.pe_report.toDict())
+        imports = report.xmetadata["imported_functions"]
+        base_slot = next(int(k) for k in imports)
+        # "#1" cannot have come from the import parsers for this DLL: they write "#N"
+        # only when no table resolves it, and ws2_32.dll ordinal 1 resolves to accept.
+        # "#99999" is past a WORD, so it never came from an import table either. Only
+        # "#4000" is a real ordinal - in range, and resolving nowhere.
+        report.xmetadata["imported_functions"] = {
+            str(base_slot): ("ws2_32.dll", "#1"),
+            str(base_slot + 0x10): ("ws2_32.dll", "#4000"),
+            str(base_slot + 0x20): ("ws2_32.dll", "#99999"),
+        }
+        parsed = lief.parse(report.synthesizeBinary(output_format=FORMAT_PE))
+        entries = [entry for imported in parsed.imports for entry in imported.entries]
+        by_name = {entry.name for entry in entries if entry.name}
+        by_ordinal = {entry.ordinal for entry in entries if not entry.name}
+        self.assertIn("#1", by_name)
+        self.assertIn("#99999", by_name)
+        self.assertNotIn(1, by_ordinal)
+        self.assertIn(4000, by_ordinal)
+
     def testElfSynthesisFromSections(self):
         report = self.elf_report
         synthesized = report.synthesizeBinary()
@@ -387,7 +410,7 @@ class SynthesisRobustnessTestSuite(unittest.TestCase):
             return True
 
         synthesizer._writeThunkAt = _record
-        synthesizer._parseOrdinal = lambda func: 1
+        synthesizer._parseOrdinal = lambda dll, func: 1
         # two slots of one DLL a megabyte apart: only the real slots may be written
         far = 0x1000 + 0x100000
         synthesizer._writeThunks(
@@ -415,7 +438,7 @@ class SynthesisRobustnessTestSuite(unittest.TestCase):
             return True
 
         synthesizer._writeThunkAt = _record
-        synthesizer._parseOrdinal = lambda func: 1
+        synthesizer._parseOrdinal = lambda dll, func: 1
         synthesizer._writeThunks(
             [],
             {0x1000: ("kernel32.dll", "a"), 0x100C: ("kernel32.dll", "b")},


### PR DESCRIPTION
A PE imports either by name or by ordinal — that is a bit in the thunk, not a property of the string. The report keeps only the string, so `"#5"` is ambiguous by the time synthesis reads it back: it is what the import parsers write for an ordinal nothing resolves, and it is also a legal PE import name.

`PeSynthesizer._parseOrdinal` read every `#N` as an ordinal. An import really named that way was therefore written as an ordinal thunk, and came back from the synthesized binary under a different name entirely.

This is the fourth and last hit from the sweep behind #260, which I had triaged there as needing a report-schema change. It does not — the information to settle it is already on both sides.

## What settles it

**An ordinal is a `WORD`.** A number above `0xFFFF` never came from an import table, so `#99999` can only be a name. Writing it as an ordinal did not merely mislabel it, it truncated the value into a *different* import.

**The parsers only write `#N` when no table resolves it.** `OrdinalHelper.resolveOrdinal("ws2_32.dll", 1)` returns `accept`, so the parsers would never have written `#1` for that DLL — a report holding it must mean a real import spelled that way. The synthesizer now applies the parsers' own test as its inverse.

What remains ambiguous is a real import named `#N` where that ordinal resolves nowhere for its DLL. That one still synthesizes as an ordinal — and re-analysing the result yields `#N` again, so the report round-trips unchanged. The divergence is invisible in the report's own terms, which is the property worth having here.

## One structural change

The hint table and the thunk writer each decided independently which entries were ordinals, and each derived the DLL key separately (`dll_name` in one, `dll or "unknown.dll"` in the other). Now that the decision depends on the DLL, disagreeing would mean a `KeyError` on the hint lookup rather than a wrong byte. Both ends key on the same value, so they cannot drift.

## Validation

The new test fails on the pre-fix tree and passes after it. Two existing robustness tests stubbed `_parseOrdinal` with a one-argument lambda and are updated — worth noting as the reason a private-method signature is not as private as it looks.

| check | result |
|---|---|
| full test suite | 1182 passed, 1 skipped, 1480 subtests |
| lint and format check | clean |
| type check | exit 0, no new diagnostics |
| diff coverage against master | 100% (12/12 changed lines) |
