### PR TITLE
test(aarch64): stop the corpus budget measuring the machine

### DIFF
--- a/tests/testAArch64MachoCorpus.py
+++ b/tests/testAArch64MachoCorpus.py
@@ -29,10 +29,12 @@ logging.disable(logging.CRITICAL)
 CORPUS_DIR = Path(__file__).resolve().parent / "aarch64_macho_corpus"
 MANIFEST_PATH = CORPUS_DIR / "manifest.json"
 MAX_XORED_FIXTURE_BYTES = 10 * 1024 * 1024
-# Per-sample wall-clock guard. Kept tight enough to still catch an analysis-time
-# regression; raise it via the environment on a contended or slow runner rather
-# than relaxing the default for everyone.
-SAMPLE_TIMEOUT_SECONDS = int(os.environ.get("SMDA_TEST_CORPUS_TIMEOUT", "45"))
+# Per-sample runaway guard, at SmdaConfig's own default. It is deliberately far above
+# what these samples need - the slowest takes a few seconds - because it is wall-clock:
+# a budget close to the healthy time measures how loaded the machine is, not whether
+# the analysis is correct, and a stall on a shared runner then reports as a defect in
+# the analyzer. Left generous, a sample that exhausts it really has run away.
+SAMPLE_TIMEOUT_SECONDS = int(os.environ.get("SMDA_TEST_CORPUS_TIMEOUT", "300"))
 MACHO_MAGICS = {
     b"\xfe\xed\xfa\xce",
     b"\xce\xfa\xed\xfe",
@@ -165,11 +167,19 @@ class TestAArch64MachoCorpus(unittest.TestCase):
                 self.assertEqual(case["loader"].getBitness(), 64)
                 self.assertTrue(case["loader"].getCodeAreas())
 
+    def _assertAnalysisCompleted(self, report, fixture_id):
+        self.assertEqual(
+            report.status,
+            "ok",
+            f"{fixture_id} reported {report.status!r}: analysis did not finish within "
+            f"{SAMPLE_TIMEOUT_SECONDS}s of wall-clock (SMDA_TEST_CORPUS_TIMEOUT)",
+        )
+
     def test_selected_fixtures_disassemble(self):
         for fixture in self.fixtures:
             with self.subTest(source=fixture["source"], fixture=fixture["id"]):
                 report = self._get_case(fixture)["report"]
-                self.assertEqual(report.status, "ok")
+                self._assertAnalysisCompleted(report, fixture["id"])
                 self.assertEqual(report.architecture, "aarch64")
                 self.assertEqual(report.bitness, 64)
                 self.assertGreaterEqual(report.num_functions, fixture["expected_min_functions"])
@@ -180,7 +190,7 @@ class TestAArch64MachoCorpus(unittest.TestCase):
             with self.subTest(source=fixture["source"], fixture=fixture["id"]):
                 report = self._get_case(fixture)["report"]
                 roundtrip = SmdaReport.fromDict(report.toDict())
-                self.assertEqual(roundtrip.status, "ok")
+                self._assertAnalysisCompleted(roundtrip, fixture["id"])
                 self.assertEqual(roundtrip.architecture, "aarch64")
                 self.assertEqual(roundtrip.bitness, 64)
                 self.assertEqual(roundtrip.num_functions, report.num_functions)


### PR DESCRIPTION
`testAArch64MachoCorpus` set a 45 second per-sample wall-clock budget and then asserted the analysis came back `"ok"`. That makes a scheduling stall indistinguishable from an analysis defect, and it reports as one: `AssertionError: 'timeout' != 'ok'`, pointing at the analyzer when the problem is the clock.

It fired on a recent run. This is what the investigation found.

## The sample is not slow, and not variable

| check | result |
|---|---|
| `objective-see/turtle`, locally | **2.90s**, status `ok`, 1778 functions |
| same, with CI's exact dependency set (capstone 5.0.9, lief 1.0.0) | **2.88s**, identical |
| across 8 `PYTHONHASHSEED` values | 2.90–3.15s, 1778 functions every time |
| whole 12-sample corpus | 9.9s total |

So it is deterministic, and it is not a dependency-version effect — worth checking, because the CI environment differs from a typical developer one by more than it looks (Python 3.11 vs 3.13, lief **1.0.0** vs 0.17.6).

It is also not the corpus accumulating: `_get_case` builds a fresh `SmdaConfig` per sample, and `turtle` is second of twelve.

## What it is

The runner. In the failing run, the sibling jobs on the identical commit were:

| job | result | duration |
|---|---|---|
| ubuntu 3.14 | success | 4.7 min |
| ubuntu 3.13 | success | 6.7 min |
| ubuntu 3.12 | success | 6.9 min |
| **ubuntu 3.11** | success | **13 min** |
| macos 3.11 | **failure** | 8.7 min |

`ubuntu-3.11` took roughly twice as long as `ubuntu-3.12` for no reason but contention, in the same run.

Measuring the platform factor rather than guessing at it: the full suite takes 211s locally and the CI macOS test phase took 488s, so that runner is about **2.3× slower**. `turtle` at 2.9s is therefore about **6.7s there**, against a 45 second budget — roughly 6.7× headroom, on a machine whose own jobs vary by 2–3×.

That is why it is rare rather than chronic: once in the last 100 runs. The other four failures in that window were real code defects, not this.

## The change

The budget stays — a sample that runs away is worth catching, and one did before, which is what #248 was about. But it goes to `SmdaConfig`'s own default of 300 seconds, where exhausting it means something genuinely ran away rather than that the runner was busy. `SMDA_TEST_CORPUS_TIMEOUT` still overrides it, so a tighter budget is one variable away for anyone who wants to measure analysis time deliberately.

The failure also explains itself now, naming the sample, the budget and the override:

```
objective-see/turtle reported 'timeout': analysis did not finish within 300s of
wall-clock (SMDA_TEST_CORPUS_TIMEOUT)
```

This is the same hazard already recorded in `BatchProcessor`, whose docstring notes that a nonzero `SmdaConfig.TIMEOUT` is wall-clock and that "under oversubscription a slow sample can time out where a serial run finished". The corpus test was doing precisely that, with the budget set close enough to the healthy time to make it likely.

## Validation

Verified the guard still fires, and reads usefully, by forcing `SMDA_TEST_CORPUS_TIMEOUT=1`.

| check | result |
|---|---|
| full test suite | 1181 passed, 1 skipped, 1480 subtests |
| lint and format check | clean |
| type check | exit 0, no new diagnostics |
| diff coverage | test-only change, no `src/smda` lines |
