### PR TITLE
fix(core): stop WITH_STRINGS from destroying a DEX report's string references

### DIFF
--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -128,9 +128,11 @@ class Disassembler:
                     for referencing_addr, string_value in sorted(smda_function.stringrefs.items())
                 ]
             if architecture == "dalvik":
-                # DEX strings are part of the parsed file structure, not the raw
-                # buffer bytes: the generic StringExtractor cannot see them either.
-                smda_function.stringrefs = analyzer_provided
+                # DEX strings are part of the parsed file structure, not the raw buffer
+                # bytes: the generic StringExtractor cannot see them either. SmdaFunction
+                # has already normalized them into the shape built above - this pass runs
+                # only when WITH_STRINGS is set, which is also what makes it normalize -
+                # so there is nothing left to convert and assigning here would discard it.
                 continue
             function_strings = analyzer_provided
             for string_result in extract_strings(smda_function, mode=mode):

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -128,11 +128,8 @@ class Disassembler:
                     for referencing_addr, string_value in sorted(smda_function.stringrefs.items())
                 ]
             if architecture == "dalvik":
-                # DEX strings are part of the parsed file structure, not the raw buffer
-                # bytes: the generic StringExtractor cannot see them either. SmdaFunction
-                # has already normalized them into the shape built above - this pass runs
-                # only when WITH_STRINGS is set, which is also what makes it normalize -
-                # so there is nothing left to convert and assigning here would discard it.
+                # DEX strings are part of the parsed file structure, not the raw
+                # buffer bytes: the generic StringExtractor cannot see them either.
                 continue
             function_strings = analyzer_provided
             for string_result in extract_strings(smda_function, mode=mode):

--- a/tests/testDalvikStringRefsWithStrings.py
+++ b/tests/testDalvikStringRefsWithStrings.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+"""DEX string references have to survive WITH_STRINGS being enabled.
+
+Dalvik string references are recovered from the parsed DEX structure rather than
+from buffer bytes, so they are populated whether or not WITH_STRINGS is set. That
+made enabling the option - whose entire purpose is more string data - the one way
+to lose all of it.
+"""
+
+import unittest
+from pathlib import Path
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+DEX_FIXTURE = Path(__file__).resolve().parent / "blockblast_classes_xored"
+
+
+def _load_dex():
+    raw = DEX_FIXTURE.read_bytes()
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(raw))
+
+
+def _disassemble(with_strings):
+    config = SmdaConfig()
+    config.WITH_STRINGS = with_strings
+    return Disassembler(config).disassembleUnmappedBuffer(_load_dex())
+
+
+class DalvikStringRefsWithStringsTestSuite(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.without = _disassemble(False)
+        cls.with_strings = _disassemble(True)
+
+    def _refs(self, report):
+        return {function.offset: function.stringrefs for function in report.getFunctions() if function.stringrefs}
+
+    def testStringRefsSurviveWithStringsEnabled(self):
+        without = self._refs(self.without)
+        # positive control: the comparison is only meaningful if the disabled run
+        # recovered references in the first place
+        self.assertGreater(len(without), 2000)
+        self.assertEqual(self._refs(self.with_strings), without)
+
+    def testEnablingWithStringsNeverReducesTheReferenceCount(self):
+        def total(report):
+            return sum(len(function.stringrefs) for function in report.getFunctions())
+
+        self.assertGreater(total(self.without), 2000)
+        self.assertGreaterEqual(total(self.with_strings), total(self.without))
+
+    def testReferencesKeepTheirNormalizedShapeUnderWithStrings(self):
+        function = next(f for f in self.with_strings.getFunctions() if f.stringrefs)
+        self.assertIsInstance(function.stringrefs, list)
+        entry = function.stringrefs[0]
+        self.assertEqual(set(entry), {"string", "ins_addr", "data_addr", "type"})
+        self.assertEqual(entry["type"], "dex")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testDalvikStringRefsWithStrings.py
+++ b/tests/testDalvikStringRefsWithStrings.py
@@ -39,8 +39,6 @@ class DalvikStringRefsWithStringsTestSuite(unittest.TestCase):
 
     def testStringRefsSurviveWithStringsEnabled(self):
         without = self._refs(self.without)
-        # positive control: the comparison is only meaningful if the disabled run
-        # recovered references in the first place
         self.assertGreater(len(without), 2000)
         self.assertEqual(self._refs(self.with_strings), without)
 


### PR DESCRIPTION
Setting `WITH_STRINGS` on a DEX buffer removes every string reference the report would otherwise carry. The switch whose entire purpose is to produce *more* string data is the only way to lose all of it.

On the bundled `blockblast_classes_xored` fixture:

| `WITH_STRINGS` | functions with `stringrefs` | total references |
| --- | --- | --- |
| `False` | 2191 | 2193 |
| `True` (before) | **0** | **0** |
| `True` (after) | 2191 | 2193 |

## Why

Dalvik string references come from the parsed DEX structure, not from buffer bytes, so `SmdaFunction.__init__` records them whether or not `WITH_STRINGS` is set — and normalizes them into the report's list shape (`_normalizeDalvikStringRefs`) as it does.

`Disassembler._extractStrings` then ran afterwards to convert "the raw `{ref_addr: string}` dict the backends record" into that same shape. For Dalvik the value was already a list, so:

```python
analyzer_provided = []
if isinstance(smda_function.stringrefs, dict):   # False - already a list
    analyzer_provided = [...]
if architecture == "dalvik":
    smda_function.stringrefs = analyzer_provided  # assigns []
    continue
```

The guard never matched, so the conversion produced an empty list, and the branch assigned it over the real data.

## The fix

The conversion cannot apply to Dalvik at all. This pass runs only when `WITH_STRINGS` is set, and that is the same condition that makes `SmdaFunction` normalize — so by the time `_extractStrings` sees a Dalvik function, its references are always already in the target shape. The assignment is dropped; the `continue` stays.

`_normalizeDalvikStringRefs` was already written the right way: it returns a list unchanged and converts only a dict, so running it twice is harmless. The bug was a second pass that was not idempotent.

## Scope

Only Dalvik is normalized at construction. Every other backend keeps its references as the raw dict, reaches `_extractStrings` in the shape it expects, and is unaffected. Measured across all four:

| fixture | architecture | analyzer refs, option off → on |
| --- | --- | --- |
| `njrat_xored` | cil | 0 → 479 |
| `aarch64_static_xored` | aarch64 | 0 → 0 (no stack-built strings in this sample) |
| `blockblast_classes_xored` | dalvik | 2193 → 2193 |
| `cutwail_xored` | intel | 0 → 11 generic |

`stringrefs` is also the only field `Disassembler` writes back onto a function after analysis, and the other write site is the non-Dalvik path where the value genuinely is still a dict. Every remaining `isinstance(x, dict|list)` in `src/smda/**` is `fromDict` boundary validation of untrusted input, which is a different thing. No siblings.

## Tests

`tests/testDalvikStringRefsWithStrings.py` — three cases, all failing on the unfixed tree:

- the reference sets recovered with the option off and on must be equal, with a positive control asserting the disabled run found more than 2000 to begin with, so it cannot pass vacuously;
- enabling the option must never reduce the total reference count;
- the entries keep their normalized shape (`string` / `ins_addr` / `data_addr` / `type`, `type == "dex"`).

## How it surfaced

Two Dalvik tests failed only when run *after* `tests/testIntegration.py`, which sets `WITH_STRINGS` on a shared module-level config object. That reads as ordinary cross-test state bleed, but it was this bug being triggered — `testDalvikDisassembler.py` passes alone (65) and after `testAArch64Disassembler.py` (152), and fails only in that pairing. The full suite never showed it because alphabetical collection puts the Dalvik file before the integration file. With this fix, that pairing goes from 2 failed to 80 passed.

## Validation

- full suite: 1183 passed, 2 skipped, exit 0
- `ruff check .`, `ruff format --check .`, type check: clean, no new diagnostics
- `diff-cover --fail-under=100`: clean
