### PR TITLE
fix(intel): scan a direct jump table whose bound was not recovered

### DIFF
--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -119,15 +119,25 @@ class JumpTableAnalyzer:
                 break
         return bonus_offset
 
-    def _extractDirectTableOffsets(self, jumptable_size, off_jumptable):
+    def _extractDirectTableOffsets(self, jumptable_size, off_jumptable, state=None, jump_instruction_address=None):
+        # an unrecovered bound arrives as 0, which read as "zero entries" and abandoned the
+        # table; the per-entry image bound below is what actually ends the scan, exactly as
+        # in _resolveExplicitTable and _extractRelativeTableOffsets
+        jumptable_size = jumptable_size if jumptable_size else 0xFF
         jump_targets = set()
-        if jumptable_size and off_jumptable and self.disassembly.isAddrWithinMemoryImage(off_jumptable):
+        if off_jumptable and self.disassembly.isAddrWithinMemoryImage(off_jumptable):
             for index in range(jumptable_size):
                 raw_entry_bytes = self.disassembly.getBytes(off_jumptable + index * 4, 4)
                 if raw_entry_bytes is None or len(raw_entry_bytes) < 4:
-                    continue
+                    break
                 entry = struct.unpack("<I", raw_entry_bytes)[0]
+                if not self.disassembly.isAddrWithinMemoryImage(entry):
+                    break
                 jump_targets.add(entry)
+                if state is not None:
+                    # claim the entry as data, or the gap scan seeds function candidates
+                    # inside the table bytes
+                    state.addDataRef(jump_instruction_address, off_jumptable + index * 4, size=4)
         return sorted(jump_targets)
 
     def _extractRelativeTableOffsets(
@@ -230,7 +240,12 @@ class JumpTableAnalyzer:
             # 32bit cases typically load into target register directly
             if backtracked_sequence.startswith("mov"):
                 off_jumptable = self._directHandler(jump_instruction_op_str, state, backtracked)
-                table_offsets = self._extractDirectTableOffsets(jumptable_size, off_jumptable)
+                table_offsets = self._extractDirectTableOffsets(
+                    jumptable_size,
+                    off_jumptable,
+                    state=state,
+                    jump_instruction_address=jump_instruction_address,
+                )
             elif backtracked_sequence.startswith("add-movsxd"):
                 jumptable_size = self._findJumpTableSize(backtracked)
                 off_jumptable = self._x64Handler(state, backtracked)

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -120,10 +120,8 @@ class JumpTableAnalyzer:
         return bonus_offset
 
     def _extractDirectTableOffsets(self, jumptable_size, off_jumptable, state=None, jump_instruction_address=None):
-        # an unrecovered bound arrives as 0, which read as "zero entries" and abandoned the
-        # table; the per-entry image bound below is what actually ends the scan, exactly as
-        # in _resolveExplicitTable and _extractRelativeTableOffsets
-        jumptable_size = jumptable_size if jumptable_size else 0xFF
+        bound_was_recovered = bool(jumptable_size)
+        jumptable_size = jumptable_size if bound_was_recovered else 0xFF
         jump_targets = set()
         if off_jumptable and self.disassembly.isAddrWithinMemoryImage(off_jumptable):
             for index in range(jumptable_size):
@@ -132,11 +130,11 @@ class JumpTableAnalyzer:
                     break
                 entry = struct.unpack("<I", raw_entry_bytes)[0]
                 if not self.disassembly.isAddrWithinMemoryImage(entry):
+                    if bound_was_recovered:
+                        continue
                     break
                 jump_targets.add(entry)
                 if state is not None:
-                    # claim the entry as data, or the gap scan seeds function candidates
-                    # inside the table bytes
                     state.addDataRef(jump_instruction_address, off_jumptable + index * 4, size=4)
         return sorted(jump_targets)
 

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -3,7 +3,9 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from smda.Disassembler import Disassembler
 from smda.intel.JumpTableAnalyzer import JumpTableAnalyzer
+from smda.SmdaConfig import SmdaConfig
 
 
 def _makeAnalyzer(binary=b"", base_addr=0x1000, binary_size=0x100, bitness=32):
@@ -316,3 +318,103 @@ class RelativeTableDataClaimTest(unittest.TestCase):
         analyzer.getJumpTargets((0x2000, 2, "jmp", "rax"), state)
 
         self.assertEqual([ref[1] for ref in state.refs], [0x1110, 0x1114])
+
+
+class DirectTableScanTest(unittest.TestCase):
+    """The 32-bit `mov <reg>, dword ptr [<reg>*4 + table]` / `jmp <reg>` shape, whose
+    extractor lacked both the unrecovered-bound fallback and the per-entry image bound
+    its two siblings already had."""
+
+    ENTRIES = [0x1100, 0x1200, 0x1300]
+    OUT_OF_IMAGE = struct.pack("<I", 0xDEADBEEF)
+
+    def _analyzer(self, trailing=OUT_OF_IMAGE):
+        analyzer = _makeAnalyzer(bitness=32)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(
+            side_effect=lambda addr: addr in (0x1090, *self.ENTRIES)
+        )
+        table = b"".join(struct.pack("<I", entry) for entry in self.ENTRIES) + trailing
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - 0x1090 : addr - 0x1090 + size]
+        )
+        return analyzer
+
+    def test_scans_when_the_size_was_not_recovered(self):
+        # an unrecovered bound arrives as 0 and abandoned the table outright; the
+        # per-entry image check is what ends the scan
+        analyzer = self._analyzer()
+        self.assertEqual(analyzer._extractDirectTableOffsets(0, 0x1090), self.ENTRIES)
+
+    def test_stops_at_the_first_out_of_image_entry(self):
+        # without the bound, a too-large size walked past the table and turned
+        # whatever followed it into jump targets
+        analyzer = self._analyzer()
+        self.assertEqual(analyzer._extractDirectTableOffsets(0xFF, 0x1090), self.ENTRIES)
+
+    def test_honours_a_recovered_size(self):
+        analyzer = self._analyzer()
+        self.assertEqual(analyzer._extractDirectTableOffsets(2, 0x1090), self.ENTRIES[:2])
+
+    def test_stops_at_a_short_read(self):
+        analyzer = self._analyzer(trailing=b"\x01\x02")
+        self.assertEqual(analyzer._extractDirectTableOffsets(0xFF, 0x1090), self.ENTRIES)
+
+    def test_each_consumed_entry_is_claimed_as_data(self):
+        analyzer = self._analyzer()
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        analyzer._extractDirectTableOffsets(0, 0x1090, state=state, jump_instruction_address=0x2000)
+        self.assertEqual(state.refs, [(0x2000, 0x1090, 4), (0x2000, 0x1094, 4), (0x2000, 0x1098, 4)])
+
+    def test_getJumpTargets_forwards_the_state_for_the_direct_shape(self):
+        analyzer = self._analyzer()
+        analyzer._directHandler = MagicMock(return_value=0x1090)
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        state.backtrackInstructions = MagicMock(
+            return_value=[(0x1FF0, 5, "mov", "eax, dword ptr [eax*4 + 0x1090]")],
+        )
+
+        targets = analyzer.getJumpTargets((0x2000, 2, "jmp", "eax"), state)
+
+        self.assertEqual(targets, self.ENTRIES)
+        self.assertEqual([ref[1] for ref in state.refs], [0x1090, 0x1094, 0x1098])
+
+
+class DirectTableRecoveryTest(unittest.TestCase):
+    """End to end: an abandoned table leaves the switch bodies unreferenced, so the gap
+    scan recovers each of them as a function of its own instead of as blocks."""
+
+    BASE = 0x400000
+    TABLE = 0x401000
+
+    def _buffer(self):
+        buffer = bytearray(0x2000)
+        code = bytes.fromhex("55")  # push ebp
+        code += bytes.fromhex("89e5")  # mov ebp, esp
+        code += bytes.fromhex("8b048500104000")  # mov eax, dword ptr [eax*4 + 0x401000]
+        code += bytes.fromhex("ffe0")  # jmp eax
+        buffer[0 : len(code)] = code
+        offset = self.TABLE - self.BASE
+        for index, target in enumerate((0x400010, 0x400020, 0x400030)):
+            struct.pack_into("<I", buffer, offset + index * 4, target)
+        struct.pack_into("<I", buffer, offset + 12, 0xDEADBEEF)  # out of image: ends the scan
+        for case in (0x10, 0x20, 0x30):
+            buffer[case : case + 3] = bytes.fromhex("31c0c3")  # xor eax, eax; ret
+        return bytes(buffer)
+
+    def test_switch_bodies_become_blocks_of_the_dispatching_function(self):
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        report = Disassembler(config).disassembleBuffer(self._buffer(), self.BASE, bitness=32)
+
+        self.assertEqual([function.offset for function in report.getFunctions()], [self.BASE])
+        function = next(iter(report.getFunctions()))
+        self.assertEqual(
+            sorted(block.offset for block in function.getBlocks()),
+            [self.BASE, 0x400010, 0x400020, 0x400030],
+        )
+        # the three consumed entries are claimed as data, so the gap scan cannot seed
+        # candidates inside the table
+        self.assertEqual(sorted(report.data_refs_from[0x40000A]), [0x401000, 0x401004, 0x401008])

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -355,6 +355,19 @@ class DirectTableScanTest(unittest.TestCase):
         analyzer = self._analyzer()
         self.assertEqual(analyzer._extractDirectTableOffsets(2, 0x1090), self.ENTRIES[:2])
 
+    def test_a_recovered_size_scans_past_an_entry_outside_the_image(self):
+        # one case dispatching outside the mapped image - a partially mapped dump, or a
+        # tailcall into another module - must not truncate the rest of a declared table
+        analyzer = self._analyzer()
+        table = struct.pack("<I", self.ENTRIES[0]) + self.OUT_OF_IMAGE + struct.pack("<I", self.ENTRIES[2])
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - 0x1090 : addr - 0x1090 + size]
+        )
+        self.assertEqual(
+            analyzer._extractDirectTableOffsets(3, 0x1090),
+            [self.ENTRIES[0], self.ENTRIES[2]],
+        )
+
     def test_stops_at_a_short_read(self):
         analyzer = self._analyzer(trailing=b"\x01\x02")
         self.assertEqual(analyzer._extractDirectTableOffsets(0xFF, 0x1090), self.ENTRIES)


### PR DESCRIPTION
## What was wrong

Of the three jump-table extractors, the direct one — the 32-bit `mov <reg>, dword ptr [<reg>*4 + table]` / `jmp <reg>` shape — was missing two things its siblings already had, plus a third they use to keep the gap scan out of the table.

1. **An unrecovered bound abandoned the table.** `_findJumpTableSize` reports "not found" as `0`, not `None`, and `if jumptable_size and ...` read that as *zero entries*. This is the same misreading `_resolveExplicitTable` was fixed for; here it means a switch whose `cmp` the backtracker cannot reach contributes no targets at all.
2. **Nothing bounded the entries.** Every dword in the scanned range became a jump target; only the caller's later in-image test kept the bogus ones out of the block queue. Both siblings stop at the first entry outside the image.
3. **The table bytes were not claimed as data**, so the gap scan can seed function candidates inside them — the reason `_extractRelativeTableOffsets` claims its own.

## Effect

On a 32-bit switch with no recoverable bound:

| | functions | blocks in the dispatcher |
| --- | --- | --- |
| master | 4 (dispatcher + each switch body as its own function) | 1 |
| this branch | **1** | **4** |

The switch bodies are unreferenced without the table, so the gap scan recovers each as a function of its own — a wrong CFG that looks like a plausible one.

All 22 bundled fixtures are byte-identical (function, block and instruction counts, and the recovered start sets). That is not because the change is inert: the direct extractor is reached 37 times across those fixtures and returns nothing every time, because none of them carries this table shape with a resolvable base. Hence the constructed case rather than a fixture.

## Scope note

The sibling `continue`s in `_extractRelativeTableOffsets` are deliberately untouched — they are the subject of the fix already sitting on `fix/intel-jumptable-entry-bound`, and duplicating it here would only create a conflict.

## Tests

`tests/testJumpTableAnalyzer.py` — six unit cases for the extractor (unrecovered bound, out-of-image stop, a real bound still capping the scan, short read, data claims, and `getJumpTargets` forwarding the state), plus one end-to-end case building the 32-bit switch above and asserting one function with four blocks and the three consumed entries claimed as data. Five of the seven fail on master.

## Validation

- `make lint`, `make typecheck` — clean
- `make test` — 1187 passed, 2 skipped
- `diff-cover` — 100% on 9 changed lines
