### PR TITLE
fix(intel): read a mapped image's bitness from its REX.W usage

### DIFF
--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -434,8 +434,10 @@ class RecursiveDisassembler:
         self.disassembly.analysis_start_ts = datetime.datetime.now(datetime.timezone.utc)
         if binary_info.bitness not in [32, 64]:
             binary_info.bitness = self.backend.probeBitness(self.disassembly)
-            LOGGER.debug(
-                "Automatically Recognized Bitness as: %d",
+            LOGGER.warning(
+                "No bitness was supplied; inferred %d-bit from the buffer's contents. "
+                "Pass the bitness explicitly when it is known - decoding in the wrong mode "
+                "yields a plausible-looking report whose blocks and edges are all wrong.",
                 binary_info.bitness,
             )
         else:

--- a/src/smda/intel/BitnessAnalyzer.py
+++ b/src/smda/intel/BitnessAnalyzer.py
@@ -20,7 +20,10 @@ REX_W_PREFIX = 0x48
 # every 0x48 introduces one of the opcodes above; in 32-bit code the byte that follows
 # is unrelated, so the share lands near the 29/256 a uniform byte would give. Measured
 # across PE/ELF/Mach-O images from Go, gcc, clang, mingw-Rust and 32-bit malware:
-# 32-bit stays at or below 0.36, 64-bit at or above 0.74.
+# over the loader's code areas, 32-bit stays at or below 0.36 and 64-bit at or above
+# 0.93; over a whole image, where data dilutes the count toward the uniform share, the
+# floor for 64-bit drops to 0.74. The threshold sits inside both gaps because a raw
+# memory dump names no code areas and has to be judged whole.
 REX_W_SHARE_THRESHOLD = 0.5
 # Below this many observations the share is noise; fall back to the first-byte tables.
 REX_W_MIN_SAMPLES = 64
@@ -39,19 +42,31 @@ class BitnessAnalyzer:
 
     def determineBitnessFromDisassembly(self, disassembly):
         LOGGER.debug("Running Bitness test on binary data of DisassemblyResult")
-        return self.determineBitness(binary=disassembly.binary_info.binary)
+        binary_info = disassembly.binary_info
+        return self.determineBitness(binary_info.binary, regions=self._codeRegions(binary_info))
 
-    def _rexWShare(self, binary):
+    @staticmethod
+    def _codeRegions(binary_info):
+        """Offsets of the loader's code areas within the mapped buffer, if it named any."""
+        regions = []
+        for area in binary_info.code_areas or []:
+            start = max(0, area[0] - binary_info.base_addr)
+            end = min(len(binary_info.binary), area[1] - binary_info.base_addr)
+            if end > start:
+                regions.append((start, end))
+        return regions
+
+    def _rexWShare(self, binary, regions=None):
         """Share of 0x48 bytes that introduce a REX.W-compatible opcode."""
         observed = 0
         introducing = 0
-        index = binary.find(REX_W_PREFIX)
-        limit = len(binary) - 1
-        while 0 <= index < limit and observed < REX_W_MAX_SAMPLES:
-            observed += 1
-            if binary[index + 1] in REX_W_OPCODES:
-                introducing += 1
-            index = binary.find(REX_W_PREFIX, index + 1)
+        for start, end in regions or [(0, len(binary))]:
+            index = binary.find(REX_W_PREFIX, start, end)
+            while 0 <= index < end - 1 and observed < REX_W_MAX_SAMPLES:
+                observed += 1
+                if binary[index + 1] in REX_W_OPCODES:
+                    introducing += 1
+                index = binary.find(REX_W_PREFIX, index + 1, end)
         if observed < REX_W_MIN_SAMPLES:
             return None, observed
         return introducing / observed, observed
@@ -79,8 +94,12 @@ class BitnessAnalyzer:
         LOGGER.debug("Bitness scores: %5.2f (32bit), %5.2f (64bit)", score["32"], score["64"])
         return 64 if score["32"] < score["64"] else 32
 
-    def determineBitness(self, binary):
-        share, observed = self._rexWShare(binary)
+    def determineBitness(self, binary, regions=None):
+        share, observed = self._rexWShare(binary, regions)
+        if share is None and regions:
+            # too little code named to decide on; the whole image is still better
+            # evidence than the byte tables
+            share, observed = self._rexWShare(binary)
         if share is None:
             LOGGER.debug(
                 "Only %d REX.W-candidate bytes, falling back to function-start bytes",

--- a/src/smda/intel/BitnessAnalyzer.py
+++ b/src/smda/intel/BitnessAnalyzer.py
@@ -6,6 +6,28 @@ from .definitions import COMMON_START_BYTES
 
 LOGGER = logging.getLogger(__name__)
 
+# Opcodes a REX.W prefix legitimately introduces in ordinary compiler output: the
+# 64-bit pointer arithmetic, moves and compares that dominate an amd64 text section.
+REX_W_OPCODES = frozenset(
+    {
+        0x01, 0x03, 0x09, 0x0B, 0x21, 0x23, 0x29, 0x2B, 0x31, 0x33, 0x39, 0x3B,
+        0x63, 0x69, 0x6B, 0x81, 0x83, 0x85, 0x87, 0x89, 0x8B, 0x8D, 0x8F,
+        0xC1, 0xC7, 0xD1, 0xD3, 0xF7, 0xFF,
+    }
+)  # fmt: skip
+REX_W_PREFIX = 0x48
+# 0x48 is REX.W in 64-bit mode and "dec eax" in 32-bit mode. In 64-bit code almost
+# every 0x48 introduces one of the opcodes above; in 32-bit code the byte that follows
+# is unrelated, so the share lands near the 29/256 a uniform byte would give. Measured
+# across PE/ELF/Mach-O images from Go, gcc, clang, mingw-Rust and 32-bit malware:
+# 32-bit stays at or below 0.36, 64-bit at or above 0.74.
+REX_W_SHARE_THRESHOLD = 0.5
+# Below this many observations the share is noise; fall back to the first-byte tables.
+REX_W_MIN_SAMPLES = 64
+# Bounds the probe on a pathological input without biasing it: an image with more
+# occurrences than this is sampled far past the point where the share stabilises.
+REX_W_MAX_SAMPLES = 1 << 16
+
 
 class BitnessAnalyzer:
     def determineBitnessFromFile(self, filepath):
@@ -19,7 +41,22 @@ class BitnessAnalyzer:
         LOGGER.debug("Running Bitness test on binary data of DisassemblyResult")
         return self.determineBitness(binary=disassembly.binary_info.binary)
 
-    def determineBitness(self, binary):
+    def _rexWShare(self, binary):
+        """Share of 0x48 bytes that introduce a REX.W-compatible opcode."""
+        observed = 0
+        introducing = 0
+        index = binary.find(REX_W_PREFIX)
+        limit = len(binary) - 1
+        while 0 <= index < limit and observed < REX_W_MAX_SAMPLES:
+            observed += 1
+            if binary[index + 1] in REX_W_OPCODES:
+                introducing += 1
+            index = binary.find(REX_W_PREFIX, index + 1)
+        if observed < REX_W_MIN_SAMPLES:
+            return None, observed
+        return introducing / observed, observed
+
+    def _scoreCommonStartBytes(self, binary):
         candidate_first_bytes = set()
         # check for potential call instructions and collect their first bytes
         for call_match in re.finditer(b"\xe8", binary):
@@ -41,3 +78,20 @@ class BitnessAnalyzer:
         score["64"] = score["64"] / total_score
         LOGGER.debug("Bitness scores: %5.2f (32bit), %5.2f (64bit)", score["32"], score["64"])
         return 64 if score["32"] < score["64"] else 32
+
+    def determineBitness(self, binary):
+        share, observed = self._rexWShare(binary)
+        if share is None:
+            LOGGER.debug(
+                "Only %d REX.W-candidate bytes, falling back to function-start bytes",
+                observed,
+            )
+            return self._scoreCommonStartBytes(binary)
+        bitness = 64 if share > REX_W_SHARE_THRESHOLD else 32
+        LOGGER.debug(
+            "Bitness probed as %d: %.3f of %d 0x48 bytes introduce a REX.W opcode",
+            bitness,
+            share,
+            observed,
+        )
+        return bitness

--- a/tests/testBitnessProbe.py
+++ b/tests/testBitnessProbe.py
@@ -1,0 +1,124 @@
+import logging
+import unittest
+from pathlib import Path
+
+from smda.Disassembler import Disassembler
+from smda.intel.BitnessAnalyzer import (
+    REX_W_MAX_SAMPLES,
+    REX_W_MIN_SAMPLES,
+    BitnessAnalyzer,
+)
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+from smda.utility.MemoryFileLoader import MemoryFileLoader
+from smda.utility.PeFileLoader import PeFileLoader
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+
+
+def _decode(name):
+    return bytes(byte ^ (index % 256) for index, byte in enumerate((FIXTURE_DIR / name).read_bytes()))
+
+
+class RexWShareTest(unittest.TestCase):
+    def testRexWPairsReadAs64Bit(self):
+        binary = b"\x48\x89" * REX_W_MIN_SAMPLES
+        self.assertEqual(BitnessAnalyzer().determineBitness(binary), 64)
+
+    def testDecEaxWithUnrelatedFollowerReadsAs32Bit(self):
+        binary = b"\x48\x50" * REX_W_MIN_SAMPLES
+        self.assertEqual(BitnessAnalyzer().determineBitness(binary), 32)
+
+    def testShareBelowSampleFloorFallsBackToStartBytes(self):
+        analyzer = BitnessAnalyzer()
+        binary = b"\x48\x89" * (REX_W_MIN_SAMPLES - 1)
+        share, observed = analyzer._rexWShare(binary)
+        self.assertIsNone(share)
+        self.assertEqual(observed, REX_W_MIN_SAMPLES - 1)
+        self.assertEqual(analyzer.determineBitness(binary), 32)
+
+    def testSamplingStopsAtTheCap(self):
+        binary = b"\x48\x89" * (REX_W_MAX_SAMPLES + 8)
+        share, observed = BitnessAnalyzer()._rexWShare(binary)
+        self.assertEqual(observed, REX_W_MAX_SAMPLES)
+        self.assertEqual(share, 1.0)
+
+    def testTrailingPrefixByteIsNotCounted(self):
+        binary = b"\x48\x89" * REX_W_MIN_SAMPLES + b"\x48"
+        share, observed = BitnessAnalyzer()._rexWShare(binary)
+        self.assertEqual(observed, REX_W_MIN_SAMPLES)
+        self.assertEqual(share, 1.0)
+
+    def testMixedShareBelowThresholdReadsAs32Bit(self):
+        binary = (b"\x48\x89" + b"\x48\x50" * 3) * REX_W_MIN_SAMPLES
+        self.assertEqual(BitnessAnalyzer().determineBitness(binary), 32)
+
+
+class MappedFixtureBitnessTest(unittest.TestCase):
+    """Ground truth: the bundled fixtures, mapped the way a dump reaches SMDA."""
+
+    def testMapped64BitPeIsRecognized(self):
+        mapped = PeFileLoader.mapBinary(_decode("rust_pe_gnu_xored"))
+        self.assertEqual(BitnessAnalyzer().determineBitness(mapped), 64)
+
+    def testMapped32BitPeIsRecognized(self):
+        mapped = PeFileLoader.mapBinary(_decode("cutwail_xored"))
+        self.assertEqual(BitnessAnalyzer().determineBitness(mapped), 32)
+
+    def test32BitMemoryDumpIsRecognized(self):
+        self.assertEqual(BitnessAnalyzer().determineBitness(_decode("asprox_0x008D0000_xored")), 32)
+
+    def test64BitElfIsRecognized(self):
+        loader = FileLoader(str(FIXTURE_DIR / "bashlite_xored"), map_file=False)
+        decoded = bytes(byte ^ (index % 256) for index, byte in enumerate(loader.getRawData()))
+        self.assertEqual(BitnessAnalyzer().determineBitness(decoded), 64)
+
+
+class MemoryDumpRecoveryTest(unittest.TestCase):
+    """End to end from a mapped image with no bitness supplied - the shape a memory
+    dump arrives in. Reading a 64-bit image as 32-bit does not fail loudly; it
+    decodes every REX prefix as `dec`/`inc` and buries the run in bogus candidates."""
+
+    def testMapped64BitImageRecoversFunctions(self):
+        loader = FileLoader(str(FIXTURE_DIR / "mirai_x64_xored"), map_file=False)
+        decoded = bytes(byte ^ (index % 256) for index, byte in enumerate(loader.getRawData()))
+        mapped = MemoryFileLoader(decoded, map_file=True)
+        config = SmdaConfig()
+        config.TIMEOUT = 300
+        config.WITH_STRINGS = False
+
+        report = Disassembler(config).disassembleBuffer(mapped.getData(), mapped.getBaseAddress())
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.bitness, 64)
+        self.assertEqual(report.architecture, "intel")
+        self.assertGreater(report.num_functions, 100)
+
+
+class ProbedBitnessIsAnnouncedTest(unittest.TestCase):
+    def setUp(self):
+        # several test modules call logging.disable() at import, which would make assertLogs
+        # see no records - and assertNoLogs pass vacuously - depending on collection order
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+    def testBufferWithoutBitnessLogsThatItWasInferred(self):
+        mapped = PeFileLoader.mapBinary(_decode("cutwail_xored"))
+        config = SmdaConfig()
+        config.TIMEOUT = 10
+        with self.assertLogs("smda.common.RecursiveDisassembler", level=logging.WARNING) as captured:
+            Disassembler(config).disassembleBuffer(mapped, 0x4000000)
+        self.assertTrue(any("inferred 32-bit" in message for message in captured.output))
+
+    def testSuppliedBitnessIsNotAnnounced(self):
+        mapped = PeFileLoader.mapBinary(_decode("cutwail_xored"))
+        config = SmdaConfig()
+        config.TIMEOUT = 10
+        logger = logging.getLogger("smda.common.RecursiveDisassembler")
+        with self.assertNoLogs(logger, level=logging.WARNING):
+            Disassembler(config).disassembleBuffer(mapped, 0x4000000, bitness=32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testBitnessProbe.py
+++ b/tests/testBitnessProbe.py
@@ -1,7 +1,9 @@
 import logging
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
+from smda.common.BinaryInfo import BinaryInfo
 from smda.Disassembler import Disassembler
 from smda.intel.BitnessAnalyzer import (
     REX_W_MAX_SAMPLES,
@@ -52,6 +54,48 @@ class RexWShareTest(unittest.TestCase):
     def testMixedShareBelowThresholdReadsAs32Bit(self):
         binary = (b"\x48\x89" + b"\x48\x50" * 3) * REX_W_MIN_SAMPLES
         self.assertEqual(BitnessAnalyzer().determineBitness(binary), 32)
+
+
+class CodeAreaSamplingTest(unittest.TestCase):
+    """Data dilutes the whole-image share toward the uniform one, so the loader's code
+    areas are sampled when it named any."""
+
+    CODE = b"\x48\x89" * REX_W_MIN_SAMPLES
+    # 0x48 followed by a byte no REX.W form uses: what data contributes to the count
+    DATA = b"\x48\x50" * (REX_W_MIN_SAMPLES * 4)
+
+    def _binary_info(self, buffer, code_areas):
+        binary_info = BinaryInfo(buffer)
+        binary_info.base_addr = 0x400000
+        binary_info.code_areas = code_areas
+        return binary_info
+
+    def testDilutedImageIsStillReadAs64BitThroughItsCodeAreas(self):
+        buffer = self.CODE + self.DATA
+        self.assertEqual(BitnessAnalyzer().determineBitness(buffer), 32)  # whole image: diluted
+        binary_info = self._binary_info(buffer, [[0x400000, 0x400000 + len(self.CODE)]])
+        disassembly = SimpleNamespace(binary_info=binary_info)
+        self.assertEqual(BitnessAnalyzer().determineBitnessFromDisassembly(disassembly), 64)
+
+    def testCodeAreasAreClampedToTheBuffer(self):
+        binary_info = self._binary_info(self.CODE, [[0x300000, 0x500000]])
+        self.assertEqual(BitnessAnalyzer()._codeRegions(binary_info), [(0, len(self.CODE))])
+
+    def testEmptyAreasAreDropped(self):
+        binary_info = self._binary_info(self.CODE, [[0x400010, 0x400010]])
+        self.assertEqual(BitnessAnalyzer()._codeRegions(binary_info), [])
+
+    def testTooLittleCodeFallsBackToTheWholeImage(self):
+        # the named area holds one sample; the image holds enough
+        buffer = self.CODE + self.DATA
+        binary_info = self._binary_info(buffer, [[0x400000, 0x400002]])
+        disassembly = SimpleNamespace(binary_info=binary_info)
+        self.assertEqual(BitnessAnalyzer().determineBitnessFromDisassembly(disassembly), 32)
+
+    def testAnImageWithoutCodeAreasIsJudgedWhole(self):
+        binary_info = self._binary_info(self.CODE, [])
+        disassembly = SimpleNamespace(binary_info=binary_info)
+        self.assertEqual(BitnessAnalyzer().determineBitnessFromDisassembly(disassembly), 64)
 
 
 class MappedFixtureBitnessTest(unittest.TestCase):


### PR DESCRIPTION
## What was wrong

`BitnessAnalyzer.determineBitness` collected the first bytes at every direct-call target and scored them against the 32- and 64-bit function-start byte tables. Those tables overlap heavily — both list push/mov/sub prologues — so the vote is decided by which table happens to hold more of the common entries, not by anything that actually differs between the two modes.

This is a memory-dump problem specifically. A file carries its machine type in a header; a dump carries nothing, so the probe is the only answer available. And reading a 64-bit image as 32-bit does not fail: it decodes every REX prefix as `dec`/`inc`, splits real instructions, and returns a full report whose blocks and edges are wrong.

## The discriminator

`0x48` is REX.W in 64-bit mode and `dec eax` in 32-bit mode. In 64-bit code it is followed by one of a small set of opcodes almost every time (the pointer arithmetic, moves and compares that dominate an amd64 text section); in 32-bit code the byte after it is unrelated, so the share lands near the 29/256 a uniform byte would give.

Sampling is restricted to the loader's code areas when it named any, because data dilutes the share toward the uniform one — measured, the clang-built C binary scores 0.993 over its code and 0.744 over the whole image. A raw dump names no code areas and is judged whole; a named area too small to sample falls back to the whole image rather than straight to the byte tables.

Measured over PE/ELF/Mach-O images from Go, gcc, clang, mingw-Rust and 32-bit malware, plus the bundled fixtures:

| sampled over | 32-bit max | 64-bit min |
| --- | --- | --- |
| code areas | **0.351** | **0.937** |
| whole image | 0.245 | 0.744 |

The 0.5 threshold sits inside both gaps, which is what lets one threshold serve both sampling modes. Four other statistics were measured first and rejected: frequency-weighted tables (6/14 correct), the REX ratio at call targets (9/13), decode length (4/13), sane termination (10/13).

Below 64 observed `0x48` bytes the share is noise and the old table vote still decides; sampling stops at 65536, far past the point where the share stabilises.

## End to end

Analysing the bundled x64 ELF as a mapped image, with no bitness supplied:

| | bitness | functions |
| --- | --- | --- |
| master | 32 | 171 |
| this branch | 64 | 152 |

The higher count was the wrong one — those are fragments of instructions split at REX prefixes.

Re-checked across the whole measurement corpus after the code-area change: 21 of 21 images with a known bitness classify correctly.

The engine also announces an inferred bitness as a warning rather than a debug line: a caller that could have supplied it has no other sign that it was guessed.

## Tests

`tests/testBitnessProbe.py` — 18 cases: the share statistic itself (pairs, `dec eax` followers, sample floor, sampling cap, trailing prefix byte, mixed share), code-area sampling (a diluted image the whole-buffer share reads as 32-bit, area clamping, empty areas, the too-few-samples fallback, an image with no areas), the bundled fixtures mapped the way a dump reaches SMDA, end-to-end recovery from a mapped 64-bit image, and the inferred-bitness warning in both directions.

## Validation

- `make lint`, `make typecheck` — clean
- `make test` — green
- `diff-cover` — 100% on changed lines
