### PR TITLE
refactor(core): drop the unused indirect-switch walker

### DIFF
--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -166,31 +166,6 @@ class RecursiveDisassembler:
             return -value if referenced_addr.group("sign") == "-" else value
         return 0
 
-    def resolveIndirectSwitch(self, addr_switch_array, size):
-        indirect_switch_bytes = []
-        current_offset = addr_switch_array + size * 4
-        if self.disassembly.isAddrWithinMemoryImage(current_offset):
-            LOGGER.debug(
-                "0x%08x analyzing potentially indirect switch table (size: 0x%08x).",
-                current_offset,
-                size,
-            )
-            current_byte = self.disassembly.getByte(current_offset)
-            if isinstance(current_byte, str):
-                current_byte = ord(current_byte)
-            while (
-                current_byte is not None
-                and current_byte < size
-                and current_offset not in self.fc_manager.getFunctionStartCandidates()
-            ):
-                indirect_switch_bytes.append(current_offset)
-                current_offset += 1
-                current_byte = self.disassembly.getByte(current_offset)
-                if isinstance(current_byte, str):
-                    current_byte = ord(current_byte)
-            LOGGER.debug("0x%08x found %d bytes.", current_offset, len(indirect_switch_bytes))
-        return indirect_switch_bytes
-
     def _handleCallTarget(self, state, from_addr, to_addr):
         # explicit None check: address 0 is valid in base-0 buffers
         if to_addr is not None and self.disassembly.isAddrWithinMemoryImage(to_addr):

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -389,20 +389,6 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(result.ins2fn.get(0x100E), 0x1000)
 
-    def test_resolve_indirect_switch_stops_at_image_end(self):
-        disassembler = IntelDisassembler.__new__(IntelDisassembler)
-        disassembler.disassembly = SimpleNamespace(
-            isAddrWithinMemoryImage=lambda addr: 0x1000 <= addr < 0x1008,
-            getByte=lambda addr: 0 if 0x1000 <= addr < 0x1008 else None,
-        )
-        disassembler.fc_manager = SimpleNamespace(getFunctionStartCandidates=lambda: set())
-
-        # walks from 0x1004 past the image end without raising on the None byte
-        self.assertEqual(
-            disassembler.resolveIndirectSwitch(0x1000, 1),
-            list(range(0x1004, 0x1008)),
-        )
-
     def test_push_ret_obfuscation_detected_at_address_zero(self):
         # a push at address 0 (base-0 buffer) must not disable push-ret detection;
         # the stub at 0x0 becomes a candidate through the call in the second function


### PR DESCRIPTION
## What

`RecursiveDisassembler.resolveIndirectSwitch()` walks the bytes that follow a jump table, reading them as case indices — the two-level MSVC switch, where a byte array indexes a smaller table of distinct targets.

It has had **no caller since it was introduced in 2020**, so it has never run in any analysis.

## Why delete rather than wire it up

Because there is nothing here to validate a wiring against. The shape it looks for was measured across the bundled fixtures instead of assumed: of the eight explicit jump tables the corpus resolves, **none** is followed by a byte run that could be an index array. (Three have some trailing bytes below the entry count, but none as long as the count, and zero padding passes that test trivially.)

A real implementation of the two-level form needs a fixture that exhibits the pattern and a measurement showing what it recovers — which is the whole of the work, with or without this text in the tree. An untested helper sitting in the architecture-neutral engine is a liability rather than a head start.

Its only exercise was a test of its own behaviour, which goes with it.

## Validation

- `make lint`, `make typecheck` — clean
- `make test` — 1179 passed, 2 skipped (one fewer than master: the test of the deleted method)
- `diff-cover` — no added lines to cover
