### PR TITLE
fix(loaders): keep the bytes of an input no format loader recognizes

### DIFF
--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -160,6 +160,7 @@ class Disassembler:
         binary_info.abi = loader.getAbi()
         binary_info.code_areas = loader.getCodeAreas()
         binary_info.has_backend = loader.getHasBackend()
+        binary_info.format_recognized = loader.getFormatRecognized()
         return binary_info
 
     def _ensureHashes(self, binary_info):
@@ -274,6 +275,11 @@ class Disassembler:
             return SmdaReport(self.disassembly, config=self.config)
         if not binary_info.has_backend:
             if not binary_info.architecture:
+                if binary_info.format_recognized:
+                    raise RuntimeError(
+                        "The container was recognized but names an instruction set SMDA has no "
+                        "backend for, so there is nothing to disassemble it with."
+                    )
                 raise RuntimeError(
                     "Input is not a PE, ELF, Mach-O, DEX or Delphi knowledge base, so neither its "
                     "instruction set nor its load address can be read from it. A memory dump has to "

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -273,6 +273,12 @@ class Disassembler:
             self.disassembly = self.disassembler.analyzeBuffer(binary_info, self._callbackAnalysisTimeout)
             return SmdaReport(self.disassembly, config=self.config)
         if not binary_info.has_backend:
+            if not binary_info.architecture:
+                raise RuntimeError(
+                    "Input is not a PE, ELF, Mach-O, DEX or Delphi knowledge base, so neither its "
+                    "instruction set nor its load address can be read from it. A memory dump has to "
+                    "be passed to disassembleBuffer() with its base address."
+                )
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -53,6 +53,7 @@ class BinaryInfo:
     is_library = False
     is_buffer = False
     has_backend = False
+    format_recognized = False
     sha256 = ""
     sha1 = ""
     md5 = ""

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -72,6 +72,12 @@ class FileLoader:
                     else:
                         self._has_backend = bool(self._architecture)
                     break
+            else:
+                # No format loader claimed the input, so there is no mapping to apply and
+                # the bytes are already whatever they are. Returning them keeps getData()
+                # honest; every format-derived field stays unset, which is what tells the
+                # caller the instruction set and load address are unknown.
+                self._data = self._raw_data
         else:
             self._data = self._raw_data
 

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -17,6 +17,7 @@ class FileLoader:
     _abi = ""
     _architecture = ""
     _has_backend = False
+    _format_recognized = False
     _code_areas = None
     file_loaders = [PeFileLoader, ElfFileLoader, MachoFileLoader, DelphiKbFileLoader, DexFileLoader]
 
@@ -46,6 +47,7 @@ class FileLoader:
         self._abi = ""
         self._architecture = ""
         self._has_backend = False
+        self._format_recognized = False
         self._code_areas = []
         self._raw_data = buffer if buffer is not None else self._loadRawFileContent()
         if self._map_file:
@@ -71,6 +73,7 @@ class FileLoader:
                         self._has_backend = loader.getHasBackend(self._raw_data, **kw)
                     else:
                         self._has_backend = bool(self._architecture)
+                    self._format_recognized = True
                     break
             else:
                 # No format loader claimed the input, so there is no mapping to apply and
@@ -98,6 +101,14 @@ class FileLoader:
 
     def getHasBackend(self):
         return self._has_backend
+
+    def getFormatRecognized(self):
+        """Whether a format loader claimed the input, regardless of what it read from it.
+
+        A recognized container whose machine type SMDA has no backend for and an input
+        no loader claims at all both end up with an empty architecture, and they need
+        opposite advice."""
+        return self._format_recognized
 
     def getBitness(self):
         return self._bitness

--- a/tests/testMachoFileLoader.py
+++ b/tests/testMachoFileLoader.py
@@ -203,7 +203,7 @@ class TestMachoFileLoader(unittest.TestCase):
 
         loader._loadFile(b"not a recognized binary")
 
-        self.assertEqual(loader.getData(), b"")
+        self.assertEqual(loader.getData(), b"not a recognized binary")
         self.assertEqual(loader.getBaseAddress(), 0)
         self.assertEqual(loader.getBitness(), 0)
         self.assertEqual(loader.getAbi(), "")

--- a/tests/testUnrecognizedInput.py
+++ b/tests/testUnrecognizedInput.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+from smda.utility.MemoryFileLoader import MemoryFileLoader
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+DUMP = bytes(byte ^ (index % 256) for index, byte in enumerate((FIXTURE_DIR / "asprox_0x008D0000_xored").read_bytes()))
+
+
+class UnrecognizedInputMappingTest(unittest.TestCase):
+    def testMappingAnUnrecognizedBufferReturnsItsBytes(self):
+        loader = MemoryFileLoader(DUMP, map_file=True)
+        self.assertEqual(loader.getData(), DUMP)
+        self.assertEqual(loader.getRawData(), DUMP)
+
+    def testUnrecognizedBufferLeavesFormatMetadataUnset(self):
+        loader = MemoryFileLoader(DUMP, map_file=True)
+        self.assertEqual(loader.getArchitecture(), "")
+        self.assertEqual(loader.getBitness(), 0)
+        self.assertEqual(loader.getBaseAddress(), 0)
+        self.assertEqual(loader.getCodeAreas(), [])
+        self.assertFalse(loader.getHasBackend())
+
+    def testRecognizedBufferStillMaps(self):
+        pe = bytes(byte ^ (index % 256) for index, byte in enumerate((FIXTURE_DIR / "cutwail_xored").read_bytes()))
+        loader = MemoryFileLoader(pe, map_file=True)
+        self.assertNotEqual(loader.getData(), pe)
+        self.assertEqual(loader.getArchitecture(), "intel")
+
+    def testUnmappedLoadReturnsTheBytesUnchanged(self):
+        loader = MemoryFileLoader(DUMP, map_file=False)
+        self.assertEqual(loader.getData(), DUMP)
+
+
+class UnrecognizedInputReportTest(unittest.TestCase):
+    def testDisassemblingADumpAsAFileExplainsWhatToDo(self):
+        path = FIXTURE_DIR / "asprox_0x008D0000_xored"
+        loader = FileLoader(str(path), map_file=True)
+        self.assertEqual(loader.getData(), loader.getRawData())
+        report = Disassembler(SmdaConfig()).disassembleFile(str(path))
+        self.assertEqual(report.status, "error")
+        self.assertIn("has to be passed to disassembleBuffer() with its base address", report.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testUnrecognizedInput.py
+++ b/tests/testUnrecognizedInput.py
@@ -1,3 +1,4 @@
+import struct
 import unittest
 from pathlib import Path
 
@@ -5,6 +6,7 @@ from smda.Disassembler import Disassembler
 from smda.SmdaConfig import SmdaConfig
 from smda.utility.FileLoader import FileLoader
 from smda.utility.MemoryFileLoader import MemoryFileLoader
+from tests.testDalvikDisassembler import build_dex_header
 
 FIXTURE_DIR = Path(__file__).resolve().parent
 DUMP = bytes(byte ^ (index % 256) for index, byte in enumerate((FIXTURE_DIR / "asprox_0x008D0000_xored").read_bytes()))
@@ -33,6 +35,47 @@ class UnrecognizedInputMappingTest(unittest.TestCase):
     def testUnmappedLoadReturnsTheBytesUnchanged(self):
         loader = MemoryFileLoader(DUMP, map_file=False)
         self.assertEqual(loader.getData(), DUMP)
+
+
+def _elf_with_machine(machine):
+    """Minimal ELF64 header naming an instruction set, and nothing else."""
+    header = bytearray(64)
+    header[0:16] = b"\x7fELF\x02\x01\x01" + b"\x00" * 9
+    struct.pack_into("<HH", header, 16, 2, machine)  # e_type = ET_EXEC, e_machine
+    struct.pack_into("<I", header, 20, 1)  # e_version
+    struct.pack_into("<HH", header, 52, 64, 0)  # e_ehsize, e_phentsize
+    struct.pack_into("<HH", header, 58, 64, 0)  # e_shentsize, e_shnum
+    return bytes(header)
+
+
+EM_AVR = 83
+
+
+class RecognizedFormatWithoutAnArchitectureTest(unittest.TestCase):
+    """A container SMDA parses but whose machine type it has no mapping for also ends
+    up with an empty architecture, and telling that caller to retry as a memory dump
+    would send them after something that cannot help."""
+
+    def testLoaderReportsTheFormatAsRecognized(self):
+        loader = MemoryFileLoader(_elf_with_machine(EM_AVR), map_file=True)
+        self.assertTrue(loader.getFormatRecognized())
+        self.assertEqual(loader.getArchitecture(), "")
+
+    def testLoaderReportsAnUnclaimedBufferAsUnrecognized(self):
+        self.assertFalse(MemoryFileLoader(DUMP, map_file=True).getFormatRecognized())
+
+    def testAFormatWithoutItsOwnBackendFlagIsStillRecognized(self):
+        # DEX and the Delphi knowledge base do not expose getHasBackend(), so they take
+        # the other arm of the dispatch and have to set the same flag
+        loader = MemoryFileLoader(build_dex_header(), map_file=True)
+        self.assertTrue(loader.getFormatRecognized())
+        self.assertEqual(loader.getArchitecture(), "dalvik")
+        self.assertTrue(loader.getHasBackend())
+
+    def testTheMessageNamesTheInstructionSetAsWhatIsMissing(self):
+        report = Disassembler(SmdaConfig()).disassembleUnmappedBuffer(_elf_with_machine(EM_AVR))
+        self.assertEqual(report.status, "error")
+        self.assertIn("names an instruction set SMDA has no backend for", report.message)
 
 
 class UnrecognizedInputReportTest(unittest.TestCase):


### PR DESCRIPTION
## What

`FileLoader` maps a buffer by asking each format loader whether it can claim it. When none can — a raw memory dump, a shellcode blob, a carved region — the loop simply ended and `getData()` returned the empty bytes it had been initialized with. `disassembleFile()` on a dump therefore analyzed nothing and reported zero functions with `status == "ok"`, which a caller cannot tell apart from a file that genuinely contains no code.

Three changes:

1. The unclaimed case returns the raw bytes. Every format-derived field stays unset (`architecture == ""`, `bitness == 0`, `base_addr == 0`, no code areas, no backend) — that is what tells the caller the instruction set and load address are unknown.
2. `_disassemble` turns "no architecture and no backend" into an error that names the one thing that resolves it: a dump has to be passed to `disassembleBuffer()` with its base address, because no header carries it.
3. A container SMDA *did* recognize but whose machine type it has no backend for also has an empty architecture, and needs the opposite advice. `FileLoader` now records whether a loader claimed the input, separately from what that loader managed to read out of it, so the two cases get their own message.

## Baseline change

`tests/testMachoFileLoader.py` asserted the empty return for an unrecognized buffer. That assertion pinned the behaviour being fixed, so it is updated to the buffer's own bytes.

## Tests

`tests/testUnrecognizedInput.py`, 9 cases: the unrecognized buffer maps to itself and leaves every format field unset, a recognized buffer still maps (positive control), the unmapped path is unchanged, `disassembleFile()` on the bundled 32-bit dump fixture reports `status == "error"` with the actionable message, and — for the recognized-container case — the loader flag for a crafted `EM_AVR` ELF, for an unclaimed buffer, the end-to-end message, and DEX, which takes the other arm of the backend-flag dispatch and has to set the same flag.

Worth noting for anyone re-checking the AVR case by hand: the two ELF fixtures that look like it (SPARC, m68k) do resolve an architecture string and reach the pre-existing "no backend available for architecture 'sparc'" message instead, so the new branch needs a crafted header to be reachable at all.

## Validation

- `make lint`, `make typecheck` — clean
- `make test` — green
- `diff-cover` — 100% on changed lines
