### PR TITLE
fix(core): let the gap scan give up when the analysis budget is spent

### DIFF
--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -764,7 +764,11 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         def in_exec(addr):
             return any(start <= addr < end for start, end in exec_ranges)
 
+        scanned = 0
         while True:
+            scanned += 1
+            if scanned % 4096 == 0 and self._candidateTimeoutTripped():
+                return None
             if base + size < self.gap_pointer:
                 return None
             # align to the instruction stride

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -195,7 +195,11 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             window_bytes = self.disassembly.getRawBytes(offset, max(256, length))
             return window_bytes[:length]
 
+        scanned = 0
         while True:
+            scanned += 1
+            if scanned % 4096 == 0 and self._candidateTimeoutTripped():
+                return None
             unskipped_pad = False
             if self.disassembly.binary_info.base_addr + self.disassembly.binary_info.binary_size < self.gap_pointer:
                 LOGGER.debug("nextGapCandidate() gap_ptr: 0x%08x - finishing", self.gap_pointer)

--- a/tests/testGapScanTimeout.py
+++ b/tests/testGapScanTimeout.py
@@ -1,0 +1,85 @@
+import unittest
+
+from smda.aarch64.definitions import INSTRUCTION_SIZE
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager as AArch64CandidateManager
+from smda.common.BinaryInfo import BinaryInfo
+from smda.DisassemblyResult import DisassemblyResult
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager as IntelCandidateManager
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+# Long enough that a single scan crosses the timeout-check interval twice.
+SKIPPED_BYTES = 4096 * 8
+AARCH64_NOP = b"\x1f\x20\x03\xd5"
+
+
+def _disassembly(image, bitness, architecture):
+    binary_info = BinaryInfo(image)
+    binary_info.base_addr = BASE
+    binary_info.bitness = bitness
+    binary_info.architecture = architecture
+    binary_info.code_areas = [[BASE, BASE + len(image)]]
+    disassembly = DisassemblyResult()
+    disassembly.setBinaryInfo(binary_info)
+    return disassembly
+
+
+class _TripsImmediately:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        return True
+
+
+class IntelGapScanTimeoutTest(unittest.TestCase):
+    def _manager(self):
+        # 0x55 is neither padding nor a nop, so a claimed run of it is walked one byte
+        # per iteration - the shape that makes a single scan long.
+        image = b"\x55" * (SKIPPED_BYTES + 16)
+        disassembly = _disassembly(image, 32, "intel")
+        for offset in range(SKIPPED_BYTES):
+            disassembly.data_map.add(BASE + offset)
+        manager = IntelCandidateManager(SmdaConfig())
+        manager.init(disassembly, None)
+        return manager
+
+    def testLongScanCompletesWithoutATimeout(self):
+        manager = self._manager()
+        self.assertEqual(manager.nextGapCandidate(BASE), BASE + SKIPPED_BYTES)
+        self.assertFalse(manager.disassembly.analysis_timeout)
+
+    def testLongScanStopsWhenTheAnalysisBudgetIsSpent(self):
+        manager = self._manager()
+        callback = _TripsImmediately()
+        manager._cb_analysis_timeout = callback
+        self.assertIsNone(manager.nextGapCandidate(BASE))
+        self.assertTrue(manager.disassembly.analysis_timeout)
+        self.assertEqual(callback.calls, 1)
+
+
+class AArch64GapScanTimeoutTest(unittest.TestCase):
+    def _manager(self):
+        image = AARCH64_NOP * (SKIPPED_BYTES // INSTRUCTION_SIZE) + b"\xfd\x7b\xbf\xa9" * 4
+        disassembly = _disassembly(image, 64, "aarch64")
+        manager = AArch64CandidateManager(SmdaConfig())
+        manager.init(disassembly, None)
+        return manager
+
+    def testLongScanCompletesWithoutATimeout(self):
+        manager = self._manager()
+        self.assertEqual(manager.nextGapCandidate(BASE), BASE + SKIPPED_BYTES)
+        self.assertFalse(manager.disassembly.analysis_timeout)
+
+    def testLongScanStopsWhenTheAnalysisBudgetIsSpent(self):
+        manager = self._manager()
+        callback = _TripsImmediately()
+        manager._cb_analysis_timeout = callback
+        self.assertIsNone(manager.nextGapCandidate(BASE))
+        self.assertTrue(manager.disassembly.analysis_timeout)
+        self.assertEqual(callback.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Both gap scans (`intel/FunctionCandidateManager.nextGapCandidate` and its AArch64 counterpart) walk forward from the gap pointer until they find a candidate or run out of image, and neither consulted the analysis timeout while doing it. The loop advances one byte (intel) or one instruction word (AArch64) per iteration over anything it cannot use, so a large claimed data run inside the code area is walked in full even after the budget for the whole run is gone. The timeout is enforced between functions, so the scan itself was the one unbounded stretch left in candidate discovery.

Both loops now poll every 4096 iterations — the same interval and shape `_splitMergedFunctionsAtPdataEnds` already uses — and return "no further candidate" once the budget is spent.

## Cost when nothing is wrong

One counter increment and one modulo per iteration; the callback is not reached at all on a scan that finishes normally.

## Scope note

This bounds a latent overrun, not a measured one: the analysis overrun that prompted the audit turned out to be caused by a wrong bitness probe on mapped 64-bit images (separate change), which inflates candidate counts rather than lengthening a single scan. Measured on the bundled fixtures, no recovered function set changes.

## Tests

`tests/testGapScanTimeout.py`, four cases: for each backend a long scan that completes normally (positive control, so the timeout case cannot pass vacuously) and the same scan with a budget that is already spent, asserting the scan returns no candidate, marks `analysis_timeout`, and calls the callback exactly once.

## Validation

- `make lint`, `make typecheck` — clean
- `make test` — 1184 passed, 2 skipped
- `diff-cover` — 100% on 8 changed lines
