### PR TITLE
docs(core): record what RESOLVE_TAILCALLS and TIMEOUT actually mean

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,23 @@ nesting 4.6% and SCC 3.2% of all calls, and disabling all three removes 17.8%. T
 a downstream consumer does not read.
 
 `RESOLVE_TAILCALLS` runs the other way round: it is **off** by default and buys recovery for time.
-It promotes the target of a jump that leaves a function into a function of its own, in a pass after
-gap analysis, so what it is worth depends on how much a binary tail-calls. On `libstdc++.so.6` it
-adds 337 functions (8473 to 8810) for 40-130% more analysis time, the spread being how much the
+Only the x86/x64 and AArch64 recursive disassemblers read it — the CIL and Dalvik backends run their
+own analysis pipelines and ignore it, so enabling it costs and buys nothing there. Where it does
+apply, it promotes the target of a jump that leaves a function into a function of its own, in a pass
+after gap analysis, so what it is worth depends on how much a binary tail-calls. On `libstdc++.so.6`
+it adds 337 functions (8473 to 8810) for 40-130% more analysis time, the spread being how much the
 measuring machine had to spare; on Go ELF and Mach-O memory images it adds 8 functions each, for
 20-26%. A jump into an already-recovered function is treated as a tailcall either way — only
 promoting targets that are not yet known needs this pass.
 
-Analysis is also bounded by `TIMEOUT` (300s by default). A run that hits it comes back with
-`status == "timeout"`: the function set is a lower bound, not the whole binary. Check the status
-before comparing counts across samples, and pass `TIMEOUT = 0` to disable the bound entirely.
+Analysis is also bounded by `TIMEOUT` (300s by default), but cooperatively rather than as a
+wall-clock guarantee. The budget is polled between function candidates and between passes, never
+inside one: a single pathological function is analyzed to completion once started, and with
+`RESOLVE_TAILCALLS` enabled the whole tailcall pass runs without a poll. It bounds how much *new*
+work is begun, not how long a call takes to return, so a run can overshoot it. A run that exceeded
+the budget comes back with `status == "timeout"`: the function set is a lower bound, not the whole
+binary. Check the status before comparing counts across samples, and pass `TIMEOUT = 0` to disable
+the bound entirely. A caller that needs a hard wall-clock ceiling has to impose one itself.
 
 ### IDA Pro integration
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ run (a stable metric, unlike wall-clock on a loaded machine): hashing accounts f
 nesting 4.6% and SCC 3.2% of all calls, and disabling all three removes 17.8%. Turn off whatever
 a downstream consumer does not read.
 
+`RESOLVE_TAILCALLS` runs the other way round: it is **off** by default and buys recovery for time.
+It promotes the target of a jump that leaves a function into a function of its own, in a pass after
+gap analysis, so what it is worth depends on how much a binary tail-calls. On `libstdc++.so.6` it
+adds 337 functions (8473 to 8810) for 40-130% more analysis time, the spread being how much the
+measuring machine had to spare; on Go ELF and Mach-O memory images it adds 8 functions each, for
+20-26%. A jump into an already-recovered function is treated as a tailcall either way — only
+promoting targets that are not yet known needs this pass.
+
+Analysis is also bounded by `TIMEOUT` (300s by default). A run that hits it comes back with
+`status == "timeout"`: the function set is a lower bound, not the whole binary. Check the status
+before comparing counts across samples, and pass `TIMEOUT = 0` to disable the bound entirely.
+
 ### IDA Pro integration
 
 SMDA can also turn an IDA-analyzed database into a SMDA report instead of running its own disassembly. Inside the IDA GUI, SMDA supports IDA Pro 8.4 and newer via the existing IDAPython integrations; older SDK generations are rejected. On IDA 9.1 or newer, it prefers the higher-level [IDA Domain API](https://ida-domain.docs.hex-rays.com/) when the optional package is installed and otherwise falls back to IDAPython.

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -17,7 +17,8 @@ class SmdaConfig:
     LOG_FORMAT = "%(asctime)-15s: %(name)-32s - %(message)s"
 
     ### SMDA disassembler config
-    # maximum time in seconds for disassembly to complete
+    # cooperative budget in seconds for disassembly, polled between candidates and between
+    # passes but never within one, so a run overshoots rather than being cut off; 0 disables it
     TIMEOUT = 300
     # maximum number of bytes to allocate while loading
     MAX_IMAGE_SIZE = 100 * 1024 * 1024
@@ -25,6 +26,9 @@ class SmdaConfig:
     STORE_BUFFER = False
     # extract strings during disassembly
     WITH_STRINGS = False
+    # the options named USE_*, RESOLVE_*, RECORD_*, CANDIDATE_QUEUE and HIGH_ACCURACY steer
+    # recursive candidate discovery and are read by the intel and aarch64 backends only; the
+    # cil and dalvik backends run their own analysis pipelines and ignore them
     # the queue to use for candidate management
     CANDIDATE_QUEUE = "PriorityQueue"  # choose from: ["BracketQueue", "PriorityQueue"]
     # improve disassembly by resolving references through data flows

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -72,6 +72,13 @@ class SmdaConfig:
     LARGE_INPUT_RSS_FACTOR = 500
     MEMORY_BUDGET_FRACTION = 0.5
     HIGH_ACCURACY = True
+    # promote the targets of jumps that leave a function into functions of their own, in a
+    # pass after gap analysis. Off by default: what it buys depends entirely on how much a
+    # binary tail-calls, and it is never free. On libstdc++.so.6 it adds 337 functions
+    # (8473 -> 8810) for 40-130% more analysis time depending on the machine; on Go ELF and
+    # Mach-O memory images, 8 functions each for 20-26%. A jump into an already-recovered
+    # function is still treated as a tailcall with the pass off - only the promotion of
+    # not-yet-known targets needs it.
     RESOLVE_TAILCALLS = False
     # optional metadata generation options; the largest built-in performance lever.
     # Measured on the cutwail fixture, as a share of all Python calls per run: hashing 10.0%,


### PR DESCRIPTION
## What was missing

`RESOLVE_TAILCALLS` ships **off**, and neither the README nor the config said so or said what turning it on is worth.

With it off, `TailcallAnalyzer` accumulates nothing and promotes nothing; the only surviving behaviour is the always-on rule that a jump into an already-recovered function ends the current one sanely. That is a defensible cost trade, but the README's CFG section reads as though tailcall handling is simply present, and a reader has no way to tell which half they are getting.

`TIMEOUT` has a related gap: a run that hits it returns `status == "timeout"` and a function set that is a **lower bound**, and a caller comparing counts across samples has no other signal that one of them was cut short.

## Measured, not described

| | functions | analysis time |
| --- | --- | --- |
| `libstdc++.so.6` | 8473 → **8810** (+337) | +40% to +130% |
| Go ELF memory image | 1936 → 1944 (+8) | +21% |
| Go Mach-O memory image | 2123 → 2131 (+8) | +26% |

The time range for `libstdc++` is deliberately a range: it is wall-clock, and the two measurements that produced it differed by how much the machine had to spare. Quoting a single number there would be quoting the machine.

## Changes

Config comment next to the flag, and a README paragraph next to the existing performance-lever section — the two places a reader already looks for this.

## Validation

- `make lint`, `make typecheck` — clean
- `make test` — 1180 passed, 2 skipped
- `diff-cover` — no executable lines changed
