### PR TITLE
fix(labels): read a lief name that is not valid UTF-8 without crashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,16 @@ markers = [
 # A DeprecationWarning from LIEF or capstone on a new interpreter is exactly the signal
 # the 3.14 matrix leg exists to surface, and it passed silently before this.
 #
-# The one exception: LIEF warns rather than raising when a Mach-O header carries a
-# cpu_type outside its enum, which is precisely the malformed input the Mach-O readers
-# are expected to survive. Suppressing it belongs here and not in src/ - warnings.
-# catch_warnings() mutates the process-wide filter list, so a library doing it is not
-# thread-safe for consumers.
+# The exceptions: LIEF warns rather than raising when a header field falls outside the
+# enum it maps to - a Mach-O cpu_type, or a PE COFF symbol's complex_type read out of a
+# mapped image, where the symbol table's file offset lands on unrelated bytes. Both are
+# precisely the malformed input the readers are expected to survive. Suppressing them
+# belongs here and not in src/ - warnings.catch_warnings() mutates the process-wide
+# filter list, so a library doing it is not thread-safe for consumers.
 filterwarnings = [
     "error",
     "ignore:[0-9]+ is not a valid CPU_TYPE:RuntimeWarning",
+    "ignore:[0-9]+ is not a valid COMPLEX_TYPE:RuntimeWarning",
 ]
 
 [tool.coverage.run]

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -7,7 +7,7 @@ import lief
 from smda.common.labelprovider.ElfSymbolProvider import ElfSymbolProvider
 from smda.common.labelprovider.MachoSymbolProvider import MachoSymbolProvider
 from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
-from smda.utility.lief_helper import safe_lief_parse
+from smda.utility.lief_helper import lief_name, safe_lief_parse
 from smda.utility.MachoFileLoader import MachoFileLoader
 
 LOGGER = logging.getLogger(__name__)
@@ -221,18 +221,18 @@ class BinaryInfo:
                 section_size = section.virtual_size or section.sizeof_raw_data
                 if section_size % 0x1000 != 0:
                     section_size += 0x1000 - (section_size % 0x1000)
-                yield section.name, section_start, section_start + section_size
+                yield lief_name(section), section_start, section_start + section_size
         elif lief_type == "ELF":
             for section in parsed_binary.sections:
                 section_start = section.virtual_address
                 section_size = section.size
-                yield section.name, section_start, section_start + section_size
+                yield lief_name(section), section_start, section_start + section_size
         elif lief_type == "MACH_O":
             adjustment = symbol_provider._get_address_adjustment(parsed_binary)
             for section in parsed_binary.sections:
                 section_start = section.virtual_address + adjustment
                 section_size = section.size
-                yield section.name, section_start, section_start + section_size
+                yield lief_name(section), section_start, section_start + section_size
 
     def isInCodeAreas(self, address):
         is_inside = False

--- a/src/smda/common/LanguageAnalyzer.py
+++ b/src/smda/common/LanguageAnalyzer.py
@@ -11,6 +11,7 @@ from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
 from smda.common.labelprovider.ItaniumDemangler import is_itanium_cpp_symbol, is_msvc_cpp_symbol
 from smda.common.labelprovider.RustSymbolEvidence import is_rust_language_evidence
 from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
+from smda.utility.lief_helper import lief_name
 from smda.utility.MachoBinary import get_active_macho_binary
 
 LOGGER = logging.getLogger(__name__)
@@ -228,10 +229,7 @@ class LanguageAnalyzer:
             except (AttributeError, UnicodeDecodeError):
                 continue
             for symbol in symbols:
-                try:
-                    symbol_name = symbol.name
-                except (AttributeError, UnicodeDecodeError):
-                    continue
+                symbol_name = lief_name(symbol)
                 if (
                     symbol_name
                     and not is_rust_language_evidence(symbol_name)

--- a/src/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/src/smda/common/labelprovider/ElfSymbolProvider.py
@@ -4,6 +4,8 @@ import logging
 
 import lief
 
+from smda.utility.lief_helper import lief_name
+
 from .AbstractLabelProvider import AbstractLabelProvider
 from .import_parsers import parse_elf_relocation_imports
 from .ItaniumDemangler import demangle_itanium_symbol
@@ -85,23 +87,14 @@ class ElfSymbolProvider(AbstractLabelProvider):
 
     _isDefinedSymbol = staticmethod(is_defined_elf_symbol)
 
-    @staticmethod
-    def _getSymbolName(symbol):
-        try:
-            raw_name = symbol.name
-        except (AttributeError, UnicodeDecodeError):
-            return ""
-        return raw_name if isinstance(raw_name, str) else ""
+    _getSymbolName = staticmethod(lief_name)
 
     @classmethod
     def _formatSymbolName(cls, symbol):
         raw_name = cls._getSymbolName(symbol)
         if not raw_name:
             return ""
-        try:
-            demangled_name = getattr(symbol, "demangled_name", None)
-        except (AttributeError, UnicodeDecodeError):
-            demangled_name = None
+        demangled_name = lief_name(symbol, "demangled_name")
         if demangled_name and demangled_name != raw_name:
             return demangled_name
         return demangle_itanium_symbol(raw_name)

--- a/src/smda/common/labelprovider/MachoSymbolProvider.py
+++ b/src/smda/common/labelprovider/MachoSymbolProvider.py
@@ -4,6 +4,7 @@ import logging
 
 import lief
 
+from smda.utility.lief_helper import lief_name
 from smda.utility.MachoBinary import (
     get_active_macho_binary,
     get_macho_address_adjustment,
@@ -56,23 +57,14 @@ class MachoSymbolProvider(AbstractLabelProvider):
             architecture=getattr(binary_info, "architecture", "") if binary_info else "",
         )
 
-    @staticmethod
-    def _get_symbol_name(symbol):
-        try:
-            raw_name = symbol.name
-        except (AttributeError, UnicodeDecodeError):
-            return ""
-        return raw_name if isinstance(raw_name, str) else ""
+    _get_symbol_name = staticmethod(lief_name)
 
     @classmethod
     def _format_symbol_name(cls, symbol):
         raw_name = cls._get_symbol_name(symbol)
         if not raw_name:
             return ""
-        try:
-            demangled = getattr(symbol, "demangled_name", None)
-        except (AttributeError, UnicodeDecodeError):
-            demangled = None
+        demangled = lief_name(symbol, "demangled_name")
         if demangled and demangled != raw_name:
             return demangled
         return demangle_macho_symbol(raw_name)

--- a/src/smda/common/labelprovider/PeSymbolProvider.py
+++ b/src/smda/common/labelprovider/PeSymbolProvider.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
-import contextlib
 import logging
 
 import lief
+
+from smda.utility.lief_helper import lief_name
 
 from .AbstractLabelProvider import AbstractLabelProvider
 from .import_parsers import parse_pe_delay_imports, parse_pe_imports, resolve_pe_base_addr
@@ -61,11 +62,7 @@ class PeSymbolProvider(AbstractLabelProvider):
                 # forwarder/extern entries redirect to another module's export and have no
                 # local address (LIEF sets .address to 0 for them) - not a local function.
                 continue
-            function_name = ""
-            with contextlib.suppress(UnicodeDecodeError, AttributeError):
-                # here may occur a LIEF exception that we want to skip ->
-                # UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
-                function_name = function.name
+            function_name = lief_name(function)
             if function_name and all(ord(c) in range(0x20, 0x7F) for c in function_name):
                 function_symbols[active_base + function.address] = function_name
         return function_symbols
@@ -86,11 +83,7 @@ class PeSymbolProvider(AbstractLabelProvider):
                     # 0/-1/-2 are undefined-external/absolute/debug: not a locally defined
                     # function, so its value is not a usable in-image offset.
                     continue
-                function_name = ""
-                with contextlib.suppress(UnicodeDecodeError, AttributeError):
-                    # here may occur a LIEF exception that we want to skip ->
-                    # UnicodeDecodeError: 'utf-32-le' codec can't decode bytes in position 0-3: code point not in range(0x110000)
-                    function_name = symbol.name
+                function_name = lief_name(symbol)
                 if function_name and all(ord(c) in range(0x20, 0x7F) for c in function_name):
                     function_offset = active_base + sections[section_idx - 1].virtual_address + symbol.value
                     if function_offset not in function_symbols:

--- a/src/smda/common/labelprovider/RustSymbolProvider.py
+++ b/src/smda/common/labelprovider/RustSymbolProvider.py
@@ -5,6 +5,7 @@ import logging
 import lief
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
+from smda.utility.lief_helper import lief_name
 from smda.utility.MachoBinary import get_active_macho_binary, get_macho_address_adjustment
 
 from .AbstractLabelProvider import AbstractLabelProvider
@@ -89,10 +90,7 @@ class RustSymbolProvider(AbstractLabelProvider):
                     symbol_lists.append(symbol_binary.dynamic_symbols)
                 for symbols in symbol_lists:
                     for sym in symbols or []:
-                        try:
-                            sym_name = sym.name
-                        except (UnicodeDecodeError, AttributeError):
-                            continue
+                        sym_name = lief_name(sym)
                         if self._is_rust_language_evidence(sym_name):
                             binary_info._is_rust = True
                             return True
@@ -155,10 +153,7 @@ class RustSymbolProvider(AbstractLabelProvider):
             if not symbol_list:
                 continue
             for symbol in symbol_list:
-                try:
-                    raw_name = symbol.name
-                except (UnicodeDecodeError, AttributeError):
-                    continue
+                raw_name = lief_name(symbol)
                 if not raw_name or not getattr(symbol, "value", 0):
                     continue
                 if not self._is_rust_symbol(raw_name):
@@ -184,13 +179,8 @@ class RustSymbolProvider(AbstractLabelProvider):
                 # forwarder/extern entries redirect to another module's export and have no
                 # local address (LIEF sets .address to 0 for them) - not a local function.
                 continue
-            raw_name = ""
+            raw_name = lief_name(function)
             try:
-                try:
-                    raw_name = function.name
-                except (UnicodeDecodeError, AttributeError):
-                    continue
-
                 if self._is_rust_symbol(raw_name):
                     demangled = demangle(raw_name)
                     if demangled:
@@ -209,12 +199,8 @@ class RustSymbolProvider(AbstractLabelProvider):
                     # section_idx 0/-1/-2 (undefined-external/absolute/debug): not a locally
                     # defined function, its value is not a usable in-image offset.
                     continue
-                raw_name = ""
+                raw_name = lief_name(symbol)
                 try:
-                    try:
-                        raw_name = symbol.name
-                    except (UnicodeDecodeError, AttributeError):
-                        continue
                     if self._is_rust_symbol(raw_name):
                         demangled = demangle(raw_name)
                         if demangled:
@@ -230,11 +216,7 @@ class RustSymbolProvider(AbstractLabelProvider):
         function_symbols = {}
         for symbol in symbols:
             if symbol is not None and symbol.is_function and symbol.value != 0 and is_defined_elf_symbol(symbol):
-                # We want the raw name to check for Rust mangling
-                try:
-                    raw_name = symbol.name
-                except (UnicodeDecodeError, AttributeError):
-                    continue
+                raw_name = lief_name(symbol)
                 if self._is_rust_symbol(raw_name):
                     try:
                         demangled = demangle(raw_name)

--- a/src/smda/common/labelprovider/import_parsers.py
+++ b/src/smda/common/labelprovider/import_parsers.py
@@ -3,6 +3,7 @@
 import lief
 
 from smda.common.labelprovider.OrdinalHelper import OrdinalHelper
+from smda.utility.lief_helper import lief_name
 
 
 def resolve_pe_base_addr(lief_binary, base_addr=None):
@@ -17,12 +18,13 @@ def parse_pe_imports(lief_binary, base_addr=None):
     active_base = resolve_pe_base_addr(lief_binary, base_addr)
     import_symbols = {}
     for imported_library in lief_binary.imports:
-        lib_name_lower = (getattr(imported_library, "name", "") or "").lower()
+        lib_name_lower = lief_name(imported_library).lower()
         for func in imported_library.entries:
-            if func.name:
+            func_name = lief_name(func)
+            if func_name:
                 import_symbols[func.iat_address + active_base] = (
                     lib_name_lower,
-                    func.name,
+                    func_name,
                 )
             elif func.is_ordinal:
                 resolved_ordinal = OrdinalHelper.resolveOrdinal(lib_name_lower, func.ordinal)
@@ -44,11 +46,12 @@ def parse_pe_delay_imports(lief_binary, base_addr=None):
     ptr_size = 8 if magic is not None and magic == lief.PE.PE_TYPE.PE32_PLUS else 4
     import_symbols = {}
     for delay_import in lief_binary.delay_imports:
-        lib_name_lower = (getattr(delay_import, "name", "") or "").lower()
+        lib_name_lower = lief_name(delay_import).lower()
         for index, func in enumerate(delay_import.entries):
             slot_addr = active_base + delay_import.iat + index * ptr_size
-            if func.name:
-                import_symbols[slot_addr] = (lib_name_lower, func.name)
+            func_name = lief_name(func)
+            if func_name:
+                import_symbols[slot_addr] = (lib_name_lower, func_name)
             elif func.is_ordinal:
                 resolved_ordinal = OrdinalHelper.resolveOrdinal(lib_name_lower, func.ordinal)
                 ordinal_name = resolved_ordinal if resolved_ordinal else f"#{func.ordinal}"
@@ -75,10 +78,7 @@ def parse_elf_relocation_imports(lief_binary):
             continue
         if not symbol.imported or not symbol.is_function:
             continue
-        try:
-            symbol_name = symbol.name
-        except (AttributeError, UnicodeDecodeError):
-            continue
+        symbol_name = lief_name(symbol)
         if not symbol_name:
             continue
 
@@ -86,7 +86,7 @@ def parse_elf_relocation_imports(lief_binary):
         symbol_version = getattr(symbol, "symbol_version", None)
         if symbol.has_version and symbol_version and symbol_version.has_auxiliary_version:
             aux = symbol_version.symbol_version_auxiliary
-            lib = aux.name if aux else None
+            lib = lief_name(aux) or None
 
         import_symbols[relocation.address] = (lib, symbol_name)
     return import_symbols
@@ -98,17 +98,13 @@ def parse_macho_bindings(lief_binary, adjustment=0):
     imports = {}
     for binding in getattr(lief_binary, "bindings", []):
         try:
-            if (
-                binding.address != 0
-                and getattr(binding, "has_symbol", False)
-                and binding.symbol
-                and binding.symbol.name
-            ):
+            symbol_name = lief_name(binding.symbol) if getattr(binding, "has_symbol", False) else ""
+            if binding.address != 0 and symbol_name:
                 lib_name = ""
                 if getattr(binding, "has_library", False) and binding.library:
-                    lib_name = (getattr(binding.library, "name", "") or "").lower()
+                    lib_name = lief_name(binding.library).lower()
                 adjusted_addr = binding.address + adjustment
-                imports[adjusted_addr] = (lib_name, binding.symbol.name)
+                imports[adjusted_addr] = (lib_name, symbol_name)
         except Exception:
             continue
     return imports

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -4,7 +4,7 @@ import lief
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.synthesis.BinarySynthesizer import BinarySynthesizer, align_down, align_up
-from smda.utility.lief_helper import safe_lief_parse
+from smda.utility.lief_helper import lief_name, safe_lief_parse
 
 IMAGE_SCN_CNT_CODE = 0x00000020
 IMAGE_SCN_CNT_INITIALIZED_DATA = 0x00000040
@@ -330,7 +330,7 @@ class PeSynthesizer(BinarySynthesizer):
                 raw = bytearray(raw_size)
             regions.append(
                 {
-                    "name": section.name.rstrip("\x00"),
+                    "name": lief_name(section).rstrip("\x00"),
                     "vaddr": section.virtual_address,
                     "vsize": section.virtual_size,
                     "chars": int(section.characteristics),

--- a/src/smda/utility/lief_helper.py
+++ b/src/smda/utility/lief_helper.py
@@ -21,6 +21,22 @@ from __future__ import annotations
 import lief
 
 
+def lief_name(obj, attribute="name"):
+    """Return a name lief exposes as text, or "" when it is not usable.
+
+    lief hands back the raw ``bytes`` when a name is not valid UTF-8 instead of
+    raising, so a ``UnicodeDecodeError`` guard alone leaves the caller holding a
+    value that every string operation on it rejects. Mapped images reach this
+    routinely: a PE's COFF symbol table is located by a file offset, so reading
+    one out of a memory image lands on unrelated bytes.
+    """
+    try:
+        value = getattr(obj, attribute)
+    except (AttributeError, UnicodeDecodeError):
+        return ""
+    return value if isinstance(value, str) else ""
+
+
 def safe_lief_parse(binary, parser=None):
     """Parse ``binary``, returning None when lief rejects it natively.
 

--- a/tests/testLiefNameNormalization.py
+++ b/tests/testLiefNameNormalization.py
@@ -18,6 +18,8 @@ from smda.common.labelprovider.MachoSymbolProvider import MachoSymbolProvider
 from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
 from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
 from smda.common.LanguageAnalyzer import LanguageAnalyzer
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
 from smda.utility.lief_helper import lief_name
 from smda.utility.PeFileLoader import PeFileLoader
 
@@ -103,6 +105,19 @@ class MappedPeSymbolNameTest(unittest.TestCase):
         symbols = PeSymbolProvider(None).parseSymbols(self.parsed, 0x140000000)
         self.assertIsInstance(symbols, dict)
         self.assertTrue(all(isinstance(name, str) for name in symbols.values()))
+
+    def testMapped64BitImageIsDisassembledEndToEnd(self):
+        # the whole run, not just the providers: an undecodable name reached string
+        # operations deep in analysis and ended it with status "error"
+        config = SmdaConfig()
+        config.TIMEOUT = 300
+        config.WITH_STRINGS = False
+
+        report = Disassembler(config).disassembleBuffer(self.mapped, 0x140000000, bitness=64)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.bitness, 64)
+        self.assertGreater(report.num_functions, 100)
 
 
 class ProviderNameNormalizationTest(unittest.TestCase):

--- a/tests/testLiefNameNormalization.py
+++ b/tests/testLiefNameNormalization.py
@@ -1,0 +1,250 @@
+import logging
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import lief
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.common.labelprovider import import_parsers
+from smda.common.labelprovider.import_parsers import (
+    parse_elf_relocation_imports,
+    parse_macho_bindings,
+    parse_pe_delay_imports,
+    parse_pe_imports,
+)
+from smda.common.labelprovider.MachoSymbolProvider import MachoSymbolProvider
+from smda.common.labelprovider.PeSymbolProvider import PeSymbolProvider
+from smda.common.labelprovider.RustSymbolProvider import RustSymbolProvider
+from smda.common.LanguageAnalyzer import LanguageAnalyzer
+from smda.utility.lief_helper import lief_name
+from smda.utility.PeFileLoader import PeFileLoader
+
+logging.disable(logging.CRITICAL)
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+UNDECODABLE = b"\xff\xfe\x80\x81name"
+
+
+def _decode(path):
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(path.read_bytes()))
+
+
+class _FakeElfBinary:
+    def __init__(self, relocations):
+        self.relocations = relocations
+
+
+class _FakeMachoBinary:
+    def __init__(self, bindings):
+        self.bindings = bindings
+
+
+def _patched_lief():
+    return SimpleNamespace(
+        ELF=SimpleNamespace(Binary=_FakeElfBinary),
+        MachO=SimpleNamespace(Binary=_FakeMachoBinary),
+        PE=lief.PE,
+    )
+
+
+class _RaisingName:
+    @property
+    def name(self):
+        raise UnicodeDecodeError("utf-32-le", b"\x00\x00\x00\x00", 0, 4, "out of range")
+
+
+class LiefNameHelperTest(unittest.TestCase):
+    def testTextNamePassesThrough(self):
+        self.assertEqual(lief_name(SimpleNamespace(name="main")), "main")
+
+    def testUndecodableNameBecomesEmpty(self):
+        self.assertEqual(lief_name(SimpleNamespace(name=UNDECODABLE)), "")
+
+    def testMissingAttributeBecomesEmpty(self):
+        self.assertEqual(lief_name(SimpleNamespace()), "")
+
+    def testRaisingAttributeBecomesEmpty(self):
+        self.assertEqual(lief_name(_RaisingName()), "")
+
+    def testAlternateAttributeIsRead(self):
+        symbol = SimpleNamespace(name="_ZN3foo3barE", demangled_name="foo::bar")
+        self.assertEqual(lief_name(symbol, "demangled_name"), "foo::bar")
+
+
+class MappedPeSymbolNameTest(unittest.TestCase):
+    """A PE read as a memory image is what makes lief hand back bytes: the COFF
+    symbol table is located by a file offset, so a mapped image reads it from
+    unrelated bytes."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mapped = PeFileLoader.mapBinary(_decode(FIXTURE_DIR / "rust_pe_gnu_xored"))
+        cls.parsed = lief.PE.parse(cls.mapped)
+
+    def testMappedImageYieldsBothNameKinds(self):
+        name_types = {type(symbol.name).__name__ for symbol in self.parsed.symbols}
+        self.assertIn("bytes", name_types)
+        self.assertIn("str", name_types)
+
+    def testLanguageAnalyzerSurvivesUndecodableSymbolNames(self):
+        binary_info = BinaryInfo(self.mapped)
+        binary_info.raw_data = self.mapped
+        binary_info.base_addr = 0x140000000
+        binary_info.bitness = 64
+        binary_info.architecture = "intel"
+        analyzer = LanguageAnalyzer(SimpleNamespace(binary_info=binary_info))
+        score, count = analyzer.getCppSymbolScore()
+        self.assertIsInstance(score, float)
+        self.assertIsInstance(count, int)
+
+    def testPeSymbolProviderSurvivesMappedCoffTable(self):
+        symbols = PeSymbolProvider(None).parseSymbols(self.parsed, 0x140000000)
+        self.assertIsInstance(symbols, dict)
+        self.assertTrue(all(isinstance(name, str) for name in symbols.values()))
+
+
+class ProviderNameNormalizationTest(unittest.TestCase):
+    def testPeExportWithUndecodableNameIsSkipped(self):
+        export = SimpleNamespace(
+            entries=[
+                SimpleNamespace(name=UNDECODABLE, address=0x1000, is_extern=False, is_forwarded=False),
+                SimpleNamespace(name="ok_export", address=0x2000, is_extern=False, is_forwarded=False),
+            ]
+        )
+        binary = SimpleNamespace(get_export=lambda: export, imagebase=0x400000)
+        self.assertEqual(PeSymbolProvider(None).parseExports(binary, 0x400000), {0x402000: "ok_export"})
+
+    def testPeCoffSymbolWithUndecodableNameIsSkipped(self):
+        binary = SimpleNamespace(
+            sections=[SimpleNamespace(virtual_address=0x1000)],
+            symbols=[
+                SimpleNamespace(
+                    name=UNDECODABLE, value=0x10, section_idx=1, complex_type=SimpleNamespace(name="FUNCTION")
+                ),
+                SimpleNamespace(name="named", value=0x20, section_idx=1, complex_type=SimpleNamespace(name="FUNCTION")),
+            ],
+            imagebase=0x400000,
+        )
+        self.assertEqual(PeSymbolProvider(None).parseSymbols(binary, 0x400000), {0x401020: "named"})
+
+    def testPeImportWithUndecodableNameFallsBackToOrdinal(self):
+        library = SimpleNamespace(
+            name=UNDECODABLE,
+            entries=[
+                SimpleNamespace(name=UNDECODABLE, iat_address=0x100, is_ordinal=True, ordinal=7),
+                SimpleNamespace(name="CreateFileW", iat_address=0x108, is_ordinal=False, ordinal=0),
+            ],
+        )
+        imports = parse_pe_imports(SimpleNamespace(imports=[library], imagebase=0x400000), 0x400000)
+        self.assertEqual(imports[0x400100], ("", "#7"))
+        self.assertEqual(imports[0x400108], ("", "CreateFileW"))
+
+    def testPeDelayImportWithUndecodableNameFallsBackToOrdinal(self):
+        delay = SimpleNamespace(
+            name=UNDECODABLE,
+            iat=0x200,
+            entries=[
+                SimpleNamespace(name=UNDECODABLE, is_ordinal=True, ordinal=3),
+                SimpleNamespace(name="SomeApi", is_ordinal=False, ordinal=0),
+            ],
+        )
+        binary = SimpleNamespace(
+            delay_imports=[delay],
+            has_delay_imports=True,
+            optional_header=SimpleNamespace(magic=lief.PE.PE_TYPE.PE32_PLUS),
+            imagebase=0x400000,
+        )
+        imports = parse_pe_delay_imports(binary, 0x400000)
+        self.assertEqual(imports[0x400200], ("", "#3"))
+        self.assertEqual(imports[0x400208], ("", "SomeApi"))
+
+    @staticmethod
+    def _elf_relocation(name, address, version_name=None):
+        auxiliary = SimpleNamespace(name=version_name) if version_name is not None else None
+        symbol = SimpleNamespace(
+            name=name,
+            imported=True,
+            is_function=True,
+            has_version=auxiliary is not None,
+            symbol_version=(
+                SimpleNamespace(has_auxiliary_version=True, symbol_version_auxiliary=auxiliary)
+                if auxiliary is not None
+                else None
+            ),
+        )
+        return SimpleNamespace(has_symbol=True, symbol=symbol, address=address)
+
+    def testElfRelocationImportNamesAreNormalized(self):
+        parsed = _FakeElfBinary(
+            [
+                self._elf_relocation(UNDECODABLE, 0x1000),
+                self._elf_relocation("puts", 0x1008, version_name=UNDECODABLE),
+                self._elf_relocation("printf", 0x1010, version_name="GLIBC_2.2.5"),
+            ]
+        )
+        with mock.patch.object(import_parsers, "lief", _patched_lief()):
+            imports = parse_elf_relocation_imports(parsed)
+        self.assertNotIn(0x1000, imports)
+        self.assertEqual(imports[0x1008], (None, "puts"))
+        self.assertEqual(imports[0x1010], ("GLIBC_2.2.5", "printf"))
+
+    def testMachoBindingNamesAreNormalized(self):
+        parsed = _FakeMachoBinary(
+            [
+                SimpleNamespace(
+                    address=0x1000,
+                    has_symbol=True,
+                    symbol=SimpleNamespace(name=UNDECODABLE),
+                    has_library=False,
+                    library=None,
+                ),
+                SimpleNamespace(
+                    address=0x1008,
+                    has_symbol=True,
+                    symbol=SimpleNamespace(name="_malloc"),
+                    has_library=True,
+                    library=SimpleNamespace(name="/usr/lib/libSystem.B.dylib"),
+                ),
+            ]
+        )
+        with mock.patch.object(import_parsers, "lief", _patched_lief()):
+            imports = parse_macho_bindings(parsed, adjustment=0x10)
+        self.assertNotIn(0x1010, imports)
+        self.assertEqual(imports[0x1018], ("/usr/lib/libsystem.b.dylib", "_malloc"))
+
+    def testMachoSymbolProviderNormalizesBothNameSlots(self):
+        self.assertEqual(MachoSymbolProvider._get_symbol_name(SimpleNamespace(name=UNDECODABLE)), "")
+        self.assertEqual(MachoSymbolProvider._format_symbol_name(SimpleNamespace(name=UNDECODABLE)), "")
+        named = SimpleNamespace(name="_start", demangled_name=UNDECODABLE)
+        self.assertEqual(MachoSymbolProvider._format_symbol_name(named), "_start")
+
+    def testRustProviderSkipsUndecodableSymbols(self):
+        provider = RustSymbolProvider(None)
+        recovered = provider._parse_lief_symbols(
+            [
+                SimpleNamespace(name=UNDECODABLE, is_function=True, value=0x1000, shndx=1, imported=False),
+                SimpleNamespace(name="_RNvC4main3foo", is_function=True, value=0x2000, shndx=1, imported=False),
+            ]
+        )
+        self.assertNotIn(0x1000, recovered)
+        self.assertIn(0x2000, recovered)
+
+
+class CodeSectionNameTest(unittest.TestCase):
+    def testUndecodableSectionNameBecomesEmptyString(self):
+        binary_info = BinaryInfo(b"MZ")
+        binary_info.base_addr = 0x400000
+        binary_info._lief_binary = SimpleNamespace(
+            sections=[
+                SimpleNamespace(name=UNDECODABLE, virtual_address=0x1000, virtual_size=0x1000, sizeof_raw_data=0x1000)
+            ]
+        )
+        binary_info._lief_type = "PE"
+        binary_info._symbol_provider = PeSymbolProvider(None)
+        self.assertEqual([entry[0] for entry in binary_info.getSections()], [""])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
lief hands back the raw bytes when a name will not decode as UTF-8 instead of raising, so every `except UnicodeDecodeError` guard around one of those reads is inert and the bytes flow on into string code.

Analysing a PE as a memory image hits this every time: the COFF symbol table is located through `PointerToSymbolTable`, a file offset, so reading it out of a mapped image lands on unrelated bytes. On the bundled `rust_pe_gnu` fixture, mapped, 2 of 350 symbol names come back as bytes and the language analyser's `name.startswith(("_R", "__R"))` raises `TypeError`. That degrades the whole report to `status="error"` with no functions at all. The same PEs analysed as files recover 2354, 1975 and 1897 functions.

## What changed

Every lief-provided name now goes through one reader that returns `""` for a name that is bytes, missing, or raises on access.

Crash sites: the language analyser, both PE symbol paths, five Rust symbol paths, and the PE section name the synthesizer trims with `rstrip("\x00")`.

Silent-bad-data sites: the four import parsers stop storing an undecodable name or library — a PE import whose name cannot be read now falls back to its ordinal — and the code-section listing yields `""` rather than bytes.

The ELF and Mach-O providers already carried a private copy of the same normalization; they share the reader now instead of keeping a third and fourth spelling of it.

Section-name comparisons (`section.name == ".plt"` and friends) are deliberately left alone: equality against a `str` simply fails for bytes, which is the right answer for a name nothing can read.

The suite treats warnings as errors, and reading a garbage COFF symbol makes lief warn that a `complex_type` falls outside its enum, so that warning joins the Mach-O `cpu_type` one already ignored for the same reason.

## Evidence

Ground truth for the failure mode was measured directly rather than assumed: patching a PE section header to a non-UTF-8 name makes `lief.PE.parse` return `bytes` for `section.name`, and the mapped `rust_pe_gnu` fixture yields `{'bytes': 2, 'str': 348}` for its COFF symbol names against `{'str': 4818}` for the same file unmapped.

Pre-fix, running the language analyser over that mapped image raises `TypeError: a bytes-like object is required, not 'str'`; post-fix it returns `(0.0, 0)`.

The second commit adds the case that was missing: the provider tests all worked at provider level, and nothing ran a whole analysis over a mapped image, which is where the failure was actually reported. Disassembling the mapped fixture returns `status="error"` with zero functions on master and `status="ok"` with 2354 functions here — that test fails on the unfixed tree for the reported reason rather than for a provider-level detail.

## Validation

- `make lint`, `make typecheck` — clean (236 diagnostics, unchanged from master)
- `make test` — 1197 passed, 2 skipped, 1480 subtests, exit 0
- `diff-cover --fail-under=100` — 42 lines, 0 missing, 100%
- `tests/testLiefNameNormalization.py`, 18 tests: the helper's four outcomes, each patched provider, the real mapped-PE fixture, and the end-to-end mapped 64-bit image
