### PR TITLE
fix: bump escaper downward-compatibility marker to 4.4.5

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -5,7 +5,12 @@ import os
 class SmdaConfig:
     # keep this in sync with smda.__version__
     VERSION = "4.4.7"
-    ESCAPER_DOWNWARD_COMPATIBILITY = "1.13.16"
+    # Bump this whenever any architecture's InstructionEscaper changes its
+    # output (mnemonic groups or escaped operands). Downstream indexes such as
+    # MCRIT treat reports whose smda_version is below this value as stale.
+    # Last output change: 4.4.5 (segment-qualified memory operands, AVX-512
+    # registers, six mnemonic groups).
+    ESCAPER_DOWNWARD_COMPATIBILITY = "4.4.5"
     CONFIG_FILE_PATH = str(os.path.abspath(__file__))
     PROJECT_ROOT = str(os.path.abspath(os.sep.join([CONFIG_FILE_PATH, "..", "..", ".."])))
 

--- a/tests/testEscaperFingerprint.py
+++ b/tests/testEscaperFingerprint.py
@@ -1,0 +1,106 @@
+"""Regression fingerprint for escaper output.
+
+MCRIT (and anything else that persists escaped-operand signatures) consults
+SmdaConfig.ESCAPER_DOWNWARD_COMPATIBILITY to decide whether stored hashes are
+stale. That marker did not move when 4.4.5 changed Intel escaping, so this
+test hashes a committed corpus of escaped representations. If the digest
+moves, bump ESCAPER_DOWNWARD_COMPATIBILITY to the current SmdaConfig.VERSION
+in the same change.
+"""
+
+import hashlib
+import logging
+import unittest
+
+logging.disable(logging.CRITICAL)
+
+from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper  # noqa: E402
+from smda.cil.CilInstructionEscaper import CilInstructionEscaper  # noqa: E402
+from smda.common.SmdaInstruction import SmdaInstruction  # noqa: E402
+from smda.dalvik.DalvikInstructionEscaper import DalvikInstructionEscaper  # noqa: E402
+from smda.intel.IntelInstructionEscaper import IntelInstructionEscaper  # noqa: E402
+
+# SHA-256 of the canonical escaped lines below. Update together with the
+# compatibility marker when any InstructionEscaper changes its output.
+ESCAPER_OUTPUT_FINGERPRINT = "3a0a318f568d282734a8879898d564b91914b25105f122c05f4efd657fca4233"
+
+# (escaper, offset, bytes, mnemonic, operands) — bytes are unused; the
+# fingerprint is mnemonic-group + escaped operands, the same pair MCRIT's
+# EscapedBlockShingler indexes.
+_CORPUS = [
+    (IntelInstructionEscaper, (0, "", "nop", "")),
+    (IntelInstructionEscaper, (0, "", "ret", "")),
+    (IntelInstructionEscaper, (0, "", "push", "rbp")),
+    (IntelInstructionEscaper, (0, "", "mov", "rax, qword ptr gs:[0x60]")),
+    (IntelInstructionEscaper, (0, "", "mov", "eax, dword ptr es:[edi]")),
+    (IntelInstructionEscaper, (0, "", "mov", "al, byte ptr es:[edi]")),
+    (IntelInstructionEscaper, (0, "", "mov", "eax, dword ptr fs:[0]")),
+    (IntelInstructionEscaper, (0, "", "mov", "rax, qword ptr gs:[0x28]")),
+    (IntelInstructionEscaper, (0, "", "ljmp", "0x33:0x401000")),
+    (IntelInstructionEscaper, (0, "", "movsq", "qword ptr es:[rdi], qword ptr ds:[rsi]")),
+    (IntelInstructionEscaper, (0, "", "cmpsq", "qword ptr ds:[rsi], qword ptr es:[rdi]")),
+    (IntelInstructionEscaper, (0, "", "popaw", "")),
+    (IntelInstructionEscaper, (0, "", "pushaw", "")),
+    (IntelInstructionEscaper, (0, "", "xgetbv", "")),
+    (IntelInstructionEscaper, (0, "", "rorx", "eax, edx, 0x4")),
+    (IntelInstructionEscaper, (0, "", "kmovq", "k0, rax")),
+    (IntelInstructionEscaper, (0, "", "kmovq", "k7, rax")),
+    (IntelInstructionEscaper, (0, "", "vmovdqa32", "zmm0 {k1}, zmmword ptr [rax]")),
+    (IntelInstructionEscaper, (0, "", "vmovdqa32", "zmm0 {k1} {z}, zmm1")),
+    (IntelInstructionEscaper, (0, "", "vpaddd", "zmm0, zmm1, dword ptr [rax]{1to16}")),
+    (IntelInstructionEscaper, (0, "", "vmovdqa", "xmm20, xmm0")),
+    (IntelInstructionEscaper, (0, "", "vmovdqa", "ymm18, ymm0")),
+    (AArch64InstructionEscaper, (0, "", "ret", "")),
+    (AArch64InstructionEscaper, (0, "", "stp", "x29, x30, [sp, #-0x10]!")),
+    (AArch64InstructionEscaper, (0, "", "ldr", "x0, [x1, #0x10]")),
+    (AArch64InstructionEscaper, (0, "", "bl", "#0x400800")),
+    (AArch64InstructionEscaper, (0, "", "cbz", "w0, #0x14")),
+    (CilInstructionEscaper, (0, "", "ldarg.0", "")),
+    (CilInstructionEscaper, (0, "", "call", "0x06000001")),
+    (CilInstructionEscaper, (0, "", "ldstr", "0x70000001")),
+    (CilInstructionEscaper, (0, "", "br.s", "0x0a")),
+    (CilInstructionEscaper, (0, "", "throw", "")),
+    (DalvikInstructionEscaper, (0, "", "return-void", "")),
+    (DalvikInstructionEscaper, (0, "", "invoke-virtual", "{v0, v1}, Lfoo;->m()V")),
+    (DalvikInstructionEscaper, (0, "", "const-string", 'v0, "hello"')),
+    (DalvikInstructionEscaper, (0, "", "goto", "+0xa")),
+    (DalvikInstructionEscaper, (0, "", "add-int", "v0, v1, v2")),
+]
+
+
+def _escaped_line(escaper, ins_tuple):
+    instruction = SmdaInstruction(ins_tuple)
+    return f"{escaper.__name__}|{instruction.getMnemonicGroup(escaper)}|{instruction.getEscapedOperands(escaper)}\n"
+
+
+def _fingerprint():
+    digest = hashlib.sha256()
+    for escaper, ins_tuple in _CORPUS:
+        digest.update(_escaped_line(escaper, ins_tuple).encode("ascii"))
+    return digest.hexdigest()
+
+
+class EscaperFingerprintTestSuite(unittest.TestCase):
+    def test_escaped_representation_fingerprint_is_stable(self):
+        actual = _fingerprint()
+        self.assertEqual(
+            actual,
+            ESCAPER_OUTPUT_FINGERPRINT,
+            "escaper output changed; bump SmdaConfig.ESCAPER_DOWNWARD_COMPATIBILITY "
+            f"to the current package version and set ESCAPER_OUTPUT_FINGERPRINT to {actual}",
+        )
+
+    def test_the_4_4_5_intel_cases_in_the_corpus_escape_as_ptr_not_const(self):
+        for operands in (
+            "qword ptr gs:[0x60]",
+            "dword ptr es:[edi]",
+            "byte ptr es:[edi]",
+            "dword ptr fs:[0]",
+            "qword ptr gs:[0x28]",
+        ):
+            with self.subTest(operands=operands):
+                self.assertEqual(IntelInstructionEscaper.escapeField(operands), "PTR")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testPackageMetadata.py
+++ b/tests/testPackageMetadata.py
@@ -19,12 +19,38 @@ from smda.SmdaConfig import SmdaConfig  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
+def _version_tuple(version):
+    return tuple(int(part) for part in version.split("."))
+
+
 class TestPackageMetadata(unittest.TestCase):
     def test_the_two_version_strings_agree(self):
         self.assertEqual(smda.__version__, SmdaConfig.VERSION)
 
     def test_the_version_is_a_three_part_release(self):
         self.assertRegex(smda.__version__, r"^\d+\.\d+\.\d+$")
+
+    def test_the_escaper_compatibility_marker_is_a_three_part_release(self):
+        self.assertRegex(SmdaConfig.ESCAPER_DOWNWARD_COMPATIBILITY, r"^\d+\.\d+\.\d+$")
+
+    def test_the_escaper_compatibility_marker_is_not_newer_than_the_package(self):
+        self.assertLessEqual(
+            _version_tuple(SmdaConfig.ESCAPER_DOWNWARD_COMPATIBILITY),
+            _version_tuple(SmdaConfig.VERSION),
+        )
+
+    def test_the_escaper_compatibility_marker_covers_the_4_4_5_output_change(self):
+        # 4.4.5 changed Intel escaped operands (segment-qualified memory, AVX-512)
+        # and six mnemonic groups. MCRIT selects samples whose recorded
+        # smda_version is strictly below this marker, so the marker must be at
+        # least 4.4.5 or those reports stay invisible to the repair path.
+        marker = _version_tuple(SmdaConfig.ESCAPER_DOWNWARD_COMPATIBILITY)
+        self.assertLessEqual(_version_tuple("4.4.5"), marker)
+        self.assertLess(_version_tuple("4.4.4"), marker)
+        # The previous marker, 1.13.16, compared less than every 2.x/4.x report
+        # and so selected nothing after 1.13.16 — including the 4.4.4 reports
+        # whose escaped output 4.4.5 invalidated.
+        self.assertFalse(_version_tuple("4.4.4") < _version_tuple("1.13.16"))
 
     def test_the_changelog_documents_the_current_version(self):
         changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes https://github.com/danielplohmann/smda/issues/277.

## What's going on

The 4.4.5 Intel escaper fix is correct. We just never told anyone it happened.

`ESCAPER_DOWNWARD_COMPATIBILITY` has been sitting at `1.13.16` since forever. Downstream (MCRIT, anything that stores escaped-operand signatures) uses that marker to answer "is my stored hash still valid?" Because it never moved, they look at a 4.4.4 report, compare it to `1.13.16`, shrug, and keep the stale hash.

## I actually reproduced this

Unpacked the PyPI wheels for 4.4.4 vs 4.4.5 vs current HEAD. Same instruction text, different escaped output. MCRIT's `EscapedBlockShingler` indexes `mnemonic-group + escaped operands`, so this is exactly what goes into minhashes:

| thing | 4.4.4 | 4.4.5 / HEAD |
|---|---|---|
| `qword ptr gs:[0x60]` | `CONST` | `PTR` |
| `dword ptr es:[edi]` | `CONST` | `PTR` |
| `dword ptr fs:[0]` | `CONST` | `PTR` |
| `k0` / `xmm20` | leaked the raw name | `XREG` |
| `movsq` / `cmpsq` / `rorx` | group `X` | `M` / `C` / `A` |
| shingle for `mov rax, qword ptr gs:[0x60]` | `M REG, CONST` | `M REG, PTR` |

The marker is `1.13.16` in 4.4.4, 4.4.5, **and** 4.4.7. `4.4.4 < 1.13.16` is false, so the repair path never fires.

Why 4.4.5 flipped those operands: the far-pointer test (`":" in operand`) ran *after* the pointer test and stomped `PTR` into `CONST` for every `es:[edi]` / `gs:[0x60]` form. That fix stays. We are not reverting it.

## MCRIT (cloned it)

`MongoDbStorage.recalculateAllPicHashes()` keeps samples whose `smda_version` is **below** this marker. That's the whole point of the constant.

Two extra notes so nobody goes down a rabbit hole:

- Minhashes (the "19.5% no longer match / some functions vanish from all 20 LSH bands" bit) have **no** selective rebuild. That's MCRIT's problem, filed over there.
- Pic-hashes use `escapeBinary`, which this classification change does **not** touch. I did **not** bump `INTEL_PIC_HASH_ESCAPE_VERSION` (still `4.3.5`) — that would just rewrite pic-hashes to the same value.

## What this PR does

1. Set `ESCAPER_DOWNWARD_COMPATIBILITY` to `"4.4.5"`.
2. Comment on the constant: if escaper *output* changes, bump this. That's the trigger. Don't wait for a "breaking" feeling.
3. A small CI fingerprint over mnemonic-group + escaped operands (the 4.4.5 Intel cases plus a couple AArch64/CIL/Dalvik rows). If that digest moves, that's your cue to bump the marker in the same commit.

No package version bump. Next release should mention this so installed copies actually ship the new marker — 4.4.7 on PyPI still says `1.13.16`.

## Reviewer checklist

- One-line behavior change: marker `1.13.16` → `4.4.5`.
- Escaper code itself is untouched.
- Tests: `tests/testEscaperFingerprint.py` + a few assertions in `tests/testPackageMetadata.py`.
- Safe to merge as-is. After merge, a 4.4.8 (or whatever) release is what makes MCRIT notice.

