### PR TITLE
fix(intel): recover switch dispatches that carry a notrack prefix

### DIFF
--- a/.github/workflows/scripts/evaluate_runtime.py
+++ b/.github/workflows/scripts/evaluate_runtime.py
@@ -40,7 +40,7 @@ BASE_PATH = Path(__file__).resolve().parent.parent.parent.parent
 RUNTIME_PATH = BASE_PATH / "runtime_measurements"
 CACHE_PATH = RUNTIME_PATH / "cache"
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 def compute_file_hash(filepath):
@@ -249,6 +249,38 @@ def check_determinism(aggregated):
 # --------------------------------------------------------------------------- #
 
 _RETURN_MNEMONICS = frozenset({"ret", "retn", "retf", "retfq", "iret", "iretd", "iretq", "retaa", "retab"})
+_LANDING_PAD_MNEMONICS = frozenset({"endbr32", "endbr64"})
+_FRAME_SETUP = {"rbp": "rbp, rsp", "ebp": "ebp, esp"}
+
+
+def _is_register(operand):
+    """A bare register name, as opposed to an immediate or a memory operand.
+
+    Capstone prints an immediate below 10 without its `0x`, so a leading digit has to be
+    rejected explicitly rather than by looking for the prefix.
+    """
+    return bool(operand) and operand.isalnum() and not operand[0].isdigit()
+
+
+def _starts_like_a_function(instructions):
+    """Whether the first instructions read as a function entry rather than as padding.
+
+    Three shapes cover what compilers emit: a CET landing pad, the frame-pointer pair, and
+    the run of callee-saved pushes a register-convention entry opens with. Padding decoded
+    from the wrong offset reaches a branch or an immediate operand within an instruction or
+    two, which is what separates it from these.
+    """
+    head = [(m.split(" ")[-1], o.strip()) for _, m, o in instructions[:2]]
+    if not head:
+        return False
+    if head[0][0] in _LANDING_PAD_MNEMONICS:
+        return True
+    if len(head) < 2 or head[0][0] != "push" or not _is_register(head[0][1]):
+        return False
+    if head[1][0] == "push" and _is_register(head[1][1]):
+        return True
+    return head[1][0] == "mov" and head[1][1] == _FRAME_SETUP.get(head[0][1])
+
 
 CLASSIFICATION_NOTE = (
     "The corpus carries no labelled function boundaries, so this gate can only see THAT the "
@@ -297,10 +329,10 @@ def describe_changed_address(addr, xcfg, other_owner, other_sorted):
         func = next((f for k, f in xcfg.items() if _parse_address(k) == addr), None)
     if func is None:
         return None
-    instructions = sorted((i[0], i[2]) for block in func.get("blocks", {}).values() for i in block)
+    instructions = sorted((i[0], i[2], i[3]) for block in func.get("blocks", {}).values() for i in block)
     if not instructions:
         return None
-    own_addresses = {a for a, _ in instructions}
+    own_addresses = {a for a, _, _ in instructions}
     low, high = instructions[0][0], instructions[-1][0]
     targets = {t for ts in (func.get("outrefs") or {}).values() for t in ts}
     targets |= {t for ts in (func.get("blockrefs") or {}).values() for t in ts}
@@ -310,6 +342,7 @@ def describe_changed_address(addr, xcfg, other_owner, other_sorted):
         "inrefs": len(func.get("inrefs") or []),
         "instructions": len(instructions),
         "ends_in_return": instructions[-1][1].split(" ")[-1] in _RETURN_MNEMONICS,
+        "starts_like_a_function": _starts_like_a_function(instructions),
         "absorbed_by": other_owner.get(addr),
         "branches_into_survivor_interior": sum(1 for t in targets if t in other_owner and other_owner[t] != t),
         "misaligned_overlap": sum(1 for a in window if a not in own_addresses),
@@ -328,13 +361,18 @@ def label_changed_address(signals, dropped):
        than a `ret`;
     3. its body reads like a whole routine - it ends in a return, and the other side does not
        decode different instructions inside its extent;
-    4. otherwise it reads like padding decoded from the wrong offset.
+    4. it opens the way a compiler opens a function, which is the one reading that survives a
+       body the other side decodes at different offsets - an entry reached only indirectly can
+       have no inbound reference and can end in a tail-call, but it still starts like an entry;
+    5. otherwise it reads like padding decoded from the wrong offset.
     """
     if signals["absorbed_by"] is not None:
         return "absorbed" if dropped else "split_out"
     if signals["inrefs"] > 0:
         return "likely_loss" if dropped else "likely_recovery"
     if signals["ends_in_return"] and signals["misaligned_overlap"] == 0:
+        return "likely_loss" if dropped else "likely_recovery"
+    if signals["starts_like_a_function"]:
         return "likely_loss" if dropped else "likely_recovery"
     return "likely_false_positive" if dropped else "likely_new_false_positive"
 

--- a/.github/workflows/scripts/evaluate_runtime.py
+++ b/.github/workflows/scripts/evaluate_runtime.py
@@ -23,6 +23,7 @@ All statistics are pure-Python (``statistics`` + ``random``); no third-party dep
 """
 
 import argparse
+import bisect
 import hashlib
 import json
 import math
@@ -31,6 +32,7 @@ import random
 import re
 import statistics
 import sys
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
@@ -38,7 +40,7 @@ BASE_PATH = Path(__file__).resolve().parent.parent.parent.parent
 RUNTIME_PATH = BASE_PATH / "runtime_measurements"
 CACHE_PATH = RUNTIME_PATH / "cache"
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 def compute_file_hash(filepath):
@@ -240,6 +242,144 @@ def check_determinism(aggregated):
         "files_disagreeing": disagreeing,
         "median_timing_cv": statistics.median(cvs) if cvs else 0.0,
     }
+
+
+# --------------------------------------------------------------------------- #
+# Changed-address classification
+# --------------------------------------------------------------------------- #
+
+_RETURN_MNEMONICS = frozenset({"ret", "retn", "retf", "retfq", "iret", "iretd", "iretq", "retaa", "retab"})
+
+CLASSIFICATION_NOTE = (
+    "The corpus carries no labelled function boundaries, so this gate can only see THAT the "
+    "function set changed. These labels read structure out of the two reports the run already "
+    "produced, to say which direction each change points. They are evidence for a human, not a "
+    "verdict: `likely_false_positive` means the dropped address decodes like padding read at the "
+    "wrong offset, and `likely_loss` means it decodes like a real function."
+)
+
+
+def _parse_address(raw):
+    """Addresses reach us as strings, decimal in a real report and hex in some fixtures."""
+    if isinstance(raw, int):
+        return raw
+    text = str(raw).strip()
+    try:
+        return int(text, 16) if text.lower().startswith("0x") else int(text)
+    except ValueError:
+        return None
+
+
+def _index_report(path):
+    """Return ``(xcfg, owner, sorted_addresses)`` for one .smda report.
+
+    ``owner`` maps every decoded instruction address to the function that owns it, which is what
+    lets the other side answer "is this address still code, and whose?".
+    """
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    xcfg = data.get("xcfg", {})
+    owner = {}
+    for start, func in xcfg.items():
+        start_int = _parse_address(start)
+        if start_int is None:
+            continue
+        for instructions in func.get("blocks", {}).values():
+            for instruction in instructions:
+                owner[instruction[0]] = start_int
+    return xcfg, owner, sorted(owner)
+
+
+def describe_changed_address(addr, xcfg, other_owner, other_sorted):
+    """Structural signals for one function that exists on this side and not on the other."""
+    func = xcfg.get(str(addr))
+    if func is None:
+        func = next((f for k, f in xcfg.items() if _parse_address(k) == addr), None)
+    if func is None:
+        return None
+    instructions = sorted((i[0], i[2]) for block in func.get("blocks", {}).values() for i in block)
+    if not instructions:
+        return None
+    own_addresses = {a for a, _ in instructions}
+    low, high = instructions[0][0], instructions[-1][0]
+    targets = {t for ts in (func.get("outrefs") or {}).values() for t in ts}
+    targets |= {t for ts in (func.get("blockrefs") or {}).values() for t in ts}
+    window = other_sorted[bisect.bisect_left(other_sorted, low) : bisect.bisect_right(other_sorted, high)]
+    return {
+        "addr": addr,
+        "inrefs": len(func.get("inrefs") or []),
+        "instructions": len(instructions),
+        "ends_in_return": instructions[-1][1].split(" ")[-1] in _RETURN_MNEMONICS,
+        "absorbed_by": other_owner.get(addr),
+        "branches_into_survivor_interior": sum(1 for t in targets if t in other_owner and other_owner[t] != t),
+        "misaligned_overlap": sum(1 for a in window if a not in own_addresses),
+    }
+
+
+def label_changed_address(signals, dropped):
+    """Turn the structural signals into one label.
+
+    The rules are ordered, and the order is the whole design:
+
+    1. the address is still decoded on the other side, inside some other function - the boundary
+       moved rather than the function vanishing;
+    2. something references it - a called address is a function whatever its body looks like, and
+       this is the rule that catches a real function whose body ends in a tail-call `jmp` rather
+       than a `ret`;
+    3. its body reads like a whole routine - it ends in a return, and the other side does not
+       decode different instructions inside its extent;
+    4. otherwise it reads like padding decoded from the wrong offset.
+    """
+    if signals["absorbed_by"] is not None:
+        return "absorbed" if dropped else "split_out"
+    if signals["inrefs"] > 0:
+        return "likely_loss" if dropped else "likely_recovery"
+    if signals["ends_in_return"] and signals["misaligned_overlap"] == 0:
+        return "likely_loss" if dropped else "likely_recovery"
+    return "likely_false_positive" if dropped else "likely_new_false_positive"
+
+
+def classify_regressions(regressions, base_folder, pr_folder):
+    """Label every changed address in every differing file.
+
+    Only the files that actually differ are re-read, and only one run per side, so the cost is
+    bounded by the size of the difference rather than by the size of the corpus.
+    """
+    counts = Counter()
+    files = []
+    for entry in regressions:
+        base_path = Path(base_folder) / entry["file"]
+        pr_path = Path(pr_folder) / entry["file"]
+        if not (base_path.exists() and pr_path.exists()):
+            continue
+        try:
+            base_xcfg, base_owner, base_sorted = _index_report(base_path)
+            pr_xcfg, pr_owner, pr_sorted = _index_report(pr_path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            # This section is evidence, never a gate, so an unreadable report costs the reading
+            # and nothing else - failing the job over it would be strictly worse than the silence
+            # this replaces.
+            print(f"classification: skipping {entry['file']}: {exc}")
+            continue
+        rows = []
+        for side, raws, source, owner, ordered, dropped in (
+            ("only_in_base", entry.get("only_in_base", []), base_xcfg, pr_owner, pr_sorted, True),
+            ("only_in_pr", entry.get("only_in_pr", []), pr_xcfg, base_owner, base_sorted, False),
+        ):
+            for raw in raws:
+                addr = _parse_address(raw)
+                if addr is None:
+                    continue
+                signals = describe_changed_address(addr, source, owner, ordered)
+                if signals is None:
+                    continue
+                signals["side"] = side
+                signals["label"] = label_changed_address(signals, dropped=dropped)
+                counts[signals["label"]] += 1
+                rows.append(signals)
+        if rows:
+            files.append({"file": entry["file"], "addresses": rows})
+    return {"counts": dict(counts), "files": files, "note": CLASSIFICATION_NOTE}
 
 
 def build_paired(base_agg, pr_agg):
@@ -527,6 +667,62 @@ def _fmt_p(wilcoxon):
     return f"{p:.4f} (n={wilcoxon.get('n_nonzero', 0)})"
 
 
+_LABEL_HEADINGS = (
+    (
+        "likely_false_positive",
+        "Likely false positives removed",
+        "an address that decodes like padding read at the wrong offset",
+    ),
+    (
+        "likely_loss",
+        "Likely real functions lost",
+        "an address that decodes like a whole routine, or that something references",
+    ),
+    ("absorbed", "Absorbed into a neighbour", "still decoded, now inside another function - a boundary moved"),
+    ("split_out", "Split out of a neighbour", "new on the PR side, and the base side had it inside another function"),
+    ("likely_recovery", "Likely real functions recovered", "new on the PR side and it reads like a whole routine"),
+    ("likely_new_false_positive", "Likely new false positives", "new on the PR side and it reads like padding"),
+)
+
+
+def _classification_lines(classification):
+    """Markdown for the changed-address classification (informational, never gating)."""
+    counts = classification.get("counts") or {}
+    if not counts:
+        return []
+    lines = ["#### 🔍 What the changed addresses look like (informational — not gated)", ""]
+    lines.append(f"> {classification.get('note', '')}")
+    lines.append("")
+    lines.append("| Reading | Count | What it means |")
+    lines.append("| --- | --- | --- |")
+    for key, heading, meaning in _LABEL_HEADINGS:
+        if counts.get(key):
+            lines.append(f"| {heading} | **{counts[key]}** | {meaning} |")
+    lines.append("")
+    loss_rows = [
+        (entry["file"], row)
+        for entry in classification.get("files", [])
+        for row in entry["addresses"]
+        if row["label"] == "likely_loss"
+    ]
+    if loss_rows:
+        lines.append(f"<details>\n<summary>{len(loss_rows)} address(es) read as a lost function</summary>")
+        lines.append("")
+        lines.append("| File | Address | Inbound refs | Instructions | Ends in return |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for filename, row in loss_rows[:50]:
+            lines.append(
+                f"| `{filename}` | `0x{row['addr']:x}` | {row['inrefs']} | {row['instructions']} | "
+                f"{'yes' if row['ends_in_return'] else 'no'} |"
+            )
+        if len(loss_rows) > 50:
+            lines.append(f"| ... and {len(loss_rows) - 50} more | | | | |")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+    return lines
+
+
 def generate_markdown_report(model, output_path):
     """Render the PR-comment Markdown. Tables are kept contiguous; long lists go
     into collapsible <details> blocks."""
@@ -646,6 +842,7 @@ def generate_markdown_report(model, output_path):
         lines.append("")
         lines.append("</details>")
         lines.append("")
+        lines.extend(_classification_lines(corr.get("classification") or {}))
 
     if block_drift:
         lines.append("#### ℹ️ Block-count Drift (informational — not gated)")
@@ -836,6 +1033,11 @@ def evaluate(runtime_path):
     pr_det = check_determinism(pr_agg)
 
     paired = build_paired(base_agg, pr_agg)
+    # Read the direction of each changed address out of the reports the run already produced.
+    # Informational: it does not touch the gate, which still fails on any function-set difference.
+    classification = classify_regressions(
+        paired["regressions"], run_folders[base_folders[0]], run_folders[pr_folders[0]]
+    )
     # Cross-runner/run-to-run noise band: base and PR are timed on separate CI
     # runners, so treat a median speedup within the per-side timing CV as noise.
     noise_floor_pct = max(base_det["median_timing_cv"], pr_det["median_timing_cv"]) * 100.0
@@ -853,6 +1055,7 @@ def evaluate(runtime_path):
             "regressions": paired["regressions"],
             "only_in_base": paired["only_in_base"],
             "only_in_pr": paired["only_in_pr"],
+            "classification": classification,
         },
         "performance": {
             "base_summary": side_summary(base_agg),

--- a/.github/workflows/scripts/evaluate_runtime.py
+++ b/.github/workflows/scripts/evaluate_runtime.py
@@ -248,7 +248,7 @@ def check_determinism(aggregated):
 # Changed-address classification
 # --------------------------------------------------------------------------- #
 
-_RETURN_MNEMONICS = frozenset({"ret", "retn", "retf", "retfq", "iret", "iretd", "iretq", "retaa", "retab"})
+_ROUTINE_RETURN_MNEMONICS = frozenset({"ret", "retn", "retaa", "retab"})
 _LANDING_PAD_MNEMONICS = frozenset({"endbr32", "endbr64"})
 _FRAME_SETUP = {"rbp": "rbp, rsp", "ebp": "ebp, esp"}
 
@@ -341,7 +341,7 @@ def describe_changed_address(addr, xcfg, other_owner, other_sorted):
         "addr": addr,
         "inrefs": len(func.get("inrefs") or []),
         "instructions": len(instructions),
-        "ends_in_return": instructions[-1][1].split(" ")[-1] in _RETURN_MNEMONICS,
+        "ends_in_return": instructions[-1][1].split(" ")[-1] in _ROUTINE_RETURN_MNEMONICS,
         "starts_like_a_function": _starts_like_a_function(instructions),
         "absorbed_by": other_owner.get(addr),
         "branches_into_survivor_interior": sum(1 for t in targets if t in other_owner and other_owner[t] != t),
@@ -359,8 +359,9 @@ def label_changed_address(signals, dropped):
     2. something references it - a called address is a function whatever its body looks like, and
        this is the rule that catches a real function whose body ends in a tail-call `jmp` rather
        than a `ret`;
-    3. its body reads like a whole routine - it ends in a return, and the other side does not
-       decode different instructions inside its extent;
+    3. its body reads like a whole routine - it ends in the near return a compiled routine
+       returns to its caller with, and the other side does not decode different instructions
+       inside its extent;
     4. it opens the way a compiler opens a function, which is the one reading that survives a
        body the other side decodes at different offsets - an entry reached only indirectly can
        have no inbound reference and can end in a tail-call, but it still starts like an entry;

--- a/.github/workflows/scripts/process_malpedia.py
+++ b/.github/workflows/scripts/process_malpedia.py
@@ -52,6 +52,35 @@ def check_bitness(content):
     return bitness
 
 
+ELF_MAGIC = b"\x7fELF"
+# EM_386 and EM_X86_64 - the two ELF machine types SMDA's intel backend reads. The sample's own
+# header is asked rather than its path: a family folder only spells the architecture out when
+# malpedia happened to name it that way, so a path test silently drops every x86-64 ELF whose
+# folder does not (elf.akira, for one).
+SUPPORTED_ELF_MACHINES = frozenset({0x03, 0x3E})
+_ELF_MACHINE_OFFSET = 0x12
+_ELF_HEADER_PREFIX = _ELF_MACHINE_OFFSET + 2
+
+
+def isIntelElf(content):
+    """Whether `content` starts an ELF header naming an instruction set SMDA can disassemble."""
+    if len(content) < _ELF_HEADER_PREFIX or content[:4] != ELF_MAGIC:
+        return False
+    # EI_DATA: 1 is little-endian, 2 is big-endian. A big-endian ELF is never x86, but the field
+    # decides how e_machine reads, so it is honoured rather than assumed.
+    byte_order = "<" if content[5] == 1 else ">"
+    machine = struct.unpack_from(byte_order + "H", content, _ELF_MACHINE_OFFSET)[0]
+    return machine in SUPPORTED_ELF_MACHINES
+
+
+def isIntelElfFile(filepath):
+    try:
+        with open(filepath, "rb") as handle:
+            return isIntelElf(handle.read(_ELF_HEADER_PREFIX))
+    except OSError:
+        return False
+
+
 class NativeCodeIdentifier:
     family_override = []
 
@@ -168,8 +197,8 @@ def work(input_element):
         disassembler = Disassembler()
         if (
             "elf." in INPUT_FILEPATH
-            and ("x86" in INPUT_FILEPATH or "x64" in INPUT_FILEPATH)
             and re.search(unpacked_file_pattern, input_element["filename"])
+            and isIntelElfFile(INPUT_FILEPATH)
         ):
             print(f"Analyzing file: {INPUT_FILEPATH}")
             try:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ There is also a demo script:
 
 * analyze.py -- example usage: perform disassembly on a file or memory dump and optionally store results in JSON to a given output path.
 
+#### Raw buffers and the instruction set
+
+`disassembleFile` reads the instruction set from the container header. `disassembleBuffer` has no
+header to read, so it guesses: DEX and AArch64 are recognized from the bytes, and anything else is
+analysed as x86. A buffer holding ARM32, MIPS, PowerPC, SPARC, SH4, m68k, Xtensa, NIOS2 or OpenRISC
+code is now recognized as well, and comes back as `status == "error"` naming the instruction set
+rather than as a report whose every block is wrong.
+
+The guess is evidence, not proof: it looks for a run of that architecture's function-return
+encoding, aligned, close enough together to be one code region, and not sitting inside text. Across
+60939 files of every type on one machine it named nothing that was not that architecture, and it
+recognized all ten bundled foreign samples. It is still a guess over bytes the caller supplies, and
+it is biased towards silence, so **pass `architecture=` whenever you know it** - an explicitly named
+architecture is never overruled.
+
 ### Batch mode
 
 Disassembly is CPU-bound and every input file is independent, so corpora are processed in parallel:
@@ -119,10 +134,14 @@ promoting targets that are not yet known needs this pass.
 
 Analysis is also bounded by `TIMEOUT` (300s by default), but cooperatively rather than as a
 wall-clock guarantee. The budget is polled between function candidates, between passes, every 256
-basic blocks within a single function, and between tailcall resolutions, so no one pass runs
-unbounded. It still bounds how much *new* work is begun rather than how long a call takes to
-return: whatever is already in flight — the block being decoded, the candidate being analyzed —
-finishes first, so a run overshoots by that much. A run that exceeded the budget comes back with
+basic blocks within a single function, between tailcall resolutions, and inside the record walks
+that carve an exception table out of a headerless image. The verdict latches the first time it trips, so
+every later pass sees it: a function the budget cut short is left truncated rather than being
+carved into a second function by the gap scan, and the function set stays a lower bound. It bounds
+how much *new* work is begun rather than how long a call takes to return: whatever is already in
+flight — the block being decoded, the candidate being analyzed — finishes first, so a run overshoots
+by that much. Label providers are the exception, and deliberately so: they parse before analysis
+begins and each caps its own table reads, so `TIMEOUT` does not bound them. A run that exceeded the budget comes back with
 `status == "timeout"`: the function set is a lower bound, not the whole binary. Check the status
 before comparing counts across samples, and pass `TIMEOUT = 0` to disable the bound entirely. A
 caller that needs a hard wall-clock ceiling has to impose one itself.

--- a/README.md
+++ b/README.md
@@ -118,13 +118,14 @@ measuring machine had to spare; on Go ELF and Mach-O memory images it adds 8 fun
 promoting targets that are not yet known needs this pass.
 
 Analysis is also bounded by `TIMEOUT` (300s by default), but cooperatively rather than as a
-wall-clock guarantee. The budget is polled between function candidates and between passes, never
-inside one: a single pathological function is analyzed to completion once started, and with
-`RESOLVE_TAILCALLS` enabled the whole tailcall pass runs without a poll. It bounds how much *new*
-work is begun, not how long a call takes to return, so a run can overshoot it. A run that exceeded
-the budget comes back with `status == "timeout"`: the function set is a lower bound, not the whole
-binary. Check the status before comparing counts across samples, and pass `TIMEOUT = 0` to disable
-the bound entirely. A caller that needs a hard wall-clock ceiling has to impose one itself.
+wall-clock guarantee. The budget is polled between function candidates, between passes, every 256
+basic blocks within a single function, and between tailcall resolutions, so no one pass runs
+unbounded. It still bounds how much *new* work is begun rather than how long a call takes to
+return: whatever is already in flight — the block being decoded, the candidate being analyzed —
+finishes first, so a run overshoots by that much. A run that exceeded the budget comes back with
+`status == "timeout"`: the function set is a lower bound, not the whole binary. Check the status
+before comparing counts across samples, and pass `TIMEOUT = 0` to disable the bound entirely. A
+caller that needs a hard wall-clock ceiling has to impose one itself.
 
 ### IDA Pro integration
 

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -9,6 +9,7 @@ from smda.aarch64.definitions import looksLikeAArch64
 from smda.cil.CilDisassembler import CilDisassembler
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.ExceptionHandling import reraise_non_operational_exception
+from smda.common.instruction_set_probe import detectUnsupportedInstructionSet
 from smda.common.labelprovider.GoLabelProvider import GoSymbolProvider
 from smda.common.SmdaReport import SmdaReport
 from smda.dalvik.DalvikDisassembler import DalvikDisassembler
@@ -238,6 +239,7 @@ class Disassembler:
         # disassembleUnmappedBuffer / disassembleFile detect the architecture through
         # FileLoader; this path bypasses it, so an unspecified architecture is decided
         # from the bytes here.
+        unsupported_instruction_set = None
         if not self._explicit_backend and not architecture:
             if DexFileLoader.isCompatible(file_content):
                 architecture = "dalvik"
@@ -250,6 +252,8 @@ class Disassembler:
                 architecture = "aarch64"
                 if bitness is None:
                     bitness = 64
+            else:
+                unsupported_instruction_set = detectUnsupportedInstructionSet(file_content)
         architecture = architecture or "intel"
         binary_info = BinaryInfo(file_content)
         binary_info.base_addr = base_addr
@@ -261,6 +265,12 @@ class Disassembler:
         self.initDisassembler(binary_info.architecture)
         start = datetime.datetime.now(datetime.timezone.utc)
         try:
+            if unsupported_instruction_set:
+                raise RuntimeError(
+                    f"The buffer holds {unsupported_instruction_set} machine code, which SMDA has no "
+                    "backend for. Disassembling it as intel would return a report whose every block is "
+                    "wrong, so nothing is analysed. Name an architecture explicitly to override this."
+                )
             smda_report = self._disassemble(binary_info, timeout=self.config.TIMEOUT)
             if self.config.WITH_STRINGS:
                 go_pclntab_offset = GoSymbolProvider(None).getPcLntabOffset(binary_info)

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -17,8 +17,9 @@ class SmdaConfig:
     LOG_FORMAT = "%(asctime)-15s: %(name)-32s - %(message)s"
 
     ### SMDA disassembler config
-    # cooperative budget in seconds for disassembly, polled between candidates and between
-    # passes but never within one, so a run overshoots rather than being cut off; 0 disables it
+    # cooperative budget in seconds for disassembly, polled between candidates, between passes,
+    # every 256 basic blocks within a function and between tailcall resolutions; work already in
+    # flight still finishes, so a run overshoots rather than being cut off; 0 disables it
     TIMEOUT = 300
     # maximum number of bytes to allocate while loading
     MAX_IMAGE_SIZE = 100 * 1024 * 1024
@@ -47,10 +48,13 @@ class SmdaConfig:
     # jmp/call from another recovered function, never from candidate membership alone.
     USE_PE_X64_PDATA_ENDS = False
     # promote unclaimed ELF .eh_frame FDE starts as late candidates on both instruction sets
-    # (after the primary pass, before gap analysis); off until validated against ground-truth
-    # function boundaries. Unwind ranges are not function starts by definition - .eh_frame also
-    # covers ranges that are not independent functions - which is why this stays opt-in while
-    # the Mach-O function-start table below does not
+    # (after the primary pass, before gap analysis). Unwind ranges are not function starts by
+    # definition - .eh_frame also covers ranges that are not independent functions. Measured
+    # against symbol-table boundaries over 50 locally built gcc/clang ELF binaries (11384
+    # labelled functions, analysed stripped): recall 93.79% -> 94.68%, so 101 more real starts,
+    # against 56 more addresses landing strictly inside a labelled function body. Off by
+    # default because that is a deliberate baseline move rather than a free win - one bundled
+    # fixture changes - so enabling it belongs with a corpus run, not with a config edit
     USE_ELF_EH_FRAME_CANDIDATES = False
     # extend the AArch64 adr/adrp address-materialization scan to Mach-O instruction sections,
     # recording targets as weak address evidence; off until validated with exact-address ground
@@ -59,10 +63,11 @@ class SmdaConfig:
     # promote unclaimed Mach-O LC_FUNCTION_STARTS entries as late candidates (after the primary
     # pass, before gap analysis). The linker writes the table and stripping keeps it, and segment
     # file offsets and VM offsets coincide in Mach-O, so it also reads correctly out of a mapped
-    # image - unlike a PE COFF symbol table. Across the bundled Mach-O fixtures it lifts the share
-    # of linker-declared starts recovered from 87.4% to 96.7% (1884 -> 2083 of 2155) with no sample
-    # losing a function; off until that is confirmed against ground-truth boundaries rather than
-    # against the same table the pass consumes
+    # image - unlike a PE COFF symbol table. Scored against the corpus samples' own symbol tables
+    # instead of the table this pass consumes, with symbols-as-candidates forced off so the metric
+    # is independent: recall 97.99% -> 98.74% of 1985 symbol-declared starts, 15 more recovered
+    # and 5 fewer functions that no symbol names. Off by default because it moves 5 of the 12
+    # Mach-O corpus samples, all upwards - a deliberate baseline update, not a config edit
     USE_MACHO_FUNCTION_STARTS = False
     RESOLVE_REGISTER_CALLS = True
     # resolve "call/jmp dword ptr [<reg> + <disp>]" against a runtime-built import table and
@@ -88,12 +93,14 @@ class SmdaConfig:
     MEMORY_BUDGET_FRACTION = 0.5
     HIGH_ACCURACY = True
     # promote the targets of jumps that leave a function into functions of their own, in a
-    # pass after gap analysis. Off by default: what it buys depends entirely on how much a
-    # binary tail-calls, and it is never free. On libstdc++.so.6 it adds 337 functions
-    # (8473 -> 8810) for 40-130% more analysis time depending on the machine; on Go ELF and
-    # Mach-O memory images, 8 functions each for 20-26%. A jump into an already-recovered
-    # function is still treated as a tailcall with the pass off - only the promotion of
-    # not-yet-known targets needs it.
+    # pass after gap analysis. Off by default, and measurement says keep it that way: against
+    # symbol-table boundaries over 50 locally built gcc/clang ELF binaries it recovers 70 more
+    # real starts but adds 235 addresses strictly inside a labelled function body, so it breaks
+    # real functions apart faster than it finds new ones. It is also never free - on
+    # libstdc++.so.6 it adds 337 functions (8473 -> 8810) for 40-130% more analysis time
+    # depending on the machine; on Go ELF and Mach-O memory images, 8 functions each for 20-26%.
+    # A jump into an already-recovered function is still treated as a tailcall with the pass
+    # off - only the promotion of not-yet-known targets needs it.
     RESOLVE_TAILCALLS = False
     # optional metadata generation options; the largest built-in performance lever.
     # Measured on the cutwail fixture, as a share of all Python calls per run: hashing 10.0%,

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -18,8 +18,10 @@ class SmdaConfig:
 
     ### SMDA disassembler config
     # cooperative budget in seconds for disassembly, polled between candidates, between passes,
-    # every 256 basic blocks within a function and between tailcall resolutions; work already in
-    # flight still finishes, so a run overshoots rather than being cut off; 0 disables it
+    # every 256 basic blocks within a function and between tailcall resolutions. The verdict
+    # latches the first time it trips, so a function the budget cut short is not re-promoted
+    # by a later pass; work already in flight still finishes, so a run overshoots rather than
+    # being cut off; 0 disables it
     TIMEOUT = 300
     # maximum number of bytes to allocate while loading
     MAX_IMAGE_SIZE = 100 * 1024 * 1024

--- a/src/smda/aarch64/FunctionCandidate.py
+++ b/src/smda/aarch64/FunctionCandidate.py
@@ -13,6 +13,11 @@ class FunctionCandidate(_CommonFunctionCandidate):
         word = int.from_bytes(self.bytes[:4], "little")
         return is_function_prologue(word) or is_bti_landing_pad(word)
 
+    def isLandingPadEntry(self):
+        if len(self.bytes) < INSTRUCTION_SIZE:
+            return False
+        return is_bti_landing_pad(int.from_bytes(self.bytes[:INSTRUCTION_SIZE], "little"))
+
     def getFunctionStartScore(self):
         # Intentionally 0 for priority-queue scoring. AArch64 frame-record stores
         # (stp x29,x30,[sp,#-imm]!) also appear mid-function; feeding them into

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -69,8 +69,14 @@ from .FunctionCandidate import FunctionCandidate
 LOGGER = logging.getLogger(__name__)
 
 _ARM64_PDATA_ENTRY_SIZE = 8
+# items (words, matches or exception records) a scan steps over between budget polls, mirroring
+# _TIMEOUT_POLL_BLOCKS in the engine. A whole exception table is walked inside one call, so
+# the poll in the pass around it never comes round again while that walk is running
+_TIMEOUT_POLL_INTERVAL = 4096
 _ARM64_PDATA_MIN_ENTRIES = 16
 _ARM64_PDATA_SEED_ENTRIES = 4
+# a sample must land inside the shortest table worth carving, whatever the table's offset:
+# _ARM64_PDATA_SAMPLE_STRIDE <= (MIN_ENTRIES - SEED_ENTRIES) * ENTRY_SIZE, pinned by a test
 _ARM64_PDATA_SAMPLE_STRIDE = 64
 
 
@@ -202,7 +208,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         for record_index, record_rva in enumerate(
             range(exception_dir.rva, exception_dir.rva + exception_dir.size - 7, 8)
         ):
-            if record_index % 4096 == 0 and self._candidateTimeoutTripped():
+            if record_index % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return
             packed_entry = self.disassembly.getRawBytes(record_rva, 8)
             if packed_entry is None or len(packed_entry) < 8:
@@ -275,6 +281,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         count = 0
         previous_begin = 0
         while count < limit:
+            if count and count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
+                break
             record = self._readArm64ExceptionRecord(binary, size, offset, previous_begin)
             if record is None:
                 break
@@ -322,6 +330,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             return
         LOGGER.debug("carved %d ARM64 RUNTIME_FUNCTION entries at 0x%08x", table_count, table_offset)
         for index in range(table_count):
+            if index and index % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
+                return
             begin_rva = struct.unpack_from("<I", binary, table_offset + index * _ARM64_PDATA_ENTRY_SIZE)[0]
             self._admitCarvedExceptionRecord(base_addr, begin_rva)
 
@@ -429,18 +439,19 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             self.addReferenceCandidate(target, source_va)
             self.setInitialCandidate(target)
 
+        rebases = fixup_state[0]
         for section in macho.sections:
             if not section.virtual_address or not section.size:
                 continue
             section_type = section.type
             if section_type in pointer_types:
-                for slot_va in range(section.virtual_address, section.virtual_address + section.size - 7, 8):
+                for slot_va in self._machoMetadataSlots(section, 8, adjustment, rebases):
                     if self._candidateTimeoutTripped():
                         return
                     seed(self._resolveMachoStoredPointer(slot_va, adjustment, fixup_state), slot_va + adjustment)
             elif init_offsets_type is not None and section_type == init_offsets_type:
                 # __init_offsets: 32-bit offsets from the image base, no fixups involved
-                for slot_va in range(section.virtual_address, section.virtual_address + section.size - 3, 4):
+                for slot_va in self._machoMetadataSlots(section, 4, adjustment, ()):
                     if self._candidateTimeoutTripped():
                         return
                     raw = self.disassembly.getBytes(slot_va + adjustment, 4)
@@ -450,10 +461,38 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             elif section_type == interposing_type:
                 # interposing entries are <replacement, replacee> pointer pairs; only
                 # the replacement of a complete pair is a local function
-                for pair_va in range(section.virtual_address, section.virtual_address + section.size - 15, 16):
+                for pair_va in self._machoMetadataSlots(section, 16, adjustment, rebases):
                     if self._candidateTimeoutTripped():
                         return
                     seed(self._resolveMachoStoredPointer(pair_va, adjustment, fixup_state), pair_va + adjustment)
+
+    def _machoMetadataSlots(self, section, stride, adjustment, rebases):
+        """Slot VAs in `section`, `stride` apart, that could resolve to anything at all.
+
+        A section header declares an extent; the mapped image decides what can be read. A slot
+        outside the image reads back None, so striding over a damaged `section.size` only spends
+        the analysis budget - the same shape as the ELF scan next door. The one thing that can
+        still resolve out there is a slot a rebase names, so those are yielded too rather than
+        assumed away: the range is clamped for cost, the union keeps it output-equivalent.
+
+        Addresses here are LIEF VAs, which `adjustment` maps to SMDA's, so the image bounds have
+        to be brought back the other way before they can be compared.
+        """
+        binary_info = self.disassembly.binary_info
+        image_start = binary_info.base_addr - adjustment
+        image_end = image_start + binary_info.binary_size
+        start = section.virtual_address
+        end = start + section.size
+        first = max(start, image_start)
+        if first > start:
+            # keep the stride phase the declared extent set, so the same slots are visited
+            first = start + -(-(first - start) // stride) * stride
+        last = min(end, image_end)
+        if last > first:
+            yield from range(first, last - (stride - 1), stride)
+        for slot in sorted(rebases):
+            if start <= slot < end and not (first <= slot < last) and (slot - start) % stride == 0:
+                yield slot
 
     def locateDataPointerCandidates(self):
         # Seed candidates from stored function pointers. ELF .init_array/.fini_array
@@ -480,6 +519,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
 
         pointer_size = 8 if binary_info.bitness == 64 else 4
         bit_mask = self.getBitMask()
+        image_start = binary_info.base_addr
+        image_end = image_start + binary_info.binary_size
         exec_flag = lief.ELF.Section.FLAGS.EXECINSTR.value
         for section in lief_binary.sections:
             flags = 0
@@ -494,8 +535,15 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # naturally aligned, so an unaligned section start would otherwise
             # stride past every aligned pointer in the section.
             scan_start = (section_start + (pointer_size - 1)) & ~(pointer_size - 1)
-            for match_count, pointer_va in enumerate(range(scan_start, section_end - (pointer_size - 1), pointer_size)):
-                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+            # A section header can describe an extent the mapped image does not hold, and a
+            # damaged one routinely does. Every read outside the image comes back None, so
+            # those addresses cannot yield a candidate and only spend the analysis budget;
+            # the surviving range visits exactly the addresses that could have matched.
+            if scan_start < image_start:
+                scan_start += -(-(image_start - scan_start) // pointer_size) * pointer_size
+            scan_end = min(section_end, image_end)
+            for match_count, pointer_va in enumerate(range(scan_start, scan_end - (pointer_size - 1), pointer_size)):
+                if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                     return
                 raw = self.disassembly.getBytes(pointer_va, pointer_size)
                 if raw is None or len(raw) != pointer_size:
@@ -568,7 +616,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             addr = low
             match_count = 0
             while addr + INSTRUCTION_SIZE <= high:
-                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                     return
                 match_count += 1
                 offset = addr - base
@@ -628,7 +676,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # call-reference candidate — the AArch64 analogue of the base 0xE8 scan.
         base = self.disassembly.binary_info.base_addr
         for match_count, word in enumerate(self._wordsView()):
-            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+            if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return
             if (word & BL_MASK) != BL_VALUE:
                 continue
@@ -650,7 +698,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # see definitions.is_function_prologue for the exact encodings.
         base = self.disassembly.binary_info.base_addr
         for match_count, word in enumerate(self._wordsView()):
-            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+            if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return
             if not is_function_prologue(word):
                 continue

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -332,7 +332,13 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         for index in range(table_count):
             if index and index % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return
-            begin_rva = struct.unpack_from("<I", binary, table_offset + index * _ARM64_PDATA_ENTRY_SIZE)[0]
+            begin_rva, unwind_data = struct.unpack_from("<II", binary, table_offset + index * _ARM64_PDATA_ENTRY_SIZE)
+            if unwind_data & 0x3 == 2:
+                # a packed fragment continues another function's body, so its begin address is
+                # not a function start - the parsed directory path skips these for the same
+                # reason. The record still has to read as valid, or the run that found the
+                # table would end at the first fragment in it.
+                continue
             self._admitCarvedExceptionRecord(base_addr, begin_rva)
 
     def _executableRanges(self):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -68,6 +68,11 @@ from .FunctionCandidate import FunctionCandidate
 
 LOGGER = logging.getLogger(__name__)
 
+_ARM64_PDATA_ENTRY_SIZE = 8
+_ARM64_PDATA_MIN_ENTRIES = 16
+_ARM64_PDATA_SEED_ENTRIES = 4
+_ARM64_PDATA_SAMPLE_STRIDE = 64
+
 
 class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
@@ -151,7 +156,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         header = self.disassembly.getRawBytes(xdata_rva, 4)
         if header is None or len(header) < 4:
             return False
-        header_word = int.from_bytes(header, "little")
+        return self._isValidArm64UnwindHeader(int.from_bytes(header, "little"))
+
+    @staticmethod
+    def _isValidArm64UnwindHeader(header_word):
         function_length = header_word & 0x3FFFF
         version = (header_word >> 18) & 0x3
         return version == 0 and function_length > 0
@@ -168,6 +176,11 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         binary_info = self.disassembly.binary_info
         lief_binary = binary_info.getLiefBinary()
         if not isinstance(lief_binary, lief.PE.Binary):
+            # A memory image keeps the mapped code but usually not a parseable header, so
+            # the exception directory has to be found in the bytes instead of read from a
+            # data directory. The table is self-describing enough to locate without one.
+            if next(binary_info.getSections(), None) is None:
+                self._carveArm64ExceptionRecords(binary_info.base_addr)
             return
         if lief_binary.header.machine != lief.PE.Header.MACHINE_TYPES.ARM64:
             return
@@ -222,6 +235,95 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if not is_exception_record_entry(begin_word):
                 continue
             self.addExceptionCandidate(addr)
+
+    def _admitCarvedExceptionRecord(self, base_addr, begin_rva):
+        begin_word_bytes = self.disassembly.getRawBytes(begin_rva, INSTRUCTION_SIZE)
+        if begin_word_bytes is None or len(begin_word_bytes) < INSTRUCTION_SIZE:
+            return
+        if not is_exception_record_entry(int.from_bytes(begin_word_bytes, "little")):
+            return
+        self.addExceptionCandidate(base_addr + begin_rva)
+
+    def _readArm64ExceptionRecord(self, binary, size, offset, previous_begin):
+        """Return a validated ARM64 RUNTIME_FUNCTION pair at offset, or None.
+
+        The exception directory is sorted and its BeginAddresses do not repeat, which is
+        what separates a run of real records from data that merely holds plausible RVAs.
+        """
+        if offset + _ARM64_PDATA_ENTRY_SIZE > size:
+            return None
+        begin_rva, unwind_data = struct.unpack_from("<II", binary, offset)
+        if begin_rva == 0 or begin_rva % INSTRUCTION_SIZE or begin_rva >= size:
+            return None
+        if begin_rva <= previous_begin:
+            return None
+        flag = unwind_data & 0x3
+        if flag == 0:
+            if not unwind_data or unwind_data + INSTRUCTION_SIZE > size:
+                return None
+            if not self._isValidArm64UnwindHeader(struct.unpack_from("<I", binary, unwind_data)[0]):
+                return None
+        elif flag == 3:
+            return None
+        else:
+            function_words = (unwind_data >> 2) & 0x7FF
+            if not function_words or begin_rva + function_words * INSTRUCTION_SIZE > size:
+                return None
+        return begin_rva, unwind_data
+
+    def _countArm64ExceptionRecords(self, binary, size, offset, limit):
+        count = 0
+        previous_begin = 0
+        while count < limit:
+            record = self._readArm64ExceptionRecord(binary, size, offset, previous_begin)
+            if record is None:
+                break
+            previous_begin = record[0]
+            offset += _ARM64_PDATA_ENTRY_SIZE
+            count += 1
+        return count
+
+    def _locateArm64ExceptionRecordTable(self, binary):
+        """Return (offset, count) of the longest RUNTIME_FUNCTION run, or (0, 0) if none qualifies."""
+        size = len(binary)
+        best_offset = best_count = 0
+        offset = 0
+        samples = 0
+        while offset + _ARM64_PDATA_SEED_ENTRIES * _ARM64_PDATA_ENTRY_SIZE <= size:
+            if samples % 4096 == 0 and self._candidateTimeoutTripped():
+                break
+            samples += 1
+            for phase in (0, 4):
+                seed = offset + phase
+                if self._countArm64ExceptionRecords(binary, size, seed, _ARM64_PDATA_SEED_ENTRIES) < (
+                    _ARM64_PDATA_SEED_ENTRIES
+                ):
+                    continue
+                start = seed
+                while start >= _ARM64_PDATA_ENTRY_SIZE:
+                    previous = self._readArm64ExceptionRecord(binary, size, start - _ARM64_PDATA_ENTRY_SIZE, 0)
+                    if previous is None or previous[0] >= struct.unpack_from("<I", binary, start)[0]:
+                        break
+                    start -= _ARM64_PDATA_ENTRY_SIZE
+                count = self._countArm64ExceptionRecords(binary, size, start, size)
+                if count > best_count:
+                    best_offset, best_count = start, count
+                offset = max(offset, start + count * _ARM64_PDATA_ENTRY_SIZE)
+                break
+            offset += _ARM64_PDATA_SAMPLE_STRIDE
+        if best_count < _ARM64_PDATA_MIN_ENTRIES:
+            return 0, 0
+        return best_offset, best_count
+
+    def _carveArm64ExceptionRecords(self, base_addr):
+        binary = self.disassembly.binary_info.binary
+        table_offset, table_count = self._locateArm64ExceptionRecordTable(binary)
+        if not table_count:
+            return
+        LOGGER.debug("carved %d ARM64 RUNTIME_FUNCTION entries at 0x%08x", table_count, table_offset)
+        for index in range(table_count):
+            begin_rva = struct.unpack_from("<I", binary, table_offset + index * _ARM64_PDATA_ENTRY_SIZE)[0]
+            self._admitCarvedExceptionRecord(base_addr, begin_rva)
 
     def _executableRanges(self):
         return self._cachedExecutableSectionRanges()

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -34,6 +34,8 @@ do not "simplify" away):
   always-taken aliases, mirroring ``b.al``/``b.nv``.
 """
 
+from smda.common.instruction_set_probe import countAlignedOccurrences
+
 # fixed AArch64 instruction width (bytes); also the recursion stride
 INSTRUCTION_SIZE = 4
 NOP = 0xD503201F
@@ -301,10 +303,5 @@ def looksLikeAArch64(buffer):
     and both x86 modes: no non-AArch64 image held a single aligned occurrence, while
     the smallest AArch64 one held five in 48 KiB.
     """
-    found = 0
-    index = buffer.find(RET_X30_BYTES)
-    while index >= 0:
-        if index % INSTRUCTION_SIZE == 0:
-            found += 1
-        index = buffer.find(RET_X30_BYTES, index + 1)
-    return found >= MIN_RETURN_WORDS and found * MAX_BYTES_PER_RETURN_WORD >= len(buffer)
+    required = max(MIN_RETURN_WORDS, -(-len(buffer) // MAX_BYTES_PER_RETURN_WORD))
+    return countAlignedOccurrences(buffer, RET_X30_BYTES, INSTRUCTION_SIZE, limit=required) >= required

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -34,7 +34,7 @@ do not "simplify" away):
   always-taken aliases, mirroring ``b.al``/``b.nv``.
 """
 
-from smda.common.instruction_set_probe import countAlignedOccurrences
+from smda.common.instruction_set_probe import countCodeReturnSites
 
 # fixed AArch64 instruction width (bytes); also the recursion stride
 INSTRUCTION_SIZE = 4
@@ -298,10 +298,15 @@ def is_exception_record_entry(word):
 def looksLikeAArch64(buffer):
     """Whether a raw buffer's bytes are AArch64 machine code.
 
-    Counts aligned ``ret`` words, which every non-leaf function ends with. Measured
-    over 37 images spanning PE/ELF/Mach-O/DEX/CIL, nine non-AArch64 instruction sets
-    and both x86 modes: no non-AArch64 image held a single aligned occurrence, while
-    the smallest AArch64 one held five in 48 KiB.
+    Counts aligned ``ret`` words, which every non-leaf function ends with, skipping any
+    that sit inside text rather than code. Measured over 37 images spanning PE/ELF/Mach-O/
+    DEX/CIL, nine non-AArch64 instruction sets and both x86 modes, and again over 50
+    locally built x86 binaries: no non-AArch64 image held a single aligned occurrence,
+    while the smallest AArch64 one held five in 48 KiB.
+
+    A count is evidence, not proof. Whoever supplies the buffer chooses its bytes, so a
+    handful of planted words can steer this either way; a caller that knows the instruction
+    set should pass ``architecture`` rather than rely on the guess.
     """
     required = max(MIN_RETURN_WORDS, -(-len(buffer) // MAX_BYTES_PER_RETURN_WORD))
-    return countAlignedOccurrences(buffer, RET_X30_BYTES, INSTRUCTION_SIZE, limit=required) >= required
+    return countCodeReturnSites(buffer, RET_X30_BYTES, INSTRUCTION_SIZE, required) >= required

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -13,6 +13,7 @@ from dncil.cil.body.reader import CilMethodBodyReaderBase
 from dncil.clr.token import InvalidToken, StringToken, Token
 from dnfile.enums import MetadataTables
 
+from smda.common.analysis_budget import analysisTimeoutTripped
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.labelprovider.CilSymbolProvider import CilSymbolProvider
 from smda.DisassemblyResult import DisassemblyResult
@@ -332,11 +333,11 @@ class CilDisassembler:
                 continue
             if not method_body.instructions:
                 continue
-            if cbAnalysisTimeout and cbAnalysisTimeout():
+            if analysisTimeoutTripped(self.disassembly, cbAnalysisTimeout):
                 break
             self.analyzeFunction(pe, method_body.offset, method_body)
         # package up and finish
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout and cbAnalysisTimeout():
+        if analysisTimeoutTripped(self.disassembly, cbAnalysisTimeout):
             self.disassembly.analysis_timeout = True
         return self.disassembly

--- a/src/smda/common/FunctionCandidate.py
+++ b/src/smda/common/FunctionCandidate.py
@@ -91,6 +91,15 @@ class FunctionCandidate:
         """Architecture-specific entry-shape score; implemented per backend."""
         raise NotImplementedError
 
+    def isLandingPadEntry(self):
+        """Whether this candidate starts on an indirect-branch landing pad.
+
+        A landing pad is the image's own declaration that an indirect branch may target the
+        address, so a candidate carrying one was not discovered by guessing. Backends without
+        the concept answer False.
+        """
+        return False
+
     def addCallRef(self, source_addr):
         previous_size = len(self.call_ref_sources)
         self.call_ref_sources.add(source_addr)

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -208,6 +208,11 @@ class RecursiveDisassembler:
         before the tailcall candidate was known). Revert the gap function so the
         current analysis can absorb its bytes as ordinary blocks.
 
+        That premise does not hold for a gap function whose entry carries an indirect-branch
+        landing pad: the scan did not guess such a start, the image declared it as somewhere an
+        indirect branch may land, so reverting it for a candidate found inside its body would
+        demote a declared entry in favour of an address carrying no such marker.
+
         Returns True if a gap function was reverted.
         """
         owner_fn = self.disassembly.ins2fn.get(colliding_addr)
@@ -215,6 +220,8 @@ class RecursiveDisassembler:
             return False
         candidate = self.fc_manager.candidates.get(owner_fn)
         if candidate is None or not candidate.is_gap_candidate:
+            return False
+        if candidate.isLandingPadEntry():
             return False
         if owner_fn not in self.disassembly.functions:
             return False

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -6,6 +6,7 @@ import re
 from bisect import bisect_right
 from itertools import chain
 
+from smda.common.analysis_budget import analysisTimeoutTripped
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.labelprovider.DelphiKbSymbolProvider import DelphiKbSymbolProvider
@@ -446,10 +447,7 @@ class RecursiveDisassembler:
         self._tfidf = self.backend.createTfIdf(binary_info.bitness)
         LOGGER.debug("Starting heuristical analysis.")
         # first pass, analyze locations identifiable by heuristics (e.g. call-reference, common prologue)
-        for candidate in self.fc_manager.getNextFunctionStartCandidate():
-            if cbAnalysisTimeout and cbAnalysisTimeout():
-                break
-            state = self.analyzeFunction(candidate.addr)
+        self._drainCandidateQueue(cbAnalysisTimeout)
         LOGGER.debug(
             "Finished heuristical analysis, functions: %d",
             len(self.disassembly.functions),
@@ -457,13 +455,13 @@ class RecursiveDisassembler:
         # deferred candidate sources need the primary pass's code_map claims to filter
         # against; they run before gap analysis so accepted starts anchor real functions
         for deferred_addr in self.fc_manager.locateDeferredCandidates():
-            if cbAnalysisTimeout and cbAnalysisTimeout():
+            if self._analysisTimeoutTripped(cbAnalysisTimeout):
                 break
             state = self.analyzeFunction(deferred_addr)
         # second pass, analyze remaining gaps for additional candidates in an iterative way
         gap_candidate = self.fc_manager.nextGapCandidate()
         while gap_candidate is not None:
-            if cbAnalysisTimeout and cbAnalysisTimeout():
+            if self._analysisTimeoutTripped(cbAnalysisTimeout):
                 break
             LOGGER.debug("based on gap, performing function analysis of 0x%08x", gap_candidate)
             state = self.analyzeFunction(gap_candidate, as_gap=True)
@@ -482,10 +480,7 @@ class RecursiveDisassembler:
         LOGGER.debug("Finished gap analysis, functions: %d", len(self.disassembly.functions))
         # candidates may have been discovered during gap analysis (e.g. tailcall targets triggered
         # by _analyzeUncondBranch); drain them before moving to the tailcall pass.
-        for candidate in self.fc_manager.getNextFunctionStartCandidate():
-            if cbAnalysisTimeout and cbAnalysisTimeout():
-                break
-            state = self.analyzeFunction(candidate.addr)
+        self._drainCandidateQueue(cbAnalysisTimeout)
         # third pass, fix potential tailcall functions that were identified during analysis
         if self.config.RESOLVE_TAILCALLS:
             tailcalled_functions = self.tailcall_analyzer.resolveTailcalls(self)
@@ -493,10 +488,7 @@ class RecursiveDisassembler:
                 self.fc_manager.addTailcallCandidate(addr)
             LOGGER.debug("Finished tailcall analysis, functions.")
             # drain any candidates that were added during tailcall resolution
-            for candidate in self.fc_manager.getNextFunctionStartCandidate():
-                if cbAnalysisTimeout and cbAnalysisTimeout():
-                    break
-                state = self.analyzeFunction(candidate.addr)
+            self._drainCandidateQueue(cbAnalysisTimeout)
         if self.config.USE_PE_X64_PDATA_ENDS:
             self._splitMergedFunctionsAtPdataEnds(cbAnalysisTimeout)
         self.disassembly.failed_analysis_addr = self.fc_manager.getAbortedCandidates()
@@ -521,7 +513,7 @@ class RecursiveDisassembler:
             )
             self.disassembly.language_guess = lang_analyzer.getGuess()
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout and cbAnalysisTimeout():
+        if self._analysisTimeoutTripped(cbAnalysisTimeout):
             self.disassembly.analysis_timeout = True
         return self.disassembly
 
@@ -559,19 +551,29 @@ class RecursiveDisassembler:
             splits_performed += self._partitionFunctionAtPdataEnds(fn_start, genuine_splits)
         return splits_performed
 
+    def _drainCandidateQueue(self, cbAnalysisTimeout):
+        """Analyse every queued candidate that is still unfinished, until the budget is spent.
+
+        Three passes drain the queue this way - the heuristic pass, the one after gap analysis
+        and the one after tailcall resolution - and they were three copies of the same four
+        lines. The tailcall drain is the reason to have it in one place: `resolveTailcalls`
+        analyses each address it returns, so the queue is normally empty by the time that copy
+        ran, and a poll that is only ever reached through the other two is a poll nobody can
+        check.
+        """
+        for candidate in self.fc_manager.getNextFunctionStartCandidate():
+            if self._analysisTimeoutTripped(cbAnalysisTimeout):
+                break
+            self.analyzeFunction(candidate.addr)
+
     def _analysisTimeoutTripped(self, cbAnalysisTimeout=None):
         """Whether the analysis budget is spent, latching the verdict onto the result.
 
         Falls back to the callback analyzeBuffer was given, so a pass that is not handed one
         is still bounded by the same budget as the passes around it.
         """
-        if self.disassembly.analysis_timeout:
-            return True
         callback = cbAnalysisTimeout if cbAnalysisTimeout is not None else self._cb_analysis_timeout
-        if callback is not None and callback():
-            self.disassembly.analysis_timeout = True
-            return True
-        return False
+        return analysisTimeoutTripped(self.disassembly, callback)
 
     def _hasNonFallthroughCodeRef(self, target_addr, owner_fn):
         for source_addr in self.disassembly.code_refs_to.get(target_addr, ()):

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -26,6 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 # a leading sign is preserved so that negative displacements ("[rip - 0x20]") resolve correctly
 _REFERENCED_ADDR_RE = re.compile(r"(?P<sign>[+-])?\s*0x(?P<value>[a-fA-F0-9]+)")
+_TIMEOUT_POLL_BLOCKS = 256
 
 
 class RecursiveDisassembler:
@@ -61,6 +62,7 @@ class RecursiveDisassembler:
         self.disassembly.setConfidenceThreshold(config.CONFIDENCE_THRESHOLD)
         self._symbol_cache = {}
         self._api_cache = {}
+        self._cb_analysis_timeout = None
 
     def _addLabelProviders(self):
         self._registerLabelProvider(WinApiResolver(self.config))
@@ -251,7 +253,11 @@ class RecursiveDisassembler:
             # state.getBlocks(); this collision path is unreachable from the gap pass today, so
             # the change is behavior-neutral (output stays byte-for-byte identical).
             return state
+        blocks_processed = 0
         while state.hasUnprocessedBlocks():
+            blocks_processed += 1
+            if blocks_processed % _TIMEOUT_POLL_BLOCKS == 0 and self._analysisTimeoutTripped():
+                break
             debug_logging = LOGGER.isEnabledFor(logging.DEBUG)
             if debug_logging:
                 LOGGER.debug(
@@ -399,6 +405,7 @@ class RecursiveDisassembler:
         )
         self._symbol_cache = {}
         self._api_cache = {}
+        self._cb_analysis_timeout = cbAnalysisTimeout
         self.disassembly = DisassemblyResult()
         self.disassembly.smda_version = self.config.VERSION
         # analyzeBuffer replaces the DisassemblyResult allocated in __init__; re-apply
@@ -526,11 +533,11 @@ class RecursiveDisassembler:
         pdata_ends = self.fc_manager.pdata_end_addresses
         if not pdata_ends:
             return 0
-        if self._pdataSplitTimeoutTripped(cbAnalysisTimeout):
+        if self._analysisTimeoutTripped(cbAnalysisTimeout):
             return 0
         split_points_by_owner = {}
         for index, end_addr in enumerate(sorted(pdata_ends)):
-            if index and index % 4096 == 0 and self._pdataSplitTimeoutTripped(cbAnalysisTimeout):
+            if index and index % 4096 == 0 and self._analysisTimeoutTripped(cbAnalysisTimeout):
                 return 0
             fn_start = self.disassembly.ins2fn.get(end_addr)
             if (
@@ -547,15 +554,21 @@ class RecursiveDisassembler:
                 split_points_by_owner.setdefault(fn_start, []).append(end_addr)
         splits_performed = 0
         for fn_start, genuine_splits in sorted(split_points_by_owner.items()):
-            if self._pdataSplitTimeoutTripped(cbAnalysisTimeout):
+            if self._analysisTimeoutTripped(cbAnalysisTimeout):
                 break
             splits_performed += self._partitionFunctionAtPdataEnds(fn_start, genuine_splits)
         return splits_performed
 
-    def _pdataSplitTimeoutTripped(self, cbAnalysisTimeout):
+    def _analysisTimeoutTripped(self, cbAnalysisTimeout=None):
+        """Whether the analysis budget is spent, latching the verdict onto the result.
+
+        Falls back to the callback analyzeBuffer was given, so a pass that is not handed one
+        is still bounded by the same budget as the passes around it.
+        """
         if self.disassembly.analysis_timeout:
             return True
-        if cbAnalysisTimeout is not None and cbAnalysisTimeout():
+        callback = cbAnalysisTimeout if cbAnalysisTimeout is not None else self._cb_analysis_timeout
+        if callback is not None and callback():
             self.disassembly.analysis_timeout = True
             return True
         return False

--- a/src/smda/common/TailcallAnalyzer.py
+++ b/src/smda/common/TailcallAnalyzer.py
@@ -119,7 +119,10 @@ class TailcallAnalyzer:
             disassembler.analyzeFunction(tailcall["destination_addr"])
             newly_created_functions.add(tailcall["destination_addr"])
             function = self.__getFunctionByStartAddr(tailcall["destination_addr"])
-            if function and tailcall["destination_function"] not in function.instruction_start_bytes:
+            absorbed = function is not None and tailcall["destination_function"] in function.instruction_start_bytes
+            candidate = disassembler.fc_manager.candidates.get(tailcall["destination_function"])
+            declared_entry = candidate is not None and candidate.isLandingPadEntry()
+            if function and (not absorbed or declared_entry):
                 # analyze the (previously) broken function a second time
                 try:
                     disassembler.analyzeFunction(tailcall["destination_function"])

--- a/src/smda/common/TailcallAnalyzer.py
+++ b/src/smda/common/TailcallAnalyzer.py
@@ -98,6 +98,8 @@ class TailcallAnalyzer:
     def resolveTailcalls(self, disassembler, verbose=False):
         newly_created_functions = set()
         for tailcall in self.getTailcalls():
+            if disassembler._analysisTimeoutTripped():
+                break
             if verbose:
                 LOGGER.debug("Processing tailcall:\n%s", json.dumps(tailcall, indent=2, sort_keys=True))
             # remove the information from the function-analysis state of the disassembly

--- a/src/smda/common/analysis_budget.py
+++ b/src/smda/common/analysis_budget.py
@@ -1,0 +1,20 @@
+"""The cooperative analysis budget, shared by the three backends that own an analyzeBuffer.
+
+`SmdaConfig.TIMEOUT` reaches a backend as a callback it is expected to poll. Asking that
+callback again at every pass is not the same as remembering its answer: a caller scopes a
+budget by where it is called from - "spent while the tailcall pass is running" - so a later
+pass that re-asks is told "not spent" and carries on doing the work the budget was meant to
+stop. The verdict has to latch onto the result the first time it trips, and every later poll
+has to read the latch first.
+"""
+
+
+def analysisTimeoutTripped(disassembly, cbAnalysisTimeout):
+    """Whether the analysis budget is spent, latching the verdict onto the result."""
+    if disassembly is not None and disassembly.analysis_timeout:
+        return True
+    if cbAnalysisTimeout is not None and cbAnalysisTimeout():
+        if disassembly is not None:
+            disassembly.analysis_timeout = True
+        return True
+    return False

--- a/src/smda/common/instruction_set_probe.py
+++ b/src/smda/common/instruction_set_probe.py
@@ -6,16 +6,38 @@ header to read the instruction set from, so it is read from the code itself: eac
 architectures is fixed-width and spells its function return one way, which makes an aligned
 count of that encoding separate them from x86 and from each other.
 
-Counts over the bundled fixtures plus a locally built x86-64/x86 corpus (72 images): every
-signature below scores at least 31 on its own architecture, and at most 3 on any other
-image in the set. The threshold sits between those, biased hard towards silence - a false
-positive turns a working x86 analysis into an error, while a false negative only leaves
-today's behaviour in place.
+What separates them is **density, measured over a window**, not a total. A count over the
+whole buffer says nothing, because a dump is mostly data: 21 aligned hits of the openrisc
+return word turned up in a real stripped x86-64 shared object, where the byte pattern
+"\x44\x00\x48\x00" is "DH" in a UTF-16LE index table. Sixty-four bytes of UTF-16 text
+appended to a bundled x86 memory dump was enough to flip it the same way. Foreign code
+returns every 332 to 1961 bytes across the ten bundled samples; the densest accidental hit
+anywhere in the fixture and ground-truth corpora is one per 27920 bytes. Requiring
+MIN_RETURN_SITES within a single WINDOW_BYTES span puts the bar at one per 4096: twice the
+sparsest real sample's density, and a seventh of the densest accident's. Because the span
+slides with the hits rather than sitting on a grid, it still finds a small code region inside
+a large dump - which a whole-buffer density never could.
+
+The bias is deliberately towards silence: a false positive turns a working x86 analysis into
+an error, while a false negative only leaves today's behaviour in place.
 """
 
-MIN_RETURN_SITES = 16
-MAX_BYTES_PER_RETURN_SITE = 64 * 1024
+from collections import deque
 
+# Measured as the densest window count over the ten bundled foreign samples against 60939
+# ordinary files of every type on one filesystem: every signature scores 24 to 189 on its own
+# architecture and zero on anything that is not that architecture, so one floor serves them
+# all - but two of them only reach it because they were lengthened rather than re-thresholded.
+#
+# xtensa's plain two-byte "retw.n" scored 43 on its own sample against 31 in a Python .pyc,
+# and refused real x86-64 shared objects; sh4's return-plus-delay-slot scored 142 against 108
+# in the go compiler. Neither gap supports a threshold. Both now carry one more word of the
+# sequence their own sample emits - 24 and 73 hits respectively, against zero in every file
+# that used to trip them. That is derived from a single artifact each, so it is a narrower
+# claim than the others: an image that does not use the idiom is missed, which is the
+# direction this module is biased in anyway. sh4's byte-swapped form has no sample behind it
+# at all and is carried only for symmetry.
+MIN_RETURN_SITES = 16
 RETURN_SIGNATURES = {
     "arm": ((b"\x1e\xff\x2f\xe1", b"\x0e\xf0\xa0\xe1", b"\xe1\x2f\xff\x1e", b"\xe1\xa0\xf0\x0e"), 4),
     "mips": ((b"\x03\xe0\x00\x08", b"\x08\x00\xe0\x03"), 4),
@@ -23,28 +45,92 @@ RETURN_SIGNATURES = {
     "sparc": ((b"\x81\xc3\xe0\x08", b"\x81\xc7\xe0\x08"), 4),
     "nios2": ((b"\x3a\x28\x00\xf8",), 4),
     "openrisc": ((b"\x44\x00\x48\x00",), 4),
-    "sh4": ((b"\x0b\x00\x09\x00", b"\x00\x0b\x00\x09"), 2),
+    "sh4": ((b"\x0b\x00\x09\x00\x09\x00", b"\x00\x0b\x00\x09\x00\x09"), 2),
     "m68k": ((b"\x4e\x5e\x4e\x75",), 2),
-    "xtensa": ((b"\x1d\xf0",), 2),
+    "xtensa": ((b"\x3d\xf0\x1d\xf0",), 2),
 }
 
+# the span that `required` return sites must fall inside: large enough to hold the sparsest
+# sample's returns many times over, small enough that a code region inside a much larger dump
+# still fills one. The span slides with the hits rather than sitting on a grid, so a code
+# region never falls across a boundary and the buffer is read once per signature.
+WINDOW_BYTES = 64 * 1024
+# a buffer dense in a MISALIGNED copy of a signature can offer an occurrence at every
+# position while none of them counts. The scan skips to the next aligned offset rather than
+# the next byte, and this caps what one pattern will look at even so: reaching it means the
+# buffer is denser in near-misses than any real code, and the answer stays silence.
+MAX_PROBES = 1 << 20
+# bytes either side of a hit that decide whether it sits in code or in text
+NEIGHBOURHOOD_BYTES = 32
+# share of a neighbourhood's 2-byte units that must read as UTF-16 to disqualify a hit
+TEXT_UNIT_SHARE = 0.8
 
-def countAlignedOccurrences(buffer, pattern, alignment, limit=None):
-    """How many times pattern occurs in buffer at a multiple of alignment.
 
-    Counting stops once limit is reached, because the caller only ever asks whether a
-    count clears a threshold. Without it a buffer that is dense in one pattern costs an
-    iteration per occurrence, which is 25 million of them for a 100 MB image.
+def looksLikeText(buffer, offset):
+    """Whether the bytes around offset read as UTF-16 rather than as machine code.
+
+    Density alone cannot separate the two. A UTF-16LE index table in a real x86-64 shared
+    object put 21 aligned openrisc return words across 37 KB - the same one-per-1786-bytes
+    the sparsest bundled foreign sample scores - so the probe refused a legitimate x86 dump.
+    What does separate them is the company each hit keeps: over the ten bundled foreign
+    samples not one hit sits in a neighbourhood like this, while every one of the 21 did.
     """
+    start = max(0, offset - NEIGHBOURHOOD_BYTES)
+    start -= start % 2  # a UTF-16 code unit begins on an even offset
+    window = buffer[start : offset + NEIGHBOURHOOD_BYTES]
+    units = len(window) // 2
+    if units < 8:
+        return False
+    little = sum(1 for i in range(0, units * 2, 2) if window[i + 1] == 0 and 0x20 <= window[i] < 0x7F)
+    big = sum(1 for i in range(0, units * 2, 2) if window[i] == 0 and 0x20 <= window[i + 1] < 0x7F)
+    return max(little, big) >= units * TEXT_UNIT_SHARE
+
+
+def countCodeReturnSites(buffer, pattern, alignment, limit):
+    """Aligned occurrences of pattern across buffer that are not sitting inside text."""
     found = 0
-    index = buffer.find(pattern)
-    while index >= 0:
-        if index % alignment == 0:
-            found += 1
-            if limit is not None and found >= limit:
-                break
-        index = buffer.find(pattern, index + 1)
+    for _offset in _codeReturnSites(buffer, pattern, alignment):
+        found += 1
+        if found >= limit:
+            break
     return found
+
+
+def hasDenseReturnRun(buffer, pattern, alignment, required):
+    """Whether `required` aligned, non-text occurrences of pattern fall within one window.
+
+    The count that matters is local. A whole-buffer total says nothing about a dump, which is
+    mostly data: what says "code" is `required` of them close enough together to be one region.
+    """
+    recent = deque(maxlen=required)
+    for offset in _codeReturnSites(buffer, pattern, alignment):
+        recent.append(offset)
+        if len(recent) == required and offset - recent[0] < WINDOW_BYTES:
+            return True
+    return False
+
+
+def _codeReturnSites(buffer, pattern, alignment):
+    """Offsets of pattern in buffer that are aligned and not sitting inside text."""
+    probes = 0
+    index = 0
+    end = len(buffer)
+    while index < end:
+        index = buffer.find(pattern, index, end)
+        if index < 0:
+            return
+        probes += 1
+        if probes > MAX_PROBES:
+            return
+        remainder = index % alignment
+        if remainder:
+            # a misaligned occurrence can never count, and neither can any position before
+            # the next aligned one, so resume the search there instead of one byte on
+            index += alignment - remainder
+            continue
+        if not looksLikeText(buffer, index):
+            yield index
+        index += alignment
 
 
 def detectUnsupportedInstructionSet(buffer):
@@ -53,11 +139,8 @@ def detectUnsupportedInstructionSet(buffer):
     Returns None for x86, AArch64 and anything else the counts cannot separate; a caller
     that already knows the instruction set should never consult this.
     """
-    required = max(MIN_RETURN_SITES, -(-len(buffer) // MAX_BYTES_PER_RETURN_SITE))
     for name, (patterns, alignment) in RETURN_SIGNATURES.items():
-        found = 0
         for pattern in patterns:
-            found += countAlignedOccurrences(buffer, pattern, alignment, limit=required - found)
-            if found >= required:
+            if hasDenseReturnRun(buffer, pattern, alignment, MIN_RETURN_SITES):
                 return name
     return None

--- a/src/smda/common/instruction_set_probe.py
+++ b/src/smda/common/instruction_set_probe.py
@@ -1,0 +1,53 @@
+"""Recognize machine code SMDA has no backend for, in a buffer with no container header.
+
+``disassembleBuffer`` defaults to intel, so a raw dump of any other instruction set is
+decoded as x86 and comes back as a full report whose every block is wrong. There is no
+header to read the instruction set from, so it is read from the code itself: each of these
+architectures is fixed-width and spells its function return one way, which makes an aligned
+count of that encoding separate them from x86 and from each other.
+
+Counts over the bundled fixtures plus a locally built x86-64/x86 corpus (72 images): every
+signature below scores at least 31 on its own architecture, and at most 3 on any other
+image in the set. The threshold sits between those, biased hard towards silence - a false
+positive turns a working x86 analysis into an error, while a false negative only leaves
+today's behaviour in place.
+"""
+
+MIN_RETURN_SITES = 16
+MAX_BYTES_PER_RETURN_SITE = 64 * 1024
+
+RETURN_SIGNATURES = {
+    "arm": ((b"\x1e\xff\x2f\xe1", b"\x0e\xf0\xa0\xe1", b"\xe1\x2f\xff\x1e", b"\xe1\xa0\xf0\x0e"), 4),
+    "mips": ((b"\x03\xe0\x00\x08", b"\x08\x00\xe0\x03"), 4),
+    "ppc": ((b"\x4e\x80\x00\x20", b"\x20\x00\x80\x4e"), 4),
+    "sparc": ((b"\x81\xc3\xe0\x08", b"\x81\xc7\xe0\x08"), 4),
+    "nios2": ((b"\x3a\x28\x00\xf8",), 4),
+    "openrisc": ((b"\x44\x00\x48\x00",), 4),
+    "sh4": ((b"\x0b\x00\x09\x00", b"\x00\x0b\x00\x09"), 2),
+    "m68k": ((b"\x4e\x5e\x4e\x75",), 2),
+    "xtensa": ((b"\x1d\xf0",), 2),
+}
+
+
+def countAlignedOccurrences(buffer, pattern, alignment):
+    """How many times pattern occurs in buffer at a multiple of alignment."""
+    found = 0
+    index = buffer.find(pattern)
+    while index >= 0:
+        if index % alignment == 0:
+            found += 1
+        index = buffer.find(pattern, index + 1)
+    return found
+
+
+def detectUnsupportedInstructionSet(buffer):
+    """Name the unsupported instruction set a raw buffer holds, or None.
+
+    Returns None for x86, AArch64 and anything else the counts cannot separate; a caller
+    that already knows the instruction set should never consult this.
+    """
+    for name, (patterns, alignment) in RETURN_SIGNATURES.items():
+        found = sum(countAlignedOccurrences(buffer, pattern, alignment) for pattern in patterns)
+        if found >= MIN_RETURN_SITES and found * MAX_BYTES_PER_RETURN_SITE >= len(buffer):
+            return name
+    return None

--- a/src/smda/common/instruction_set_probe.py
+++ b/src/smda/common/instruction_set_probe.py
@@ -29,13 +29,20 @@ RETURN_SIGNATURES = {
 }
 
 
-def countAlignedOccurrences(buffer, pattern, alignment):
-    """How many times pattern occurs in buffer at a multiple of alignment."""
+def countAlignedOccurrences(buffer, pattern, alignment, limit=None):
+    """How many times pattern occurs in buffer at a multiple of alignment.
+
+    Counting stops once limit is reached, because the caller only ever asks whether a
+    count clears a threshold. Without it a buffer that is dense in one pattern costs an
+    iteration per occurrence, which is 25 million of them for a 100 MB image.
+    """
     found = 0
     index = buffer.find(pattern)
     while index >= 0:
         if index % alignment == 0:
             found += 1
+            if limit is not None and found >= limit:
+                break
         index = buffer.find(pattern, index + 1)
     return found
 
@@ -46,8 +53,11 @@ def detectUnsupportedInstructionSet(buffer):
     Returns None for x86, AArch64 and anything else the counts cannot separate; a caller
     that already knows the instruction set should never consult this.
     """
+    required = max(MIN_RETURN_SITES, -(-len(buffer) // MAX_BYTES_PER_RETURN_SITE))
     for name, (patterns, alignment) in RETURN_SIGNATURES.items():
-        found = sum(countAlignedOccurrences(buffer, pattern, alignment) for pattern in patterns)
-        if found >= MIN_RETURN_SITES and found * MAX_BYTES_PER_RETURN_SITE >= len(buffer):
-            return name
+        found = 0
+        for pattern in patterns:
+            found += countAlignedOccurrences(buffer, pattern, alignment, limit=required - found)
+            if found >= required:
+                return name
     return None

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -5,6 +5,7 @@ import struct
 
 import lief
 
+from smda.common.analysis_budget import analysisTimeoutTripped
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.dalvik.DalvikFunctionAnalysisState import DalvikFunctionAnalysisState
 from smda.dalvik.DalvikOpcodeDecoder import (
@@ -1611,7 +1612,7 @@ class DalvikDisassembler:
         analyzed_count = 0
         known_code_offsets = set()
         for method in methods:
-            if cbAnalysisTimeout and cbAnalysisTimeout():
+            if analysisTimeoutTripped(self.disassembly, cbAnalysisTimeout):
                 break
             if not getattr(method, "has_class", False):
                 method_counts["skipped_no_class"] += 1
@@ -1644,10 +1645,10 @@ class DalvikDisassembler:
 
         # Recover code_items hidden from the method table (orphans).
         method_counts["orphans_discovered"] = 0
-        if not (cbAnalysisTimeout and cbAnalysisTimeout()):
+        if not analysisTimeoutTripped(self.disassembly, cbAnalysisTimeout):
             orphan_offsets = self._discoverOrphanCodeItems(raw_for_resolver, known_code_offsets)
             for code_offset in orphan_offsets:
-                if cbAnalysisTimeout and cbAnalysisTimeout():
+                if analysisTimeoutTripped(self.disassembly, cbAnalysisTimeout):
                     break
                 if code_offset in self.disassembly.functions:
                     continue
@@ -1670,7 +1671,7 @@ class DalvikDisassembler:
                     LOGGER.debug("Orphan code_item @0x%x rejected: %s", code_offset, exc)
 
         self.disassembly.analysis_end_ts = datetime.datetime.now(datetime.timezone.utc)
-        if cbAnalysisTimeout and cbAnalysisTimeout():
+        if analysisTimeoutTripped(self.disassembly, cbAnalysisTimeout):
             self.disassembly.analysis_timeout = True
         self._logAnalysisSummary(self.disassembly.binary_info.version, method_counts, analyzed_count)
         return self.disassembly

--- a/src/smda/intel/FunctionCandidate.py
+++ b/src/smda/intel/FunctionCandidate.py
@@ -25,6 +25,9 @@ class FunctionCandidate(_CommonFunctionCandidate):
                 return prologue_score
         return None
 
+    def isLandingPadEntry(self):
+        return self.bitness == 64 and self.bytes[:_ENDBR64_LEN] == ENDBR64_BYTES
+
     def getFunctionStartScore(self):
         if self.function_start_score is None:
             # endbr64 is a CET landing pad prefixing the real prologue, not a prologue itself:

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -63,6 +63,10 @@ _RE_PLTSEC_BLOCK = re.compile(
 _RE_PLTSEC_ENTRY = re.compile(b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?P<function>.{4})", re.DOTALL)
 
 _PDATA_ENTRY_SIZE = 12
+# items (candidates, matches or exception records) a scan steps over between budget polls, mirroring
+# _TIMEOUT_POLL_BLOCKS in the engine. A whole exception table is walked inside one call, so
+# the poll in the pass around it never comes round again while that walk is running
+_TIMEOUT_POLL_INTERVAL = 4096
 _PDATA_MIN_ENTRIES = 16
 _PDATA_SEED_ENTRIES = 4
 # A sample only finds a table if it lands inside one with a whole seed window left, so this
@@ -395,7 +399,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
     def locateReferenceCandidates(self):
         # check for potential call instructions and check if their destinations have a common function prologue
         for match_count, call_match in enumerate(re.finditer(b"\xe8", self.disassembly.binary_info.binary)):
-            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+            if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return
             if not self._passesCodeFilter(self.disassembly.binary_info.base_addr + call_match.start()):
                 continue
@@ -417,7 +421,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # also check for "jmp dword ptr <offset>", as they sometimes point to local functions (i.e. non-API)
         if self.bitness == 32:
             for match_count, match in enumerate(re.finditer(b"\xff\x25", self.disassembly.binary_info.binary)):
-                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                     return
                 function_addr = self.resolvePointerReference(match.start())
                 if not self._passesCodeFilter(function_addr):
@@ -430,7 +434,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                     self.setInitialCandidate(function_addr)
             # also check for "call dword ptr <offset>", as they sometimes point to local functions (i.e. non-API)
             for match_count, match in enumerate(re.finditer(b"\xff\x15", self.disassembly.binary_info.binary)):
-                if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+                if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                     return
                 function_addr = self.resolvePointerReference(match.start())
                 if not self._passesCodeFilter(function_addr):
@@ -447,7 +451,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         further patterns instead of each one re-discovering the timeout on its own first match."""
         binary = self.disassembly.binary_info.binary
         for match_count, prologue_match in enumerate(re.finditer(pattern, binary)):
-            if match_count % 4096 == 0 and self._candidateTimeoutTripped():
+            if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return True
             offset = prologue_match.start()
             candidate_addr = (self.disassembly.binary_info.base_addr + offset) & self.getBitMask()
@@ -605,6 +609,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         count = 0
         previous_end = 0
         while count < limit:
+            if count and count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
+                break
             record = self._readExceptionRecord(binary, size, offset, previous_end)
             if record is None:
                 break
@@ -654,6 +660,8 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             return
         LOGGER.debug("carved %d RUNTIME_FUNCTION entries at 0x%08x", table_count, table_offset)
         for index in range(table_count):
+            if index and index % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
+                return
             rva_start, rva_end, rva_unwind_info = struct.unpack_from(
                 "<III", binary, table_offset + index * _PDATA_ENTRY_SIZE
             )

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -3,7 +3,16 @@ import logging
 import re
 import struct
 
+from .definitions import stripFlatSegmentOverride
+
 LOGGER = logging.getLogger(__name__)
+
+# The walk below models `mov` and `lea` and reads every other mnemonic as harmless, which is
+# only true of instructions that write nothing. These do: the rest either overwrite their first
+# operand or write a register they never name - xchg and xadd write both, mul and div write
+# edx:eax, and a call clobbers whatever the ABI allows - so a value carried past one of them is
+# the value before it, and resolving with it names the wrong target rather than none.
+_VALUE_PRESERVING_MNEMONICS = frozenset({"cmp", "test", "push", "bt", "nop"})
 
 
 class IndirectCallAnalyzer:
@@ -127,13 +136,26 @@ class IndirectCallAnalyzer:
         for ins in reversed(block):
             if debug_logging:
                 LOGGER.debug("0x%08x: %s %s", ins[0], ins[2], ins[3])
-            if ins[2] == "mov":
+            # the anchored patterns below describe an operand with no segment override;
+            # one that carries a zero-base override names the same slot
+            operands = stripFlatSegmentOverride(ins[3])
+            mnemonic = ins[2].split(" ")[-1]
+            if (
+                ins[0] != self.current_calling_addr
+                and mnemonic not in ("mov", "lea")
+                and mnemonic not in _VALUE_PRESERVING_MNEMONICS
+            ):
+                # the walk begins at the call being resolved, which is itself a clobber; every
+                # instruction before it is not
+                LOGGER.debug("giving up at 0x%08x: %s may write %s", ins[0], mnemonic, register_name)
+                return False
+            if mnemonic == "mov":
                 # mov <reg>, <reg>
-                match1 = self.RE_MOV_REG_REG.match(ins[3])
+                match1 = self.RE_MOV_REG_REG.match(operands)
                 if match1 and match1.group("reg1") == register_name:
                     register_name = match1.group("reg2")
                 # mov <reg>, <const>
-                match2 = self.RE_MOV_REG_CONST.match(ins[3])
+                match2 = self.RE_MOV_REG_CONST.match(operands)
                 if match2:
                     registers[match2.group("reg")] = int(match2.group("val"), 16)
                     LOGGER.debug(
@@ -144,7 +166,7 @@ class IndirectCallAnalyzer:
                     if match2.group("reg") == register_name:
                         abs_value_found = True
                 # mov <reg>, dword ptr [<addr>]
-                match3 = self.RE_REG_DWORD_PTR_ADDR.match(ins[3])
+                match3 = self.RE_REG_DWORD_PTR_ADDR.match(operands)
                 if match3:
                     # Import resolvers may key APIs by the pointer slot address,
                     # so preserve known import slots instead of dereferencing them.
@@ -172,7 +194,7 @@ class IndirectCallAnalyzer:
                             if match3.group("reg") == register_name:
                                 abs_value_found = True
                 # mov <reg>, qword ptr [reg + <addr>]
-                match4 = self.RE_REG_QWORD_PTR_RIP_ADDR.match(ins[3])
+                match4 = self.RE_REG_QWORD_PTR_RIP_ADDR.match(operands)
                 if match4:
                     # rip-relative addressing already resolves the slot; the register then
                     # receives the whole qword stored there, not rip plus its low half
@@ -190,13 +212,13 @@ class IndirectCallAnalyzer:
                         )
                         if match4.group("reg") == register_name:
                             abs_value_found = True
-            elif ins[2] == "lea":
+            elif mnemonic == "lea":
                 LOGGER.debug("*checking %s %s", ins[2], ins[3])
                 # lea <reg>, dword ptr [<addr>] and lea <reg>, [<addr>]
                 # lea computes an address; the register receives the address itself, so
                 # dereferencing it here would resolve the call against the wrong target
                 for pattern in (self.RE_REG_DWORD_PTR_ADDR, self.RE_REG_ADDR):
-                    match1 = pattern.match(ins[3])
+                    match1 = pattern.match(operands)
                     if match1:
                         address = int(match1.group("addr"), 16)
                         registers[match1.group("reg")] = address

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -3,7 +3,7 @@ import logging
 import re
 import struct
 
-from .definitions import CJMP_INS, JMP_INS, stripFlatSegmentOverride
+from .definitions import CALL_INS, CJMP_INS, JMP_INS, stripFlatSegmentOverride
 
 LOGGER = logging.getLogger(__name__)
 
@@ -11,6 +11,17 @@ LOGGER = logging.getLogger(__name__)
 # known to write no general register. These write none - a branch touches rip and the flags, the
 # rest compare or read. LOOP_INS is absent deliberately: `loop` decrements rcx.
 _VALUE_PRESERVING_MNEMONICS = frozenset({"cmp", "test", "push", "bt", "nop"}) | CJMP_INS | JMP_INS
+# Vector moves whose destination is a vector register or memory. `movd`/`movq` are absent because
+# they also spell a vector-to-general move, and `movsd` because capstone spells the string
+# instruction - which writes esi and edi - with the same mnemonic as the scalar-double move.
+_VECTOR_MOVE_MNEMONICS = frozenset({"movaps", "movapd", "movups", "movupd", "movdqa", "movdqu", "movntps", "movntdq"})
+# What a call leaves alone. Every x86 convention preserves ebx, esi, edi and ebp; on x86-64 only
+# the registers both the SysV and the Microsoft ABI make callee-saved are listed, so rsi and rdi
+# stay out.
+_CALLEE_SAVED_32 = frozenset({"ebx", "esi", "edi", "ebp", "bx", "si", "di", "bp", "bl", "bh"})
+_CALLEE_SAVED_64 = frozenset({"rbx", "rbp", "ebx", "ebp", "bx", "bp", "bl", "bh", "bpl"}) | {
+    f"r1{number}{suffix}" for number in "2345" for suffix in ("", "d", "w", "b")
+}
 
 
 class IndirectCallAnalyzer:
@@ -116,6 +127,13 @@ class IndirectCallAnalyzer:
             self.processBlock(analysis_state, start_block, {}, register_name, [], block_depth)
         self.current_slot = None
 
+    def _callPreserves(self, mnemonic, register_name):
+        """Whether a call leaves `register_name` as the caller left it."""
+        if mnemonic not in CALL_INS:
+            return False
+        bitness = getattr(self.disassembly.binary_info, "bitness", 32)
+        return register_name in (_CALLEE_SAVED_64 if bitness == 64 else _CALLEE_SAVED_32)
+
     def processBlock(self, analysis_state, block, registers, register_name, processed, depth):
         if not block:
             return False
@@ -142,6 +160,8 @@ class IndirectCallAnalyzer:
                 ins[0] != self.current_calling_addr
                 and mnemonic not in ("mov", "lea")
                 and mnemonic not in _VALUE_PRESERVING_MNEMONICS
+                and mnemonic not in _VECTOR_MOVE_MNEMONICS
+                and not self._callPreserves(mnemonic, register_name)
             ):
                 # the walk begins at the call being resolved, which is itself a clobber; every
                 # instruction before it is not

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -3,16 +3,14 @@ import logging
 import re
 import struct
 
-from .definitions import stripFlatSegmentOverride
+from .definitions import CJMP_INS, JMP_INS, stripFlatSegmentOverride
 
 LOGGER = logging.getLogger(__name__)
 
-# The walk below models `mov` and `lea` and reads every other mnemonic as harmless, which is
-# only true of instructions that write nothing. These do: the rest either overwrite their first
-# operand or write a register they never name - xchg and xadd write both, mul and div write
-# edx:eax, and a call clobbers whatever the ABI allows - so a value carried past one of them is
-# the value before it, and resolving with it names the wrong target rather than none.
-_VALUE_PRESERVING_MNEMONICS = frozenset({"cmp", "test", "push", "bt", "nop"})
+# The walk models `mov` and `lea`; a value may only be carried past another mnemonic that is
+# known to write no general register. These write none - a branch touches rip and the flags, the
+# rest compare or read. LOOP_INS is absent deliberately: `loop` decrements rcx.
+_VALUE_PRESERVING_MNEMONICS = frozenset({"cmp", "test", "push", "bt", "nop"}) | CJMP_INS | JMP_INS
 
 
 class IndirectCallAnalyzer:

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -3,7 +3,7 @@ import logging
 import re
 import struct
 
-from .definitions import CALL_INS, CJMP_INS, JMP_INS, stripFlatSegmentOverride
+from .definitions import CALL_INS, CJMP_INS, JMP_INS, canonicalRegister, stripFlatSegmentOverride
 
 LOGGER = logging.getLogger(__name__)
 
@@ -134,6 +134,32 @@ class IndirectCallAnalyzer:
         bitness = getattr(self.disassembly.binary_info, "bitness", 32)
         return register_name in (_CALLEE_SAVED_64 if bitness == 64 else _CALLEE_SAVED_32)
 
+    _MODELLED_WRITE_PATTERNS = (
+        "RE_MOV_REG_REG",
+        "RE_MOV_REG_CONST",
+        "RE_REG_DWORD_PTR_ADDR",
+        "RE_REG_QWORD_PTR_RIP_ADDR",
+        "RE_REG_ADDR",
+    )
+
+    def _writesUnmodelledRegister(self, operands, register_name, registers):
+        """Whether this mov/lea writes a register the walk is reading, in a form it cannot read.
+
+        Returns True only for the tracked register, whose value the walk would otherwise take
+        from an earlier instruction. A write of some other tracked register is not a reason to
+        stop, but its recorded value is stale from here on, so it is dropped.
+        """
+        if any(getattr(self, name).match(operands) for name in self._MODELLED_WRITE_PATTERNS):
+            return False
+        destination = canonicalRegister(operands.split(",")[0])
+        if destination is None:
+            return False
+        if destination == canonicalRegister(register_name):
+            return True
+        for spelling in [name for name in registers if canonicalRegister(name) == destination]:
+            registers.pop(spelling, None)
+        return False
+
     def processBlock(self, analysis_state, block, registers, register_name, processed, depth):
         if not block:
             return False
@@ -166,6 +192,18 @@ class IndirectCallAnalyzer:
                 # the walk begins at the call being resolved, which is itself a clobber; every
                 # instruction before it is not
                 LOGGER.debug("giving up at 0x%08x: %s may write %s", ins[0], mnemonic, register_name)
+                return False
+            # mov and lea are exempted from the clobber check above because the patterns below
+            # model them - but only some of their forms. A form none of the patterns match still
+            # writes its destination, and reading past it resolves the call against whatever
+            # wrote the register earlier: a wrong answer rather than a missing one.
+            # `mov eax, dword ptr [esi]`, the vtable dispatch load, is the common case.
+            if (
+                mnemonic in ("mov", "lea")
+                and ins[0] != self.current_calling_addr
+                and self._writesUnmodelledRegister(operands, register_name, registers)
+            ):
+                LOGGER.debug("giving up at 0x%08x: unmodelled %s write of %s", ins[0], mnemonic, register_name)
                 return False
             if mnemonic == "mov":
                 # mov <reg>, <reg>

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -10,9 +10,11 @@ _DIRECT_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, dword ptr \[[^ ]+ \+ 0x[0-9a-f]+\
 _X64_LEA_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, \[rip (\+|\-) 0x[0-9a-f]+\]")
 _X64_BONUS_OFFSET_RE = re.compile(r"[a-z0-9]{2,3},.*0x[0-9a-f]+\]")
 _SCALED_INDEX_RE = re.compile(r"\[(?:[a-z][a-z0-9]{1,3} \+ )?(?P<index>[a-z][a-z0-9]{1,3})\*[1248]")
-_SIZE_PREFIX_RE = re.compile(r"^(?:byte|word|dword|qword|xmmword) ptr ")
 _IMMEDIATE_RE = re.compile(r"^(?:0x[0-9a-f]+|[0-9]+)$")
+_IDENTIFIER_RE = re.compile(r"[a-z][a-z0-9]{1,4}")
 _INDEX_COPY_MNEMONICS = frozenset({"mov", "movzx", "movsx", "movsxd", "movabs"})
+# first operand read but not written, so it redefines no index
+_INDEX_READ_ONLY_MNEMONICS = frozenset({"test", "push", "bt", "nop"})
 
 
 class JumpTableAnalyzer:
@@ -72,14 +74,37 @@ class JumpTableAnalyzer:
 
     @staticmethod
     def _operandKey(operand):
-        """A comparable name for whatever an operand reads: a register family or a memory cell."""
+        """A comparable name for whatever an operand reads: a register family or a memory cell.
+
+        A memory key keeps its size prefix. "dword ptr [rbp - 8]" and "byte ptr [rbp - 8]" name
+        overlapping storage but not the same value, so treating them as one key ties a bound to
+        an index that was never compared against it.
+        """
         operand = stripFlatSegmentOverride(operand.strip())
         register = canonicalRegister(operand)
         if register:
             return register
         if operand.startswith("[") or "ptr [" in operand:
-            return _SIZE_PREFIX_RE.sub("", operand)
+            return operand
         return None
+
+    @staticmethod
+    def _keyRegisters(key):
+        """The register families a memory key addresses through, empty for a register key."""
+        if "[" not in key:
+            return frozenset()
+        return frozenset(
+            register for register in (canonicalRegister(token) for token in _IDENTIFIER_RE.findall(key)) if register
+        )
+
+    @classmethod
+    def _invalidated(cls, tracked, destination_key):
+        """tracked with everything the write to destination_key just made stale.
+
+        A memory cell is only as stable as the registers that address it: once the base is
+        written, the same text names different storage.
+        """
+        return {key for key in tracked if key != destination_key and destination_key not in cls._keyRegisters(key)}
 
     @classmethod
     def _dispatchIndexKeys(cls, operand):
@@ -121,14 +146,22 @@ class JumpTableAnalyzer:
                     if not untied_size and self.RE_CMP_SIZE.match(operands):
                         untied_size = bound
                 continue
-            if not tracked or mnemonic not in _INDEX_COPY_MNEMONICS:
+            if not tracked or mnemonic in _INDEX_READ_ONLY_MNEMONICS:
                 continue
             destination, _, source = operands.partition(",")
             destination_key = self._operandKey(destination)
-            if destination_key is None or destination_key not in tracked:
+            if destination_key is None:
                 continue
-            tracked.discard(destination_key)
-            tracked |= self._dispatchIndexKeys(source)
+            if mnemonic in _INDEX_COPY_MNEMONICS:
+                carried = self._dispatchIndexKeys(source) if destination_key in tracked else set()
+                tracked = self._invalidated(tracked, destination_key) | carried
+                continue
+            # Anything else redefines whatever it writes, and several x86 instructions write a
+            # register they do not name first - xchg and xadd write both operands, mul and div
+            # write rdx:rax, cpuid writes four. Invalidating only the named one would leave a
+            # tie to a compare that bounds a value the dispatch never indexes with, so the tie
+            # is dropped whole and the untied scan answers instead.
+            tracked = set()
         return untied_size
 
     def _directHandler(self, jump_instruction_op_str, state, backtracked):
@@ -205,13 +238,20 @@ class JumpTableAnalyzer:
         jump_targets = set()
         jump_base = alternative_base if alternative_base else off_jumptable
         if jumptable_size and off_jumptable and self.disassembly.isAddrWithinMemoryImage(off_jumptable):
+            rebased = off_jumptable + bonus_offset - self.disassembly.binary_info.base_addr
+            # loop-invariant, so it decides the whole scan on the first entry rather than
+            # once per declared entry
+            if rebased < 0:
+                return sorted(jump_targets)
             for index in range(jumptable_size):
-                rebased = off_jumptable + bonus_offset - self.disassembly.binary_info.base_addr
-                if rebased < 0:
-                    continue
                 raw_entry_bytes = self.disassembly.getRawBytes(rebased + index * 4, 4)
+                # the read offset only grows, so a short one means the table has run off the
+                # end of the image and every later entry reads the same way. The bound is
+                # recovered from a compare against attacker-controlled bytes, so continuing
+                # here spends it as an iteration count: 0xffffffff is a four-billion-entry
+                # walk over an image that holds a few thousand.
                 if len(raw_entry_bytes) < 4:
-                    continue
+                    break
                 # relative entries are target - table_base as int32 and are negative
                 # whenever the switch bodies precede the table; unpack signed so the
                 # real offset is recovered, then mask before the bounds check (line 140
@@ -280,7 +320,15 @@ class JumpTableAnalyzer:
         ) = jump_instruction
         table_offsets = []
         off_jumptable = None
-        backtracked = state.backtrackInstructions(jump_instruction_address, 50)
+        # Every consumer of this window matches anchored operand patterns, and a segment
+        # override renders inside the operand, so the byte that makes a dispatch a notrack
+        # dispatch also hides its table base and its bound compare. Normalizing the window
+        # at its single source keeps the strip off the stored instruction, whose operand
+        # text and escaped form still describe the bytes that are there.
+        backtracked = [
+            (instr[0], instr[1], instr[2], stripFlatSegmentOverride(instr[3]), *instr[4:])
+            for instr in state.backtrackInstructions(jump_instruction_address, 50)
+        ]
         backtracked_sequence = "-".join([ins[2] for ins in backtracked[::-1]][:3])
         index_keys = self._dispatchIndexKeys(stripFlatSegmentOverride(jump_instruction_op_str))
         jumptable_size = self._findJumpTableSize(backtracked, index_keys)

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -2,13 +2,17 @@ import logging
 import re
 import struct
 
-from smda.intel.definitions import RET_INS
+from smda.intel.definitions import RET_INS, canonicalRegister, stripFlatSegmentOverride
 
 LOGGER = logging.getLogger(__name__)
 
 _DIRECT_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, dword ptr \[[^ ]+ \+ 0x[0-9a-f]+\]")
 _X64_LEA_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, \[rip (\+|\-) 0x[0-9a-f]+\]")
 _X64_BONUS_OFFSET_RE = re.compile(r"[a-z0-9]{2,3},.*0x[0-9a-f]+\]")
+_SCALED_INDEX_RE = re.compile(r"\[(?:[a-z][a-z0-9]{1,3} \+ )?(?P<index>[a-z][a-z0-9]{1,3})\*[1248]")
+_SIZE_PREFIX_RE = re.compile(r"^(?:byte|word|dword|qword|xmmword) ptr ")
+_IMMEDIATE_RE = re.compile(r"^(?:0x[0-9a-f]+|[0-9]+)$")
+_INDEX_COPY_MNEMONICS = frozenset({"mov", "movzx", "movsx", "movsxd", "movabs"})
 
 
 class JumpTableAnalyzer:
@@ -66,16 +70,66 @@ class JumpTableAnalyzer:
                 jumptables.add(table_offset)
         return jumptables
 
-    def _findJumpTableSize(self, backtracked):
-        jumptable_size = 0
+    @staticmethod
+    def _operandKey(operand):
+        """A comparable name for whatever an operand reads: a register family or a memory cell."""
+        operand = stripFlatSegmentOverride(operand.strip())
+        register = canonicalRegister(operand)
+        if register:
+            return register
+        if operand.startswith("[") or "ptr [" in operand:
+            return _SIZE_PREFIX_RE.sub("", operand)
+        return None
+
+    @classmethod
+    def _dispatchIndexKeys(cls, operand):
+        """The operand a table read takes its index from, as a one-element set.
+
+        A scaled memory operand ("[r11 + rdx*4]") indexes with its scaled register, so that
+        register is what a bound check tests; anything else reads as a whole.
+        """
+        scaled = _SCALED_INDEX_RE.search(operand)
+        if scaled:
+            key = cls._operandKey(scaled.group("index"))
+            return {key} if key else set()
+        key = cls._operandKey(operand)
+        return {key} if key else set()
+
+    def _findJumpTableSize(self, backtracked, index_keys=None):
+        """Recover the switch bound, preferring a compare against the dispatch's own index.
+
+        Walking back to the first `cmp <reg>, <imm>` finds an unrelated compare whenever one
+        sits between the real bound check and the dispatch, and misses pattern B entirely,
+        where the bound is checked against the memory cell the index is loaded from. Following
+        the index backwards through its copies answers both: the compare that bounds the table
+        is the one testing whatever the dispatch ends up indexing with.
+        """
+        tracked = set(index_keys) if index_keys else set()
+        untied_size = 0
         for instr in backtracked[::-1]:
-            if instr[2].split(" ")[-1] in RET_INS:
+            mnemonic = instr[2].split(" ")[-1]
+            if mnemonic in RET_INS:
                 break
-            if instr[2] == "cmp" and self.RE_CMP_SIZE.match(instr[3]):
-                jumptable_size = int(instr[3].split(",")[-1].strip(), base=16) + 1
-                # print("  0x%x: found potential jump table size with backtracking: 0x%x (%s %s)" % (instr[0], jumptable_size, instr[2], instr[3]))
-                break
-        return jumptable_size
+            operands = instr[3]
+            if mnemonic == "cmp":
+                left, _, right = operands.partition(",")
+                right = right.strip()
+                if _IMMEDIATE_RE.match(right):
+                    bound = int(right, 16 if right.startswith("0x") else 10) + 1
+                    if tracked and self._operandKey(left) in tracked:
+                        return bound
+                    if not untied_size and self.RE_CMP_SIZE.match(operands):
+                        untied_size = bound
+                continue
+            if not tracked or mnemonic not in _INDEX_COPY_MNEMONICS:
+                continue
+            destination, _, source = operands.partition(",")
+            destination_key = self._operandKey(destination)
+            if destination_key is None or destination_key not in tracked:
+                continue
+            tracked.discard(destination_key)
+            tracked |= self._dispatchIndexKeys(source)
+        return untied_size
 
     def _directHandler(self, jump_instruction_op_str, state, backtracked):
         register = jump_instruction_op_str.lower()
@@ -228,7 +282,8 @@ class JumpTableAnalyzer:
         off_jumptable = None
         backtracked = state.backtrackInstructions(jump_instruction_address, 50)
         backtracked_sequence = "-".join([ins[2] for ins in backtracked[::-1]][:3])
-        jumptable_size = self._findJumpTableSize(backtracked)
+        index_keys = self._dispatchIndexKeys(stripFlatSegmentOverride(jump_instruction_op_str))
+        jumptable_size = self._findJumpTableSize(backtracked, index_keys)
         # if False and jump_instruction_address:
         #     print("0x%x %s %s -> %s" % (jump_instruction_address, jump_instruction_mnemonic, jump_instruction_op_str, backtracked_sequence))
         if jump_instruction_op_str.startswith(("dword ptr [", "qword ptr [")):
@@ -245,7 +300,6 @@ class JumpTableAnalyzer:
                     jump_instruction_address=jump_instruction_address,
                 )
             elif backtracked_sequence.startswith("add-movsxd"):
-                jumptable_size = self._findJumpTableSize(backtracked)
                 off_jumptable = self._x64Handler(state, backtracked)
                 alternative_base = 0
                 if "rsi" in backtracked[::-1][0][3]:
@@ -258,13 +312,11 @@ class JumpTableAnalyzer:
                     jump_instruction_address=jump_instruction_address,
                 )
             elif backtracked_sequence.startswith(("lea", "add-add", "add-shr")):
-                jumptable_size = self._findJumpTableSize(backtracked)
                 off_jumptable = self._x64Handler(state, backtracked)
                 table_offsets = self._extractRelativeTableOffsets(
                     jumptable_size, off_jumptable, state=state, jump_instruction_address=jump_instruction_address
                 )
             elif backtracked_sequence.startswith("add-mov"):
-                jumptable_size = self._findJumpTableSize(backtracked)
                 off_jumptable = self._x64Handler(state, backtracked)
                 bonus = self._getx64BonusOffset(backtracked)
                 table_offsets = self._extractRelativeTableOffsets(

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -216,7 +216,7 @@ class JumpTableAnalyzer:
                 if raw_entry_bytes is None or len(raw_entry_bytes) < 4:
                     break
                 entry = struct.unpack("<I", raw_entry_bytes)[0]
-                if not self.disassembly.isAddrWithinMemoryImage(entry):
+                if not entry or not self.disassembly.isAddrWithinMemoryImage(entry):
                     if bound_was_recovered:
                         continue
                     break
@@ -295,13 +295,13 @@ class JumpTableAnalyzer:
         else:
             LOGGER.warning("Unsupported %s-bit jump table analysis", bitness)
             return jumptable_addresses
-        if self.disassembly.isAddrWithinMemoryImage(jumptable_address):
+        if jumptable_address and self.disassembly.isAddrWithinMemoryImage(jumptable_address):
             for i in range(jumptable_size):
                 raw_entry_bytes = self.disassembly.getBytes(jumptable_address + i * entry_size, entry_size)
                 if raw_entry_bytes is None or len(raw_entry_bytes) < entry_size:
                     break
                 table_entry = struct.unpack(entry_format, raw_entry_bytes)[0]
-                if not self.disassembly.isAddrWithinMemoryImage(table_entry):
+                if not table_entry or not self.disassembly.isAddrWithinMemoryImage(table_entry):
                     break
                 state.addDataRef(
                     jump_instruction_address,

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -208,10 +208,15 @@ class X86Backend(ArchBackend):
             if i_op_str.startswith("dword ptr [0x"):
                 # case = "DWORD-PTR"
                 dereferenced = d.disassembly.dereferenceDword(call_destination)
-                if dereferenced is not None:
+                if dereferenced and d.disassembly.isAddrWithinMemoryImage(dereferenced):
                     state.addCodeRef(i_address, dereferenced)
                     d._handleCallTarget(state, i_address, dereferenced)
                     d._handleApiTarget(i_address, call_destination, dereferenced, slot=call_destination)
+                else:
+                    # import-like case: keep the reference on the slot itself
+                    state.addCodeRef(i_address, call_destination)
+                    if dereferenced is not None:
+                        d._handleApiTarget(i_address, call_destination, dereferenced, slot=call_destination)
             else:
                 # case = "DWORD-PTR-REG"
                 self._collectMemRegSlot(state, i_address, i_op_str)
@@ -219,7 +224,7 @@ class X86Backend(ArchBackend):
             rip = i_address + i_size
             call_destination = rip + d.getReferencedAddr(i_op_str)
             dereferenced = d.disassembly.dereferenceQword(call_destination)
-            if dereferenced is not None and d.disassembly.isAddrWithinMemoryImage(dereferenced):
+            if dereferenced and d.disassembly.isAddrWithinMemoryImage(dereferenced):
                 # the slot holds an in-image target (thunk/local function): book the call
                 # against the real destination, like the 32-bit dword-ptr path does
                 state.addCodeRef(i_address, dereferenced)

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -19,6 +19,7 @@ from .definitions import (
     REGS_32BIT,
     REGS_64BIT,
     RET_INS,
+    stripFlatSegmentOverride,
 )
 from .FunctionAnalysisState import FunctionAnalysisState
 from .FunctionCandidateManager import FunctionCandidateManager
@@ -171,6 +172,7 @@ class X86Backend(ArchBackend):
                 continue
             if mnemonic != "jmp":
                 return None
+            op_str = stripFlatSegmentOverride(op_str)
             if op_str.startswith("qword ptr [rip"):
                 return address + size + d.getReferencedAddr(op_str)
             if op_str.startswith("dword ptr [0x"):
@@ -194,6 +196,7 @@ class X86Backend(ArchBackend):
         # segment selector. There is no in-image target to book, so drop it like _analyzeJmp.
         if i_mnemonic.split(" ")[-1] == "lcall":
             return
+        i_op_str = stripFlatSegmentOverride(i_op_str)
         call_destination = d.getReferencedAddr(i_op_str)
         if i_op_str.startswith("dword ptr ["):
             if i_op_str.startswith("dword ptr [0x"):
@@ -311,9 +314,11 @@ class X86Backend(ArchBackend):
 
     def _analyzeJmpInstruction(self, d, i, state):
         i_address, i_size, i_mnemonic, i_op_str = i
+        i_op_str = stripFlatSegmentOverride(i_op_str)
+        i = (i_address, i_size, i_mnemonic, i_op_str)
         # case = "FALLTHROUGH"
         if ":" in i_op_str:
-            # case = "LONG-JMP"
+            # case = "LONG-JMP", or an fs:/gs: operand whose base is not in the image
             pass
         elif i_op_str.startswith("dword ptr [0x"):
             # case = "DWORD-PTR"

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -489,7 +489,7 @@ class X86Backend(ArchBackend):
                 )
             if previous_address is not None and previous_mnemonic == "push":
                 push_ret_destination = d.getReferencedAddr(previous_instruction[3].strip())
-                if d.disassembly.isAddrWithinMemoryImage(push_ret_destination):
+                if push_ret_destination and d.disassembly.isAddrWithinMemoryImage(push_ret_destination):
                     LOGGER.debug(
                         "  analyzeFunction() found push-return jump obfuscation: @0x%08x",
                         i_address,

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -197,6 +197,12 @@ class X86Backend(ArchBackend):
         if i_mnemonic.split(" ")[-1] == "lcall":
             return
         i_op_str = stripFlatSegmentOverride(i_op_str)
+        # case = "LONG-CALL-INDIRECT": FF /3 loads a seg:offset pair from memory. capstone
+        # renders it with a bare "ptr " where a near indirect call (FF /2) always names its
+        # width, and that is the only difference between them once a segment override is
+        # normalized away. No arm below claims it today; saying so keeps it that way.
+        if i_op_str.startswith("ptr "):
+            return
         call_destination = d.getReferencedAddr(i_op_str)
         if i_op_str.startswith("dword ptr ["):
             if i_op_str.startswith("dword ptr [0x"):
@@ -257,6 +263,7 @@ class X86Backend(ArchBackend):
         for i_address, i_size, i_mnemonic, i_op_str, _ in state.instructions:
             if i_mnemonic.split(" ")[-1] != "mov":
                 continue
+            i_op_str = stripFlatSegmentOverride(i_op_str)
             match = IMPORT_SLOT_LOAD_RE.match(i_op_str)
             if match is None:
                 continue
@@ -317,8 +324,12 @@ class X86Backend(ArchBackend):
         i_op_str = stripFlatSegmentOverride(i_op_str)
         i = (i_address, i_size, i_mnemonic, i_op_str)
         # case = "FALLTHROUGH"
-        if ":" in i_op_str:
-            # case = "LONG-JMP", or an fs:/gs: operand whose base is not in the image
+        if i_op_str.startswith("ptr ") or ":" in i_op_str:
+            # case = "LONG-JMP": a far branch names a segment and an offset, so it reaches no
+            # address in this image. The direct form (ljmp) holds a colon; the indirect form
+            # (FF /5) is told from a near indirect branch by the missing width - capstone
+            # renders "ptr [0x402000]" where a near one renders "dword ptr [0x402000]".
+            # Also the arm for an fs:/gs: operand whose base is not in the image.
             pass
         elif i_op_str.startswith("dword ptr [0x"):
             # case = "DWORD-PTR"

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -1,3 +1,19 @@
+import re
+
+FLAT_SEGMENT_OVERRIDE_RE = re.compile(r"\b(?:cs|ds|es|ss):")
+
+
+def stripFlatSegmentOverride(op_str):
+    """Return op_str without a zero-base segment override, leaving fs:/gs: in place.
+
+    CS/DS/ES/SS have a zero base in 64-bit long mode and in the 32-bit flat model every
+    supported container uses, so such an operand is an ordinary image address once the
+    override is gone. FS/GS carry a thread-local base that is not in the image, so their
+    operands stay unresolvable and keep the prefix that marks them so.
+    """
+    return FLAT_SEGMENT_OVERRIDE_RE.sub("", op_str, count=1)
+
+
 # some mnemonics as specific to capstone
 # (frozensets: membership-tested per instruction on the analysis hot path)
 CJMP_INS = frozenset(
@@ -70,6 +86,40 @@ REGS_64BIT = frozenset(
     }
 )
 DOUBLE_ZERO = bytearray(b"\x00\x00")
+
+
+def _buildRegisterAliases():
+    aliases = {}
+    for spellings in (
+        ("rax", "eax", "ax", "ah", "al"),
+        ("rbx", "ebx", "bx", "bh", "bl"),
+        ("rcx", "ecx", "cx", "ch", "cl"),
+        ("rdx", "edx", "dx", "dh", "dl"),
+        ("rsi", "esi", "si", "sil"),
+        ("rdi", "edi", "di", "dil"),
+        ("rbp", "ebp", "bp", "bpl"),
+        ("rsp", "esp", "sp", "spl"),
+    ):
+        for spelling in spellings:
+            aliases[spelling] = spellings[0]
+    for number in range(8, 16):
+        wide = f"r{number}"
+        for suffix in ("", "d", "w", "b"):
+            aliases[wide + suffix] = wide
+    return aliases
+
+
+REGISTER_ALIASES = _buildRegisterAliases()
+
+
+def canonicalRegister(name):
+    """Map any spelling of a general-purpose register to its widest name, or None.
+
+    "al", "ax" and "eax" all name parts of "rax", so a value written through one is
+    readable through the others and a def-use chase has to treat them as one register.
+    """
+    return REGISTER_ALIASES.get(name.strip().lower())
+
 
 DEFAULT_PROLOGUES = [
     b"\x8b\xff\x55\x8b\xec",

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -131,12 +131,14 @@ def _build_aarch64_elf(code, base=0x400000, vaddr=0x401000):
     return ehdr + phdr + code + shstrtab + section_headers
 
 
-def _build_aarch64_elf_with_init_array(text, init_pointers, base=0x400000, text_va=0x401000):
+def _build_aarch64_elf_with_init_array(text, init_pointers, base=0x400000, text_va=0x401000, declared_init_size=None):
     """ELF64/AArch64 object carrying an .init_array of function pointers.
 
     Builds a section header table (.text exec + .init_array + .shstrtab) plus a
     single covering PT_LOAD, so the loader exposes sections and the candidate
-    manager can read the .init_array entries.
+    manager can read the .init_array entries. `declared_init_size` overrides the
+    section header's sh_size without changing the bytes actually present, which is
+    how a damaged or hostile container describes an extent the image does not hold.
     """
     em_aarch64, ehsize, phentsize, shentsize = 183, 64, 56, 64
     shstrtab = b"\x00.text\x00.init_array\x00.shstrtab\x00"
@@ -176,7 +178,16 @@ def _build_aarch64_elf_with_init_array(text, init_pointers, base=0x400000, text_
     section_headers = (
         shdr(0, 0, 0, 0, 0, 0, 0, 0)  # SHT_NULL
         + shdr(name_text, 1, 0x6, text_va, text_off, len(text), 4, 0)  # PROGBITS, ALLOC|EXECINSTR
-        + shdr(name_init, 14, 0x3, init_va, init_off, len(init_data), 8, 8)  # INIT_ARRAY, ALLOC|WRITE
+        + shdr(  # INIT_ARRAY, ALLOC|WRITE
+            name_init,
+            14,
+            0x3,
+            init_va,
+            init_off,
+            len(init_data) if declared_init_size is None else declared_init_size,
+            8,
+            8,
+        )
         + shdr(name_str, 3, 0, 0, shstr_off, len(shstrtab), 1, 0)  # STRTAB
     )
     return ehdr + phdr + text + init_data + shstrtab + section_headers
@@ -1118,6 +1129,97 @@ class TestAArch64DataPointerRecovery(unittest.TestCase):
         self.assertEqual(report.status, "ok")
         self.assertIsNotNone(report.getFunction(text_va))
         self.assertIsNotNone(report.getFunction(ctor_va))
+
+
+class TestAArch64DataPointerScanExtent(unittest.TestCase):
+    """A section header describes an extent; the mapped image decides what can be read.
+
+    The stored-pointer scan strides over the declared extent, and every address outside the
+    image reads back None, so a section claiming a gigabyte of pointers costs a hundred
+    million iterations to produce nothing. The timeout is not the bound that matters here -
+    the scan does poll it - but spending the whole budget on addresses that cannot match
+    returns an empty function set for an image that analyses in milliseconds. A memory dump
+    is where this arrives: the bytes parse as an ELF while the section table describes the
+    file the dump was taken from, not the region captured.
+    """
+
+    BASE = 0x400000
+    TEXT_VA = BASE + 0x78  # section VAs equal file offsets, as in a dump of the whole image
+    DECLARED_INIT_SIZE = 0x40000000
+    # 36 reads cover the clamped scan and everything else candidate discovery does here;
+    # the scan over the declared extent alone would be DECLARED_INIT_SIZE // 8 of them
+    READ_BUDGET = 1000
+
+    class _TooManyReads(AssertionError):
+        pass
+
+    def _blob(self, declared_init_size=None):
+        text = b"".join(
+            w.to_bytes(4, "little")
+            for w in [
+                0xA9BF7BFD,  # main: stp x29, x30, [sp, #-16]!
+                0x52800000,  #       mov w0, #0
+                0xA8C17BFD,  #       ldp x29, x30, [sp], #16
+                0xD65F03C0,  #       ret
+                0xD2800020,  # ctor: mov x0, #1   (no prologue, no BL target)
+                0xD65F03C0,  #       ret
+                0xD503201F,  #       nop
+                0xD503201F,  #       nop
+            ]
+        )
+        return _build_aarch64_elf_with_init_array(
+            text,
+            [self.TEXT_VA + 0x10],
+            base=self.BASE,
+            text_va=self.TEXT_VA,
+            declared_init_size=declared_init_size,
+        )
+
+    def _candidates(self, blob, read_budget=READ_BUDGET):
+        binary_info = BinaryInfo(blob)
+        binary_info.base_addr = self.BASE
+        binary_info.bitness = 64
+        binary_info.architecture = "aarch64"
+        disassembly = DisassemblyResult()
+        disassembly.setBinaryInfo(binary_info)
+
+        reads = {"n": 0}
+        underlying = disassembly.getBytes
+        too_many = self._TooManyReads
+
+        def counted(addr, num_bytes):
+            reads["n"] += 1
+            if reads["n"] > read_budget:
+                raise too_many(f"the scan read past {read_budget} addresses")
+            return underlying(addr, num_bytes)
+
+        disassembly.getBytes = counted
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        manager = FunctionCandidateManager(config)
+        manager.init(disassembly, None)
+        return set(manager.candidates)
+
+    def test_a_section_claiming_more_than_the_image_is_not_scanned_past_it(self):
+        candidates = self._candidates(self._blob(declared_init_size=self.DECLARED_INIT_SIZE))
+
+        self.assertIn(self.TEXT_VA + 0x10, candidates)
+
+    def test_an_honestly_sized_section_finds_the_same_pointer(self):
+        """Positive control: the pointer is found because the scan still covers the bytes
+        that are there, not because the clamp turned the scan off."""
+        self.assertIn(self.TEXT_VA + 0x10, self._candidates(self._blob()))
+
+    def test_a_section_declaring_no_pointers_leaves_the_target_unfound(self):
+        """Negative control: the stored pointer is the only evidence for that address, so
+        the two cases above are reporting the scan rather than the prologue or gap pass."""
+        self.assertNotIn(self.TEXT_VA + 0x10, self._candidates(self._blob(declared_init_size=0)))
+
+    def test_the_read_counter_the_other_cases_rely_on_does_fire(self):
+        """Instrument control: without this, a counter that was never consulted would make
+        every case above pass regardless of how far the scan ran."""
+        with self.assertRaises(self._TooManyReads):
+            self._candidates(self._blob(), read_budget=0)
 
 
 class TestAArch64StringExtraction(unittest.TestCase):

--- a/tests/testAArch64MachoMetadataCandidates.py
+++ b/tests/testAArch64MachoMetadataCandidates.py
@@ -14,6 +14,7 @@ the metadata scan (a zero corpus delta says nothing about it).
 
 import struct
 import unittest
+from types import SimpleNamespace
 
 from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
 from smda.Disassembler import Disassembler
@@ -259,6 +260,71 @@ class MachoAddressRefCandidateTestSuite(unittest.TestCase):
             self.assertIn(target, fcm.candidates)
             # weak address evidence: no inbound call references were recorded
             self.assertEqual(fcm.candidates[target].call_ref_sources, set())
+
+
+class MachoMetadataSlotExtentTestSuite(unittest.TestCase):
+    """A section header declares an extent; the mapped image decides what can be read. Striding
+    over a damaged `section.size` only spends the analysis budget, so the walk is clamped - but a
+    slot a rebase names still resolves outside the image, so those are kept."""
+
+    BASE = 0x100000000
+    IMAGE = 0x4000
+    SECTION = 0x1000
+
+    def _manager(self):
+        binary_info = SimpleNamespace(base_addr=self.BASE, binary_size=self.IMAGE)
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info)
+        return manager
+
+    def _slots(self, declared_size, stride=8, rebases=(), adjustment=0):
+        section = SimpleNamespace(virtual_address=self.BASE + self.SECTION, size=declared_size)
+        return list(self._manager()._machoMetadataSlots(section, stride, adjustment, rebases))
+
+    def test_a_section_claiming_more_than_the_image_stops_at_the_image(self):
+        slots = self._slots(0x40000000)
+
+        self.assertEqual(slots[0], self.BASE + self.SECTION)
+        self.assertLess(slots[-1], self.BASE + self.IMAGE)
+        self.assertEqual(len(slots), (self.IMAGE - self.SECTION) // 8)
+
+    def test_an_honestly_sized_section_yields_every_slot(self):
+        """Positive control: the clamp only removes what the image does not hold, so a section
+        that fits is walked in full."""
+        self.assertEqual(self._slots(0x80), [self.BASE + self.SECTION + i * 8 for i in range(16)])
+
+    def test_a_rebased_slot_beyond_the_image_is_still_yielded(self):
+        """The clamp is for cost, not for meaning: a stored pointer outside the mapped image
+        reads back None, but one a rebase names resolves from the fixup table instead."""
+        rebased = self.BASE + self.IMAGE + 0x40
+
+        self.assertIn(rebased, self._slots(0x40000000, rebases={rebased: 0}))
+
+    def test_a_section_starting_below_the_image_resumes_on_the_stride(self):
+        """A section can also be declared to start before the mapped image. The walk resumes at
+        the first slot at or after the image that the declared extent's own stride would have
+        visited, so the same addresses are seen - never a shifted lattice."""
+        section = SimpleNamespace(virtual_address=self.BASE - 0x100, size=0x400)
+        slots = list(self._manager()._machoMetadataSlots(section, 8, 0, ()))
+
+        self.assertEqual(slots[0], self.BASE)
+        self.assertTrue(all((slot - section.virtual_address) % 8 == 0 for slot in slots))
+
+    def test_a_section_starting_below_the_image_keeps_an_odd_phase(self):
+        """Positive control for the phase: a start that is not a multiple of the stride must keep
+        its own offset rather than snapping to the image boundary."""
+        section = SimpleNamespace(virtual_address=self.BASE - 0x104, size=0x400)
+        slots = list(self._manager()._machoMetadataSlots(section, 8, 0, ()))
+
+        self.assertEqual(slots[0], self.BASE + 4)
+        self.assertTrue(all((slot - section.virtual_address) % 8 == 0 for slot in slots))
+
+    def test_a_rebased_slot_off_the_stride_is_not_yielded(self):
+        """Second control: the union keeps the lattice the declared extent set, so it cannot
+        invent a slot the unclamped walk would never have visited."""
+        rebased = self.BASE + self.IMAGE + 0x44
+
+        self.assertNotIn(rebased, self._slots(0x40000000, rebases={rebased: 0}))
 
 
 if __name__ == "__main__":

--- a/tests/testAArch64PdataCarving.py
+++ b/tests/testAArch64PdataCarving.py
@@ -1,7 +1,17 @@
 import struct
+import traceback
 import unittest
+from pathlib import Path
+from unittest import mock
 
-from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+import smda.aarch64.FunctionCandidateManager as arm64_candidates
+from smda.aarch64.FunctionCandidateManager import (
+    _ARM64_PDATA_ENTRY_SIZE,
+    _ARM64_PDATA_MIN_ENTRIES,
+    _ARM64_PDATA_SAMPLE_STRIDE,
+    _ARM64_PDATA_SEED_ENTRIES,
+    FunctionCandidateManager,
+)
 from smda.common.BinaryInfo import BinaryInfo
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
@@ -101,6 +111,123 @@ class Arm64ExceptionRecordCarvingTestSuite(unittest.TestCase):
         image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, records=8)
 
         self.assertEqual(_exceptionCandidates(_candidateManager(image)), set())
+
+
+class Arm64SamplingStrideTestSuite(unittest.TestCase):
+    def test_the_stride_cannot_step_over_a_qualifying_table(self):
+        """The scan samples every _ARM64_PDATA_SAMPLE_STRIDE bytes and needs
+        _ARM64_PDATA_SEED_ENTRIES consecutive records from wherever it lands, so a table at
+        an arbitrary offset is only reachable while the stride fits inside what a shortest
+        qualifying table leaves after the seed run. Widening the stride, or raising the seed
+        length without raising the minimum, silently stops carving short tables."""
+        reachable = (_ARM64_PDATA_MIN_ENTRIES - _ARM64_PDATA_SEED_ENTRIES) * _ARM64_PDATA_ENTRY_SIZE
+
+        self.assertLessEqual(_ARM64_PDATA_SAMPLE_STRIDE, reachable)
+
+
+class Arm64CarveBudgetTestSuite(unittest.TestCase):
+    """A buffer that looks like one enormous exception table keeps the record walk inside a
+    single call, where the sampling loop's own poll never comes round again."""
+
+    POLL_INTERVAL = 4096
+
+    def _longTable(self, records):
+        size = 0x2000 + records * _ARM64_PDATA_ENTRY_SIZE + 0x1000
+        image = bytearray(size)
+        for index in range(records):
+            struct.pack_into("<II", image, 0x2000 + index * _ARM64_PDATA_ENTRY_SIZE, 4 + index * 4, PACKED_UNWIND)
+        return bytes(image)
+
+    def test_the_record_walk_gives_up_when_the_budget_is_spent(self):
+        image = self._longTable(self.POLL_INTERVAL * 2)
+        manager = _candidateManager(_mappedImage((FRAME_PROLOGUE, RET), stride=8)[0])
+        manager._cb_analysis_timeout = lambda: True
+
+        counted = manager._countArm64ExceptionRecords(image, len(image), 0x2000, len(image))
+
+        self.assertEqual(counted, self.POLL_INTERVAL)
+
+    def test_the_same_walk_completes_within_budget(self):
+        """Positive control: with the budget intact the walk counts every record, so the stop
+        above is the poll rather than the records failing validation."""
+        image = self._longTable(self.POLL_INTERVAL * 2)
+        manager = _candidateManager(_mappedImage((FRAME_PROLOGUE, RET), stride=8)[0])
+        manager._cb_analysis_timeout = None
+
+        counted = manager._countArm64ExceptionRecords(image, len(image), 0x2000, len(image))
+
+        self.assertEqual(counted, self.POLL_INTERVAL * 2)
+
+    def test_the_admit_loop_gives_up_when_the_budget_is_spent(self):
+        """The budget is intact while the table is being located and spent afterwards.
+
+        Answering "spent" throughout would stop the locate instead, and the admit loop this
+        is about would never run - the test would pass while proving nothing.
+        """
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, records=64)
+        manager = _candidateManager(image)
+        manager.candidates = {}
+        manager._cb_analysis_timeout = lambda: (
+            not any(frame.name == "_locateArm64ExceptionRecordTable" for frame in traceback.extract_stack())
+        )
+
+        with mock.patch.object(arm64_candidates, "_TIMEOUT_POLL_INTERVAL", 4):
+            manager._carveArm64ExceptionRecords(IMAGE_BASE)
+
+        self.assertEqual(len(_exceptionCandidates(manager)), 4)
+
+    def test_the_admit_loop_takes_every_record_within_budget(self):
+        """Positive control for the loop itself: the same table admits all 64 when nothing
+        stops it, so the count above is the poll and not the table being short."""
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, records=64)
+        manager = _candidateManager(image)
+        manager.candidates = {}
+        manager._cb_analysis_timeout = None
+
+        with mock.patch.object(arm64_candidates, "_TIMEOUT_POLL_INTERVAL", 4):
+            manager._carveArm64ExceptionRecords(IMAGE_BASE)
+
+        self.assertEqual(len(_exceptionCandidates(manager)), 64)
+
+
+class Arm64CarveFalsePositiveTestSuite(unittest.TestCase):
+    """The validator's bar is only meaningful if real AArch64 code and data does not clear it."""
+
+    def test_real_aarch64_code_is_not_mistaken_for_an_exception_table(self):
+        fixture = Path(__file__).resolve().parent / "aarch64_static_xored"
+        raw = bytes(byte ^ (index % 256) for index, byte in enumerate(fixture.read_bytes()))
+        manager = _candidateManager(raw)
+
+        self.assertEqual(manager._locateArm64ExceptionRecordTable(raw), (0, 0))
+        self.assertEqual(_exceptionCandidates(manager), set())
+
+    def test_no_bundled_non_arm64_image_holds_a_qualifying_table(self):
+        """Measured more widely than this: over 2961 files (the bundled fixtures, 50 locally
+        built x86 binaries and the system libraries on one machine) the scan located a
+        qualifying run in 51, all of them x86, and the entry-shape gate admitted a candidate
+        from none of them. Those files also all carry a section table, so the carve - which
+        only runs on a headerless image - never reaches them at all."""
+        for name in ("mirai_x64_xored", "mirai_i386_xored", "cutwail_xored", "rust_pe_gnu_xored"):
+            with self.subTest(fixture=name):
+                fixture = Path(__file__).resolve().parent / name
+                raw = bytes(byte ^ (index % 256) for index, byte in enumerate(fixture.read_bytes()))
+                manager = FunctionCandidateManager(_config())
+                manager.disassembly = None
+                manager._cb_analysis_timeout = None
+
+                self.assertEqual(manager._locateArm64ExceptionRecordTable(raw), (0, 0))
+
+    def test_the_same_buffer_with_a_planted_table_is_carved(self):
+        """Positive control: the fixture is not simply too small or unreadable for the carve."""
+        fixture = Path(__file__).resolve().parent / "aarch64_static_xored"
+        raw = bytearray(byte ^ (index % 256) for index, byte in enumerate(fixture.read_bytes()))
+        planted_at = len(raw) - RECORDS * _ARM64_PDATA_ENTRY_SIZE - 0x100
+        for index in range(RECORDS):
+            struct.pack_into("<II", raw, planted_at + index * _ARM64_PDATA_ENTRY_SIZE, 4 + index * 4, PACKED_UNWIND)
+
+        offset, count = _candidateManager(bytes(raw))._locateArm64ExceptionRecordTable(bytes(raw))
+
+        self.assertEqual((offset, count), (planted_at, RECORDS))
 
 
 class Arm64ExceptionRecordValidationTestSuite(unittest.TestCase):

--- a/tests/testAArch64PdataCarving.py
+++ b/tests/testAArch64PdataCarving.py
@@ -29,6 +29,7 @@ MOVZ_X16 = 0xD2800010 | (0x1234 << 5)  # movz x16, #0x1234
 BR_X16 = 0xD61F0200
 UNDEFINED = 0x00000000
 PACKED_UNWIND = 0x01 | (2 << 2)  # flag 1, FunctionLength 2 words
+PACKED_FRAGMENT = 0x02 | (2 << 2)  # flag 2, FunctionLength 2 words
 
 
 def _config(**overrides):
@@ -111,6 +112,34 @@ class Arm64ExceptionRecordCarvingTestSuite(unittest.TestCase):
         image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, records=8)
 
         self.assertEqual(_exceptionCandidates(_candidateManager(image)), set())
+
+
+class Arm64CarvedFragmentRecordTestSuite(unittest.TestCase):
+    """A packed fragment continues another function's body, so its begin address is a mid-body
+    word rather than a function start. The parsed exception-directory path skips flag 2 for
+    that reason; the carve read the begin address alone and admitted it whenever the word it
+    names happened to read as an entry."""
+
+    FRAGMENT_INDEX = 5
+
+    def _carved(self, unwind_data):
+        image, starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8)
+        patched = bytearray(image)
+        struct.pack_into("<I", patched, PDATA_RVA + self.FRAGMENT_INDEX * _ARM64_PDATA_ENTRY_SIZE + 4, unwind_data)
+        return _exceptionCandidates(_candidateManager(bytes(patched))), starts
+
+    def test_a_packed_fragment_record_is_not_admitted(self):
+        carved, starts = self._carved(PACKED_FRAGMENT)
+
+        self.assertEqual(carved, set(starts) - {starts[self.FRAGMENT_INDEX]})
+
+    def test_the_same_record_is_admitted_when_it_names_a_whole_function(self):
+        """Positive control: only the two flag bits differ, so the address dropped above is
+        dropped for the flag and not because the record stopped validating or the word it
+        names stopped reading as an entry."""
+        carved, starts = self._carved(PACKED_UNWIND)
+
+        self.assertEqual(carved, set(starts))
 
 
 class Arm64SamplingStrideTestSuite(unittest.TestCase):

--- a/tests/testAArch64PdataCarving.py
+++ b/tests/testAArch64PdataCarving.py
@@ -1,0 +1,249 @@
+import struct
+import unittest
+
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+from smda.common.BinaryInfo import BinaryInfo
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
+
+IMAGE_BASE = 0x180000000
+TEXT_RVA = 0x1000
+PDATA_RVA = 0x4000
+IMAGE_SIZE = 0x8000
+RECORDS = 24
+
+FRAME_PROLOGUE = 0xA9BF7BFD  # stp x29, x30, [sp, #-16]!
+RET = 0xD65F03C0
+MOVZ_X16 = 0xD2800010 | (0x1234 << 5)  # movz x16, #0x1234
+BR_X16 = 0xD61F0200
+UNDEFINED = 0x00000000
+PACKED_UNWIND = 0x01 | (2 << 2)  # flag 1, FunctionLength 2 words
+
+
+def _config(**overrides):
+    config = SmdaConfig()
+    config.CALCULATE_HASHING = False
+    config.CALCULATE_SCC = False
+    config.CALCULATE_NESTING = False
+    config.TIMEOUT = 0
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _mappedImage(entries, stride, records=RECORDS, pdata_rva=PDATA_RVA, size=IMAGE_SIZE):
+    """A mapped ARM64 image with no container header, as a memory dump of one would be."""
+    image = bytearray(size)
+    body = b"".join(struct.pack("<" + "I" * len(entries), *entries) for _ in range(records))
+    image[TEXT_RVA : TEXT_RVA + len(body)] = body
+    pdata = b"".join(struct.pack("<II", TEXT_RVA + stride * i, PACKED_UNWIND) for i in range(records))
+    image[pdata_rva : pdata_rva + len(pdata)] = pdata
+    return bytes(image), [IMAGE_BASE + TEXT_RVA + stride * i for i in range(records)]
+
+
+def _candidateManager(image):
+    binary_info = BinaryInfo(image)
+    binary_info.base_addr = IMAGE_BASE
+    binary_info.bitness = 64
+    binary_info.is_buffer = True
+    binary_info.architecture = "aarch64"
+    disassembly = DisassemblyResult()
+    disassembly.setBinaryInfo(binary_info)
+    manager = FunctionCandidateManager(_config())
+    manager.init(disassembly, None)
+    return manager
+
+
+def _exceptionCandidates(manager):
+    # entry-shaped words are also picked up by the prologue scanner, so membership in
+    # candidates alone cannot show that the exception path ran
+    return {addr for addr, candidate in manager.candidates.items() if candidate.is_exception_handler}
+
+
+class Arm64ExceptionRecordCarvingTestSuite(unittest.TestCase):
+    """A memory image keeps the mapped code but usually not a parseable header, so the
+    exception directory cannot be read from a data directory and has to be found in the bytes.
+    The x64 side has carved its RUNTIME_FUNCTION table since 4.4.7; ARM64 did not."""
+
+    def test_records_are_recovered_from_a_headerless_image(self):
+        image, starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8)
+
+        self.assertEqual(_exceptionCandidates(_candidateManager(image)), set(starts))
+
+    def test_nothing_is_carved_when_the_source_is_disabled(self):
+        """Positive control: the candidates above come from the exception path, not from the
+        prologue scan happening to flag the same words."""
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8)
+        binary_info = BinaryInfo(image)
+        binary_info.base_addr = IMAGE_BASE
+        binary_info.bitness = 64
+        binary_info.is_buffer = True
+        binary_info.architecture = "aarch64"
+        disassembly = DisassemblyResult()
+        disassembly.setBinaryInfo(binary_info)
+        manager = FunctionCandidateManager(_config(USE_PE_ARM64_PDATA_CANDIDATES=False))
+        manager.init(disassembly, None)
+
+        self.assertEqual(_exceptionCandidates(manager), set())
+
+    def test_thunk_entries_are_recovered_that_nothing_else_reaches(self):
+        """A two-word veneer separated by an undefined word is reachable neither by the
+        prologue scan nor by a linear sweep, so the exception records are the only evidence
+        it is a function at all."""
+        image, starts = _mappedImage((MOVZ_X16, BR_X16, UNDEFINED), stride=12)
+        report = Disassembler(config=_config()).disassembleBuffer(image, IMAGE_BASE, bitness=64, architecture="aarch64")
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual({function.offset for function in report.getFunctions()}, set(starts))
+
+    def test_a_table_shorter_than_the_minimum_run_is_not_carved(self):
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, records=8)
+
+        self.assertEqual(_exceptionCandidates(_candidateManager(image)), set())
+
+
+class Arm64ExceptionRecordValidationTestSuite(unittest.TestCase):
+    def _manager(self):
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8)
+        return _candidateManager(image), image
+
+    def test_a_well_formed_record_reads_back(self):
+        manager, image = self._manager()
+
+        self.assertEqual(
+            manager._readArm64ExceptionRecord(image, len(image), PDATA_RVA, 0),
+            (TEXT_RVA, PACKED_UNWIND),
+        )
+
+    def test_records_that_do_not_advance_are_rejected(self):
+        manager, image = self._manager()
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(image, len(image), PDATA_RVA, TEXT_RVA))
+
+    def test_a_reserved_unwind_flag_is_rejected(self):
+        manager, image = self._manager()
+        record = bytearray(image)
+        struct.pack_into("<II", record, PDATA_RVA, TEXT_RVA, 0x3)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(bytes(record), len(record), PDATA_RVA, 0))
+
+    def test_a_misaligned_begin_address_is_rejected(self):
+        manager, _image = self._manager()
+        record = struct.pack("<II", TEXT_RVA + 1, PACKED_UNWIND)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(record, 0x8000, 0, 0))
+
+    def test_a_zero_begin_address_is_rejected(self):
+        manager, _image = self._manager()
+        record = struct.pack("<II", 0, PACKED_UNWIND)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(record, 0x8000, 0, 0))
+
+    def test_a_packed_record_of_zero_length_is_rejected(self):
+        manager, _image = self._manager()
+        record = struct.pack("<II", TEXT_RVA, 0x1)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(record, 0x8000, 0, 0))
+
+    def test_a_truncated_record_is_rejected(self):
+        manager, image = self._manager()
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(image, len(image), len(image) - 4, 0))
+
+    def test_an_xdata_pointer_outside_the_image_is_rejected(self):
+        manager, image = self._manager()
+        record = bytearray(image)
+        struct.pack_into("<II", record, PDATA_RVA, TEXT_RVA, len(image) + 0x10)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(bytes(record), len(record), PDATA_RVA, 0))
+
+    def test_an_unreadable_xdata_header_is_rejected(self):
+        """flag 0 points at a full .xdata record, whose header word has to declare version 0
+        and a non-zero length; a pointer into zeroed bytes declares neither."""
+        manager, image = self._manager()
+        record = bytearray(image)
+        struct.pack_into("<II", record, PDATA_RVA, TEXT_RVA, 0x6000)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(bytes(record), len(record), PDATA_RVA, 0))
+
+    def test_a_well_formed_xdata_header_is_accepted(self):
+        """Positive control for the arm above: the same record with a valid .xdata header
+        reads back, so the rejection is the header check and not the flag-0 path failing."""
+        manager, image = self._manager()
+        record = bytearray(image)
+        struct.pack_into("<II", record, PDATA_RVA, TEXT_RVA, 0x6000)
+        struct.pack_into("<I", record, 0x6000, 0x4)
+
+        self.assertEqual(
+            manager._readArm64ExceptionRecord(bytes(record), len(record), PDATA_RVA, 0),
+            (TEXT_RVA, 0x6000),
+        )
+
+    def test_a_zero_unwind_pointer_is_rejected(self):
+        manager, image = self._manager()
+        record = bytearray(image)
+        struct.pack_into("<II", record, PDATA_RVA, TEXT_RVA, 0)
+
+        self.assertIsNone(manager._readArm64ExceptionRecord(bytes(record), len(record), PDATA_RVA, 0))
+
+    def test_the_table_is_found_from_a_sample_landing_inside_it(self):
+        """The scan samples at a stride, so it usually lands mid-table and has to walk back to
+        the real first entry; a table that begins off-stride is what exercises that walk."""
+        image, starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, pdata_rva=PDATA_RVA + 8)
+        manager = _candidateManager(image)
+
+        self.assertEqual(_exceptionCandidates(manager), set(starts))
+        self.assertEqual(manager._locateArm64ExceptionRecordTable(image), (PDATA_RVA + 8, RECORDS))
+
+    def test_a_spent_budget_stops_the_table_scan(self):
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8)
+        manager = _candidateManager(image)
+        manager._cb_analysis_timeout = lambda: True
+
+        self.assertEqual(manager._locateArm64ExceptionRecordTable(image), (0, 0))
+
+    def test_no_qualifying_run_yields_no_table(self):
+        manager, _image = self._manager()
+
+        self.assertEqual(manager._locateArm64ExceptionRecordTable(b"\x00" * 0x400), (0, 0))
+
+
+class Arm64CarvedRecordAdmissionTestSuite(unittest.TestCase):
+    def _manager(self):
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8)
+        return _candidateManager(image)
+
+    def test_a_record_naming_a_mid_body_word_is_not_admitted(self):
+        """Exception records also name funclets and fragments, whose begin address continues
+        the enclosing function; seeding one as a start would split a real function."""
+        manager = self._manager()
+        before = _exceptionCandidates(manager)
+        manager._admitCarvedExceptionRecord(IMAGE_BASE, TEXT_RVA + 4)
+
+        self.assertEqual(_exceptionCandidates(manager), before)
+
+    def test_a_record_naming_an_entry_word_is_admitted(self):
+        """Positive control: the same call on an entry-shaped word does add a candidate, so
+        the rejection above is the entry-shape gate rather than the call doing nothing."""
+        # a table below the minimum run is not carved, so nothing is flagged up front
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, records=8)
+        manager = _candidateManager(image)
+        self.assertEqual(_exceptionCandidates(manager), set())
+        manager._admitCarvedExceptionRecord(IMAGE_BASE, TEXT_RVA)
+
+        self.assertEqual(_exceptionCandidates(manager), {IMAGE_BASE + TEXT_RVA})
+
+    def test_a_begin_address_too_close_to_the_end_is_not_admitted(self):
+        """A buffer whose length is not a multiple of the instruction size can hold a
+        4-aligned address with fewer than four bytes behind it."""
+        image, _starts = _mappedImage((FRAME_PROLOGUE, RET), stride=8, size=IMAGE_SIZE - 2)
+        manager = _candidateManager(image)
+        before = _exceptionCandidates(manager)
+        manager._admitCarvedExceptionRecord(IMAGE_BASE, IMAGE_SIZE - 4)
+
+        self.assertEqual(_exceptionCandidates(manager), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAnalysisBudgetBounds.py
+++ b/tests/testAnalysisBudgetBounds.py
@@ -1,0 +1,178 @@
+import struct
+import traceback
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+TEXT_RVA = 0x1000
+IMAGE_SIZE = 0x40000
+PROLOGUE = b"\x55\x48\x89\xe5"  # push rbp ; mov rbp, rsp
+CHAIN_BLOCKS = 900
+TAILCALL_PAIRS = 20
+
+
+def _config(**overrides):
+    config = SmdaConfig()
+    config.CALCULATE_HASHING = False
+    config.CALCULATE_SCC = False
+    config.CALCULATE_NESTING = False
+    config.TIMEOUT = 0
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _budgetedDisassembler(config, spent_inside=None):
+    """A disassembler whose budget is spent only while `spent_inside` is on the stack.
+
+    Naming the frame rather than counting callback invocations keeps the test about the
+    question it is asking - is the budget consulted from inside this pass at all - instead of
+    about how many times earlier passes happen to poll.
+    """
+
+    class _Budgeted(Disassembler):
+        def _callbackAnalysisTimeout(self):
+            if spent_inside is None:
+                return False
+            return any(frame.name == spent_inside for frame in traceback.extract_stack())
+
+    return _Budgeted(config=config)
+
+
+def _blockChainImage(blocks):
+    """One function whose body is a chain of `blocks` conditional branches.
+
+    Each `test eax, eax ; jne +0` step opens a new basic block while staying in the same
+    function - the shape whose analysis used to run to completion however long it took,
+    because nothing consulted the budget inside a function.
+    """
+    body = bytearray(PROLOGUE)
+    for _ in range(blocks):
+        body += b"\x85\xc0\x75\x00"
+    body += b"\x5d\xc3"  # pop rbp ; ret
+    image = bytearray(IMAGE_SIZE)
+    image[TEXT_RVA : TEXT_RVA + len(body)] = body
+    return bytes(image)
+
+
+def _tailcallImage(pairs):
+    """`pairs` callees whose interior is jumped into from a separate function.
+
+    A jump from outside a function into the middle of it is what the tailcall pass promotes
+    into a function of its own, so this image gives that pass real work to do.
+    """
+    body = bytearray()
+    interiors = []
+    for _ in range(pairs):
+        body += PROLOGUE + b"\x90\x90"
+        interiors.append(len(body))
+        body += PROLOGUE + b"\x5d\xc3"
+    jumps = []
+    for _ in interiors:
+        jumps.append(len(body))
+        body += PROLOGUE + b"\xe9" + struct.pack("<i", 0)
+    for jump_at, target in zip(jumps, interiors, strict=True):
+        struct.pack_into("<i", body, jump_at + len(PROLOGUE) + 1, target - (jump_at + len(PROLOGUE) + 5))
+    image = bytearray(IMAGE_SIZE)
+    image[TEXT_RVA : TEXT_RVA + len(body)] = body
+    return bytes(image), [BASE + TEXT_RVA + offset for offset in interiors]
+
+
+class BlockLoopBudgetTestSuite(unittest.TestCase):
+    """The budget used to be consulted only between candidates and between passes, so one
+    pathological function was analysed to completion once started."""
+
+    def _analyze(self, spent_inside):
+        disassembler = _budgetedDisassembler(_config(), spent_inside=spent_inside)
+        report = disassembler.disassembleBuffer(_blockChainImage(CHAIN_BLOCKS), BASE, bitness=64)
+        functions = list(report.getFunctions())
+        blocks = len(list(functions[0].getBlocks())) if functions else 0
+        return report, len(functions), blocks
+
+    def test_a_long_function_is_cut_short_when_the_budget_is_spent(self):
+        report, functions, blocks = self._analyze(spent_inside="analyzeFunction")
+
+        self.assertEqual(report.status, "timeout")
+        self.assertEqual(functions, 1)
+        self.assertGreater(blocks, 0)
+        self.assertLess(blocks, CHAIN_BLOCKS)
+
+    def test_the_same_function_completes_within_budget(self):
+        """Positive control: the cut above has to come from the budget, not from the fixture
+        being unanalysable or the chain being shorter than it looks."""
+        report, functions, blocks = self._analyze(spent_inside=None)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(functions, 1)
+        self.assertEqual(blocks, CHAIN_BLOCKS + 1)
+
+
+class TailcallPassBudgetTestSuite(unittest.TestCase):
+    """`resolveTailcalls` was invoked with no callback at all, so an enabled tailcall pass ran
+    to completion regardless of the budget."""
+
+    def _analyze(self, spent_inside, resolve_tailcalls=True):
+        image, interiors = _tailcallImage(TAILCALL_PAIRS)
+        disassembler = _budgetedDisassembler(_config(RESOLVE_TAILCALLS=resolve_tailcalls), spent_inside=spent_inside)
+        report = disassembler.disassembleBuffer(image, BASE, bitness=64)
+        recovered = {function.offset for function in report.getFunctions()}
+        return report, len(recovered), len(set(interiors) & recovered)
+
+    def test_the_pass_promotes_nothing_once_the_budget_is_spent(self):
+        report, _functions, promoted = self._analyze(spent_inside="resolveTailcalls")
+
+        self.assertEqual(report.status, "timeout")
+        self.assertEqual(promoted, 0)
+
+    def test_the_pass_promotes_every_interior_entry_within_budget(self):
+        """Positive control: with the budget intact the same image gives the pass real work,
+        so the zero above is the poll stopping it rather than there being nothing to do."""
+        report, _functions, promoted = self._analyze(spent_inside=None)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(promoted, TAILCALL_PAIRS)
+
+    def test_nothing_is_promoted_with_the_pass_disabled(self):
+        """Second control: the promotions above are the tailcall pass and not ordinary
+        candidate discovery finding the interior entries by itself."""
+        report, _functions, promoted = self._analyze(spent_inside=None, resolve_tailcalls=False)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(promoted, 0)
+
+
+class AnalysisTimeoutHelperTestSuite(unittest.TestCase):
+    def _engine(self):
+        return Disassembler(config=_config(), backend="intel").disassembler
+
+    def test_an_explicit_callback_wins_over_the_stored_one(self):
+        engine = self._engine()
+        engine._cb_analysis_timeout = lambda: False
+
+        self.assertTrue(engine._analysisTimeoutTripped(lambda: True))
+        self.assertTrue(engine.disassembly.analysis_timeout)
+
+    def test_the_stored_callback_is_used_when_none_is_passed(self):
+        engine = self._engine()
+        engine._cb_analysis_timeout = lambda: True
+
+        self.assertTrue(engine._analysisTimeoutTripped())
+
+    def test_no_callback_at_all_never_trips(self):
+        engine = self._engine()
+        engine._cb_analysis_timeout = None
+
+        self.assertFalse(engine._analysisTimeoutTripped())
+
+    def test_the_verdict_latches_once_recorded(self):
+        engine = self._engine()
+        engine._cb_analysis_timeout = None
+        engine.disassembly.analysis_timeout = True
+
+        self.assertTrue(engine._analysisTimeoutTripped())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAnalysisBudgetBounds.py
+++ b/tests/testAnalysisBudgetBounds.py
@@ -109,6 +109,55 @@ class BlockLoopBudgetTestSuite(unittest.TestCase):
         self.assertEqual(blocks, CHAIN_BLOCKS + 1)
 
 
+class BudgetLatchTestSuite(unittest.TestCase):
+    """Once the budget has cut a function short, no later pass may pick the remainder up.
+
+    The block-loop poll leaves the rest of the function undecoded, so its bytes are still
+    unclaimed when the gap scan runs. Each orchestrator loop used to ask the callback again
+    rather than the recorded verdict, and a callback that answers by where it is called from
+    - which is how a caller scopes a budget to one pass - said no. The gap scan then promoted
+    the remainder, and a truncated function came back as two.
+    """
+
+    def _afterNthCall(self, config, calls):
+        """A budget that trips inside analyzeFunction only, and only after `calls` polls."""
+
+        class _Budgeted(Disassembler):
+            polls = 0
+
+            def _callbackAnalysisTimeout(self):
+                if not any(frame.name == "analyzeFunction" for frame in traceback.extract_stack()):
+                    return False
+                _Budgeted.polls += 1
+                return _Budgeted.polls > calls
+
+        _Budgeted.polls = 0
+        return _Budgeted(config=config)
+
+    def _functions(self, calls):
+        report = self._afterNthCall(_config(), calls).disassembleBuffer(
+            _blockChainImage(CHAIN_BLOCKS), BASE, bitness=64, architecture="intel"
+        )
+        return report.status, {function.offset for function in report.getFunctions()}
+
+    def test_a_function_cut_short_is_not_carved_into_two(self):
+        for calls in (0, 1, 2, 3):
+            with self.subTest(polls_before_tripping=calls):
+                status, offsets = self._functions(calls)
+
+                self.assertEqual(offsets, {BASE + TEXT_RVA}, f"status={status}")
+
+    def test_the_same_image_is_one_function_with_no_budget_at_all(self):
+        """Positive control: the image holds one function, so the assertion above is about
+        the cut and not about the fixture."""
+        report = Disassembler(config=_config()).disassembleBuffer(
+            _blockChainImage(CHAIN_BLOCKS), BASE, bitness=64, architecture="intel"
+        )
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual({function.offset for function in report.getFunctions()}, {BASE + TEXT_RVA})
+
+
 class TailcallPassBudgetTestSuite(unittest.TestCase):
     """`resolveTailcalls` was invoked with no callback at all, so an enabled tailcall pass ran
     to completion regardless of the budget."""
@@ -140,6 +189,62 @@ class TailcallPassBudgetTestSuite(unittest.TestCase):
         report, _functions, promoted = self._analyze(spent_inside=None, resolve_tailcalls=False)
 
         self.assertEqual(report.status, "ok")
+        self.assertEqual(promoted, 0)
+
+
+def _aarch64TailcallImage(pairs):
+    """`pairs` AArch64 callees whose interior is branched into from a separate function.
+
+    The intel backend registers a tailcall candidate without queueing it, so the drain after
+    the tailcall pass has nothing to take; the AArch64 one queues, which is the arm that
+    actually reaches the loop.
+    """
+    prologue, nop, ret = 0xA9BF7BFD, 0xD503201F, 0xD65F03C0
+    word = lambda value: struct.pack("<I", value)  # noqa: E731
+    body = bytearray()
+    interiors = []
+    for _ in range(pairs):
+        body += word(prologue) + word(nop)
+        interiors.append(len(body))
+        body += word(prologue) + word(ret)
+    branches = []
+    for _ in interiors:
+        branches.append(len(body))
+        body += word(prologue) + word(0)
+    for branch_at, target in zip(branches, interiors, strict=True):
+        offset = target - (branch_at + 4)
+        struct.pack_into("<I", body, branch_at + 4, 0x14000000 | ((offset // 4) & 0x03FFFFFF))
+    image = bytearray(IMAGE_SIZE)
+    image[TEXT_RVA : TEXT_RVA + len(body)] = body
+    return bytes(image), [BASE + TEXT_RVA + offset for offset in interiors]
+
+
+class TailcallDrainBudgetTestSuite(unittest.TestCase):
+    """The drain that follows the tailcall pass is an orchestrator loop like the others, so
+    it has to consult the recorded verdict rather than re-ask a callback that may answer by
+    where it is called from."""
+
+    PAIRS = 8
+
+    def _analyze(self, spent_inside):
+        image, interiors = _aarch64TailcallImage(self.PAIRS)
+        disassembler = _budgetedDisassembler(_config(RESOLVE_TAILCALLS=True), spent_inside=spent_inside)
+        report = disassembler.disassembleBuffer(image, BASE, bitness=64, architecture="aarch64")
+        recovered = {function.offset for function in report.getFunctions()}
+        return report, len(set(interiors) & recovered)
+
+    def test_the_drain_runs_and_promotes_every_interior_entry(self):
+        report, promoted = self._analyze(spent_inside=None)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(promoted, self.PAIRS)
+
+    def test_a_budget_spent_inside_the_tailcall_pass_stops_the_drain_too(self):
+        """The latch, not the callback: this budget answers "spent" only while the tailcall
+        pass is on the stack, so a loop that re-asked it would carry on draining."""
+        report, promoted = self._analyze(spent_inside="resolveTailcalls")
+
+        self.assertEqual(report.status, "timeout")
         self.assertEqual(promoted, 0)
 
 

--- a/tests/testAnalysisTimeoutCallback.py
+++ b/tests/testAnalysisTimeoutCallback.py
@@ -12,6 +12,7 @@ import unittest
 from types import SimpleNamespace
 
 from smda.aarch64.AArch64Disassembler import AArch64Disassembler
+from smda.common.analysis_budget import analysisTimeoutTripped
 from smda.common.BinaryInfo import BinaryInfo
 from smda.Disassembler import Disassembler
 from smda.intel.IntelDisassembler import IntelDisassembler
@@ -63,6 +64,53 @@ class TimeoutCallbackReachesCandidateScansTestSuite(unittest.TestCase):
         result = disassembler.analyzeBuffer(_aarch64_binary_info(), cbAnalysisTimeout=lambda: True)
         self.assertNotIn(0x401010, disassembler.fc_manager.candidates)
         self.assertTrue(result.analysis_timeout)
+
+
+class BudgetVerdictLatchTestSuite(unittest.TestCase):
+    """A caller scopes a budget by where it is called from - "spent while the tailcall pass is
+    running" - so once that pass returns, the same callback answers "not spent". Every backend
+    used to re-ask it at each pass and at the end, so a run the budget had already cut short
+    reported ok. The verdict latches onto the result instead, and every later poll reads that
+    first. All three analyzeBuffer implementations - native, CIL and Dalvik - share this."""
+
+    def _spentOnceThenNot(self):
+        """The shape a call-site-scoped budget presents: True while its pass runs, then False."""
+        state = {"asked": 0}
+
+        def callback():
+            state["asked"] += 1
+            return state["asked"] == 1
+
+        return callback, state
+
+    def test_a_verdict_that_tripped_once_stays_tripped(self):
+        disassembly = SimpleNamespace(analysis_timeout=False)
+        callback, state = self._spentOnceThenNot()
+
+        self.assertTrue(analysisTimeoutTripped(disassembly, callback))
+        self.assertTrue(disassembly.analysis_timeout)
+        self.assertTrue(analysisTimeoutTripped(disassembly, callback))
+        self.assertEqual(state["asked"], 1, "the latch must answer without asking again")
+
+    def test_a_budget_that_never_trips_latches_nothing(self):
+        """Positive control: the latch only records a real trip, so an intact budget is not
+        turned into a timeout by having been polled."""
+        disassembly = SimpleNamespace(analysis_timeout=False)
+
+        self.assertFalse(analysisTimeoutTripped(disassembly, lambda: False))
+        self.assertFalse(disassembly.analysis_timeout)
+
+    def test_no_callback_at_all_never_trips(self):
+        disassembly = SimpleNamespace(analysis_timeout=False)
+
+        self.assertFalse(analysisTimeoutTripped(disassembly, None))
+        self.assertFalse(disassembly.analysis_timeout)
+
+    def test_a_missing_result_object_is_tolerated(self):
+        """Passes construct backends without a result in places; the helper must not require
+        one to answer."""
+        self.assertFalse(analysisTimeoutTripped(None, lambda: False))
+        self.assertTrue(analysisTimeoutTripped(None, lambda: True))
 
 
 class IdaExporterTimeoutTestSuite(unittest.TestCase):

--- a/tests/testBenchmarkEval.py
+++ b/tests/testBenchmarkEval.py
@@ -243,5 +243,216 @@ class TestEndToEnd(unittest.TestCase):
         _make_runtime(root, base_runs, pr_runs)
 
 
+def _function(addr, instructions, inrefs=(), outrefs=None):
+    """One xcfg entry: `instructions` is [(addr, mnemonic), ...] laid out in one block."""
+    return {
+        "blocks": {str(addr): [[a, "90", m, ""] for a, m in instructions]},
+        "inrefs": list(inrefs),
+        "outrefs": outrefs or {},
+        "blockrefs": {},
+    }
+
+
+def _write_cfg(folder: Path, name: str, functions):
+    folder.mkdir(parents=True, exist_ok=True)
+    data = {"execution_time": 1.0, "xcfg": {str(a): f for a, f in functions.items()}}
+    with open(folder / name, "w", encoding="utf-8") as handle:
+        json.dump(data, handle)
+
+
+class TestChangedAddressLabels(unittest.TestCase):
+    """The label rules are ordered, and the order is what makes them right."""
+
+    BASE = {"absorbed_by": None, "inrefs": 0, "ends_in_return": False, "misaligned_overlap": 0}
+
+    def _label(self, dropped=True, **overrides):
+        return er.label_changed_address({**self.BASE, **overrides}, dropped=dropped)
+
+    def test_padding_read_at_the_wrong_offset_reads_as_a_false_positive(self):
+        self.assertEqual(self._label(), "likely_false_positive")
+
+    def test_a_whole_routine_reads_as_a_loss(self):
+        self.assertEqual(self._label(ends_in_return=True), "likely_loss")
+
+    def test_a_referenced_address_reads_as_a_loss_however_its_body_ends(self):
+        """A function ending in a tail-call `jmp`, inside a region the other side decodes
+        differently, is still a function when something calls it - the body rules alone would
+        call this padding."""
+        self.assertEqual(self._label(inrefs=5, ends_in_return=False, misaligned_overlap=21), "likely_loss")
+
+    def test_a_return_inside_a_differently_decoded_extent_is_not_a_loss(self):
+        """A `ret` byte falls out of almost any run of data, so it only counts when the other
+        side does not decode different instructions across the same bytes."""
+        self.assertEqual(self._label(ends_in_return=True, misaligned_overlap=40), "likely_false_positive")
+
+    def test_still_decoded_elsewhere_is_a_boundary_move_not_a_loss(self):
+        self.assertEqual(self._label(absorbed_by=0x401000), "absorbed")
+
+    def test_the_same_signals_read_the_other_way_for_an_added_address(self):
+        self.assertEqual(self._label(absorbed_by=0x401000, dropped=False), "split_out")
+        self.assertEqual(self._label(inrefs=1, dropped=False), "likely_recovery")
+        self.assertEqual(self._label(dropped=False), "likely_new_false_positive")
+
+
+class TestChangedAddressSignals(unittest.TestCase):
+    def test_signals_are_read_from_the_two_reports(self):
+        xcfg = {
+            "1000": _function(1000, [(1000, "push"), (1002, "ret")], inrefs=[900], outrefs={"1000": [2000]}),
+        }
+        other_owner = {2000: 1900, 1001: 1001}
+        signals = er.describe_changed_address(1000, xcfg, other_owner, sorted(other_owner))
+
+        self.assertEqual(signals["inrefs"], 1)
+        self.assertEqual(signals["instructions"], 2)
+        self.assertTrue(signals["ends_in_return"])
+        self.assertIsNone(signals["absorbed_by"])
+        self.assertEqual(signals["branches_into_survivor_interior"], 1)
+        self.assertEqual(signals["misaligned_overlap"], 1)
+
+    def test_a_prefixed_return_still_counts_as_a_return(self):
+        xcfg = {"1000": _function(1000, [(1000, "bnd ret")])}
+        signals = er.describe_changed_address(1000, xcfg, {}, [])
+
+        self.assertTrue(signals["ends_in_return"])
+
+    def test_an_address_the_report_does_not_carry_is_skipped(self):
+        self.assertIsNone(er.describe_changed_address(1000, {}, {}, []))
+
+
+class TestClassifyRegressions(unittest.TestCase):
+    def test_each_kind_of_change_is_labelled_end_to_end(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = {
+                0x1000: _function(0x1000, [(0x1000, "push"), (0x1002, "ret")]),
+                0x2000: _function(0x2000, [(0x2000, "add"), (0x2002, "add")]),
+                0x3000: _function(0x3000, [(0x3000, "push"), (0x3002, "ret")]),
+            }
+            # 0x1000 survives; 0x2000 is padding; 0x3000 is still decoded inside 0x1000.
+            pr = {
+                0x1000: _function(0x1000, [(0x1000, "push"), (0x1002, "ret"), (0x3000, "push")]),
+                0x4000: _function(0x4000, [(0x4000, "push"), (0x4002, "ret")], inrefs=[0x1000]),
+            }
+            _write_cfg(root / "base_0", "s.smda", base)
+            _write_cfg(root / "pr_0", "s.smda", pr)
+            regressions = [
+                {
+                    "file": "s.smda",
+                    "only_in_base": ["8192", "12288"],
+                    "only_in_pr": ["16384"],
+                }
+            ]
+
+            result = er.classify_regressions(regressions, root / "base_0", root / "pr_0")
+
+            self.assertEqual(
+                result["counts"],
+                {"likely_false_positive": 1, "absorbed": 1, "likely_recovery": 1},
+            )
+            labels = {row["addr"]: row["label"] for row in result["files"][0]["addresses"]}
+            self.assertEqual(labels[0x2000], "likely_false_positive")
+            self.assertEqual(labels[0x3000], "absorbed")
+            self.assertEqual(labels[0x4000], "likely_recovery")
+
+    def test_hex_spelled_addresses_are_read_the_same_as_decimal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_cfg(root / "base_0", "s.smda", {0x1000: _function(0x1000, [(0x1000, "add")])})
+            _write_cfg(root / "pr_0", "s.smda", {})
+
+            result = er.classify_regressions(
+                [{"file": "s.smda", "only_in_base": ["0x1000"], "only_in_pr": []}],
+                root / "base_0",
+                root / "pr_0",
+            )
+
+            self.assertEqual(result["counts"], {"likely_false_positive": 1})
+
+    def test_an_unreadable_report_costs_the_reading_and_not_the_run(self):
+        """The section is evidence, not a gate, so a corrupt report must not fail the job."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_cfg(root / "base_0", "s.smda", {0x1000: _function(0x1000, [(0x1000, "ret")])})
+            (root / "pr_0").mkdir(parents=True, exist_ok=True)
+            (root / "pr_0" / "s.smda").write_text("{not json", encoding="utf-8")
+
+            result = er.classify_regressions(
+                [{"file": "s.smda", "only_in_base": ["4096"], "only_in_pr": []}],
+                root / "base_0",
+                root / "pr_0",
+            )
+
+            self.assertEqual(result["counts"], {})
+
+    def test_a_file_missing_from_a_side_is_skipped_rather_than_raising(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_cfg(root / "base_0", "s.smda", {0x1000: _function(0x1000, [(0x1000, "ret")])})
+            (root / "pr_0").mkdir(parents=True, exist_ok=True)
+
+            result = er.classify_regressions(
+                [{"file": "s.smda", "only_in_base": ["4096"], "only_in_pr": []}],
+                root / "base_0",
+                root / "pr_0",
+            )
+
+            self.assertEqual(result["counts"], {})
+            self.assertEqual(result["files"], [])
+
+
+class TestClassificationMarkdown(unittest.TestCase):
+    def test_nothing_is_rendered_without_a_classification(self):
+        self.assertEqual(er._classification_lines({}), [])
+        self.assertEqual(er._classification_lines({"counts": {}}), [])
+
+    def test_losses_are_listed_with_the_evidence_for_calling_them_losses(self):
+        classification = {
+            "counts": {"likely_loss": 1, "likely_false_positive": 2},
+            "note": "note",
+            "files": [
+                {
+                    "file": "s.smda",
+                    "addresses": [
+                        {
+                            "addr": 0xA65150,
+                            "label": "likely_loss",
+                            "inrefs": 0,
+                            "instructions": 16,
+                            "ends_in_return": True,
+                        }
+                    ],
+                }
+            ],
+        }
+
+        rendered = "\n".join(er._classification_lines(classification))
+
+        self.assertIn("Likely false positives removed", rendered)
+        self.assertIn("| Likely real functions lost | **1** |", rendered)
+        self.assertIn("0xa65150", rendered)
+        self.assertIn("not gated", rendered)
+
+
+class TestClassificationReachesTheModel(unittest.TestCase):
+    def test_the_report_model_carries_the_classification(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for i in range(2):
+                _write_cfg(
+                    root / f"base_{i}",
+                    "s.smda",
+                    {
+                        0x1000: _function(0x1000, [(0x1000, "ret")]),
+                        0x2000: _function(0x2000, [(0x2000, "add")]),
+                    },
+                )
+                _write_cfg(root / f"pr_{i}", "s.smda", {0x1000: _function(0x1000, [(0x1000, "ret")])})
+
+            model, status = er.evaluate(root)
+
+            self.assertEqual(status, "ok")
+            self.assertEqual(model["correctness"]["classification"]["counts"], {"likely_false_positive": 1})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testBenchmarkEval.py
+++ b/tests/testBenchmarkEval.py
@@ -263,7 +263,13 @@ def _write_cfg(folder: Path, name: str, functions):
 class TestChangedAddressLabels(unittest.TestCase):
     """The label rules are ordered, and the order is what makes them right."""
 
-    BASE = {"absorbed_by": None, "inrefs": 0, "ends_in_return": False, "misaligned_overlap": 0}
+    BASE = {
+        "absorbed_by": None,
+        "inrefs": 0,
+        "ends_in_return": False,
+        "misaligned_overlap": 0,
+        "starts_like_a_function": False,
+    }
 
     def _label(self, dropped=True, **overrides):
         return er.label_changed_address({**self.BASE, **overrides}, dropped=dropped)
@@ -285,6 +291,18 @@ class TestChangedAddressLabels(unittest.TestCase):
         side does not decode different instructions across the same bytes."""
         self.assertEqual(self._label(ends_in_return=True, misaligned_overlap=40), "likely_false_positive")
 
+    def test_an_entry_shaped_body_reads_as_a_loss_though_every_other_rule_declines(self):
+        """A function reached only indirectly has no inbound reference, can end in a call
+        rather than a return, and sits in an extent the other side decodes differently - the
+        first three rules all decline it, and it is still a function."""
+        self.assertEqual(
+            self._label(inrefs=0, ends_in_return=False, misaligned_overlap=1758, starts_like_a_function=True),
+            "likely_loss",
+        )
+
+    def test_an_entry_shaped_added_address_reads_as_a_recovery(self):
+        self.assertEqual(self._label(starts_like_a_function=True, dropped=False), "likely_recovery")
+
     def test_still_decoded_elsewhere_is_a_boundary_move_not_a_loss(self):
         self.assertEqual(self._label(absorbed_by=0x401000), "absorbed")
 
@@ -292,6 +310,55 @@ class TestChangedAddressLabels(unittest.TestCase):
         self.assertEqual(self._label(absorbed_by=0x401000, dropped=False), "split_out")
         self.assertEqual(self._label(inrefs=1, dropped=False), "likely_recovery")
         self.assertEqual(self._label(dropped=False), "likely_new_false_positive")
+
+
+class TestEntryShape(unittest.TestCase):
+    """The reading that separates a function entry from padding decoded at a wrong offset."""
+
+    def _shape(self, *head):
+        return er._starts_like_a_function([(0x1000 + i * 4, m, o) for i, (m, o) in enumerate(head)])
+
+    def test_a_landing_pad_opens_a_function(self):
+        self.assertTrue(self._shape(("endbr64", ""), ("push", "rbx")))
+        self.assertTrue(self._shape(("endbr32", ""), ("push", "ebx")))
+
+    def test_the_frame_pointer_pair_opens_a_function(self):
+        self.assertTrue(self._shape(("push", "rbp"), ("mov", "rbp, rsp")))
+        self.assertTrue(self._shape(("push", "ebp"), ("mov", "ebp, esp")))
+
+    def test_a_run_of_callee_saved_pushes_opens_a_function(self):
+        self.assertTrue(self._shape(("push", "ebx"), ("push", "esi")))
+
+    def test_a_prefixed_mnemonic_is_read_by_its_base_opcode(self):
+        self.assertTrue(self._shape(("bnd push", "rbp"), ("mov", "rbp, rsp")))
+
+    def test_a_push_reaching_a_branch_is_not_an_entry(self):
+        """Padding decoded at the wrong offset reaches a branch within an instruction or two,
+        which is what every false positive in the labelled corpus does."""
+        self.assertFalse(self._shape(("push", "esi"), ("jno", "0x45b0cc")))
+
+    def test_a_pushed_immediate_is_not_an_entry(self):
+        self.assertFalse(self._shape(("push", "0x7a6d3250"), ("push", "eax")))
+
+    def test_a_pushed_single_digit_immediate_is_not_an_entry(self):
+        """Capstone prints an immediate below 10 with no `0x`, so the prefix cannot be what
+        distinguishes an immediate from a register name."""
+        self.assertFalse(self._shape(("push", "8"), ("push", "eax")))
+
+    def test_a_frame_pointer_move_into_a_different_register_is_not_the_pair(self):
+        self.assertFalse(self._shape(("push", "rbp"), ("mov", "rax, rsp")))
+
+    def test_a_frame_pointer_loaded_from_anything_but_the_stack_is_not_the_pair(self):
+        self.assertFalse(self._shape(("push", "rbp"), ("mov", "rbp, rax")))
+
+    def test_the_frame_pointer_pair_must_match_its_own_width(self):
+        self.assertFalse(self._shape(("push", "rbp"), ("mov", "rbp, esp")))
+
+    def test_a_single_instruction_body_is_not_an_entry(self):
+        self.assertFalse(self._shape(("push", "rbp")))
+
+    def test_an_empty_body_is_not_an_entry(self):
+        self.assertFalse(self._shape())
 
 
 class TestChangedAddressSignals(unittest.TestCase):

--- a/tests/testBenchmarkEval.py
+++ b/tests/testBenchmarkEval.py
@@ -382,6 +382,19 @@ class TestChangedAddressSignals(unittest.TestCase):
 
         self.assertTrue(signals["ends_in_return"])
 
+    def test_a_far_or_interrupt_return_does_not_read_as_a_routine_ending(self):
+        """A compiled routine returns to its caller with a near return. 0xca, 0xcb and 0xcf are
+        ordinary bytes in text and data, so a body that decodes a string lands on one often -
+        counting those would read a decoded string as a whole routine. The control is the same
+        two-instruction body ending in `ret`, which must still read as one."""
+        for mnemonic in ("retf", "retfq", "iret", "iretd", "iretq"):
+            with self.subTest(mnemonic=mnemonic):
+                xcfg = {"1000": _function(1000, [(1000, "in"), (1001, mnemonic)])}
+                self.assertFalse(er.describe_changed_address(1000, xcfg, {}, [])["ends_in_return"])
+
+        control = {"1000": _function(1000, [(1000, "in"), (1001, "ret")])}
+        self.assertTrue(er.describe_changed_address(1000, control, {}, [])["ends_in_return"])
+
     def test_an_address_the_report_does_not_carry_is_skipped(self):
         self.assertIsNone(er.describe_changed_address(1000, {}, {}, []))
 

--- a/tests/testDalvikDisassembler.py
+++ b/tests/testDalvikDisassembler.py
@@ -93,6 +93,72 @@ def build_code_item(insns, tries=None, handlers_blob=b"", registers_size=1, ins_
     return header + insns + padding + try_items + handlers_blob
 
 
+class DalvikOrphanPassBudgetTestSuite(unittest.TestCase):
+    """The orphan pass runs last, so a spent budget usually lands in it. Its poll used to re-ask
+    the callback, and a caller scopes a budget by where it is called from - once the pass that
+    set it has returned, the same callback answers "not spent" and the drain carries on. The
+    verdict latches instead."""
+
+    class _Watched(list):
+        """A list that records what the loop actually pulled from it."""
+
+        def __init__(self, items):
+            super().__init__(items)
+            self.consumed = []
+
+        def __iter__(self):
+            for item in list.__iter__(self):
+                self.consumed.append(item)
+                yield item
+
+    def _drainOrphans(self, spend_on_entry):
+        from smda.dalvik.DalvikDisassembler import DalvikDisassembler
+
+        with open(os.path.join(config.PROJECT_ROOT, "tests", "blockblast_classes_xored"), "rb") as handle:
+            dex = bytes(byte ^ (index % 256) for index, byte in enumerate(handle.read()))
+        offsets = self._Watched([0x10, 0x20, 0x30])
+        entered = {"orphan_pass": False}
+
+        def fake_discover(_self, _raw, known_code_offsets):
+            entered["orphan_pass"] = True
+            return offsets
+
+        class _Budgeted(Disassembler):
+            def _callbackAnalysisTimeout(self):
+                return spend_on_entry and entered["orphan_pass"]
+
+        with mock.patch.object(DalvikDisassembler, "_discoverOrphanCodeItems", fake_discover):
+            _Budgeted(config, backend="dalvik").disassembleUnmappedBuffer(dex)
+        return offsets.consumed
+
+    def test_a_budget_spent_when_the_orphan_pass_starts_stops_the_drain(self):
+        self.assertEqual(self._drainOrphans(spend_on_entry=True), [0x10])
+
+    def test_a_verdict_that_tripped_once_still_reports_a_timeout(self):
+        """The latch itself: a budget scoped to one pass answers "spent" while that pass runs and
+        "not spent" afterwards. Re-asking it at the end reported ok for a run that was cut short."""
+        with open(os.path.join(config.PROJECT_ROOT, "tests", "blockblast_classes_xored"), "rb") as handle:
+            dex = bytes(byte ^ (index % 256) for index, byte in enumerate(handle.read()))
+        asked = {"count": 0}
+
+        class _Budgeted(Disassembler):
+            def _callbackAnalysisTimeout(self):
+                asked["count"] += 1
+                return asked["count"] == 1
+
+        report = _Budgeted(config, backend="dalvik").disassembleUnmappedBuffer(dex)
+
+        # re-asking answered "not spent" 66 more times and reported ok for 64 functions it had
+        # already stopped analysing; the latch answers once and stands
+        self.assertEqual(asked["count"], 1)
+        self.assertEqual(report.status, "timeout")
+
+    def test_the_same_drain_takes_every_orphan_within_budget(self):
+        """Positive control: with the budget intact the loop pulls all three, so the single
+        entry above is the poll stopping it rather than the list being short."""
+        self.assertEqual(self._drainOrphans(spend_on_entry=False), [0x10, 0x20, 0x30])
+
+
 class DalvikDisassemblerTestSuite(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -623,7 +623,12 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
                 self.assertEqual(report.status, "ok")
                 self.assertEqual(report.architecture, architecture)
                 self.assertEqual(report.bitness, bitness)
-                self.assertEqual(report.num_functions, 151)
+                # 150, not 151: both binaries dispatch a switch whose bound is compared
+                # against the memory cell the index is read from, which the bound scan now
+                # follows. Reading all 11 table entries instead of one makes 0x408829 (x64)
+                # a basic block of the function that jumps to it, where it used to be
+                # unreachable and got promoted to a function of its own. Nothing calls it.
+                self.assertEqual(report.num_functions, 150)
 
 
 if __name__ == "__main__":

--- a/tests/testIndirectCallAnalyzer.py
+++ b/tests/testIndirectCallAnalyzer.py
@@ -144,6 +144,51 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
 
         self.assertEqual(self._resolveThrough(block), {})
 
+    def test_an_unmodelled_mov_write_stops_the_walk(self):
+        """The mov/lea exemption assumed the patterns below model every mov. They model only
+        some forms, and `mov eax, dword ptr [esi]` - the vtable dispatch load - is not one of
+        them, so the walk read past the real last write and bound the call to a dead
+        assignment. On a 32-bit PE corpus that shape reaches the walk a few hundred times per
+        sample."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 2, "mov", "eax, dword ptr [esi]"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {})
+
+    def test_an_unmodelled_write_through_a_sub_register_stops_the_walk(self):
+        """al is part of eax, so a value written through one is readable through the other."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 2, "mov", "al, byte ptr [esi]"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {})
+
+    def test_an_unmodelled_write_of_an_untracked_register_does_not_stop_the_walk(self):
+        """Control for the rule above: only the tracked register's value is at stake, so an
+        unmodelled write elsewhere must not throw the resolution away."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 2, "mov", "ebx, dword ptr [esi]"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {"eax": 0x402000})
+
+    def test_a_store_to_memory_does_not_stop_the_walk(self):
+        """Second control: a mov whose destination is memory writes no register at all."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 5, "mov", "dword ptr [0x400500], eax"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {"eax": 0x402000})
+
     def test_a_call_between_the_definition_and_the_call_stops_the_walk(self):
         """Same class through the ABI rather than the operand: a call clobbers the register
         without naming it at all."""

--- a/tests/testIndirectCallAnalyzer.py
+++ b/tests/testIndirectCallAnalyzer.py
@@ -113,7 +113,7 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         # eax should have 0x402000
         self.assertEqual(registers.get("eax"), 0x402000, f"Expected eax to be 0x402000, but got {registers.get('eax')}")
 
-    def _resolveThrough(self, block, register_name="eax", calling_addr=0x401100):
+    def _resolveThrough(self, block, register_name="eax", calling_addr=0x401100, bitness=32):
         """Run the backward walk over `block` and return the register values it recovered.
 
         The walk renames what it is tracking as it follows a copy chain, so the value can land
@@ -124,6 +124,7 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         analyzer = IndirectCallAnalyzer(disassembler)
         analyzer.disassembly = MagicMock()
         analyzer.disassembly.isAddrWithinMemoryImage.return_value = True
+        analyzer.disassembly.binary_info.bitness = bitness
         analyzer.current_calling_addr = calling_addr
         analyzer.current_slot = None
         analyzer.state = MagicMock()
@@ -175,6 +176,59 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         block = [
             [0x401000, 5, "mov", "eax, 0x402000"],
             [0x401005, 2, "loop", "0x401100"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {})
+
+    def test_a_call_preserves_a_callee_saved_register(self):
+        """A resolved target is booked as a function candidate, so a walk that stops early costs
+        a function rather than an API name. Every x86 convention preserves ebx, so the definition
+        is still the value the call receives."""
+        block = [
+            [0x401000, 5, "mov", "ebx, 0x402000"],
+            [0x401005, 5, "call", "0x403000"],
+            [0x401100, 2, "call", "ebx"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block, register_name="ebx").get("ebx"), 0x402000)
+
+    def test_a_callee_saved_register_survives_a_call_in_64_bit_code(self):
+        block = [
+            [0x401000, 7, "mov", "rbx, 0x402000"],
+            [0x401007, 5, "call", "0x403000"],
+            [0x401100, 2, "call", "rbx"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block, register_name="rbx", bitness=64).get("rbx"), 0x402000)
+
+    def test_rsi_does_not_survive_a_call_in_64_bit_code(self):
+        """Control: esi is callee-saved on x86 and rsi is not under the SysV ABI, so the set is
+        chosen by bitness rather than by register name alone."""
+        block = [
+            [0x401000, 7, "mov", "rsi, 0x402000"],
+            [0x401007, 5, "call", "0x403000"],
+            [0x401100, 2, "call", "rsi"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block, register_name="rsi", bitness=64), {})
+
+    def test_a_vector_move_does_not_stop_the_walk(self):
+        """A move whose destination is a vector register writes no general register."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 4, "movaps", "xmm0, xmmword ptr [ecx]"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block).get("eax"), 0x402000)
+
+    def test_a_string_move_still_stops_the_walk(self):
+        """Control on the mnemonic capstone overloads: `movsd` also spells the string
+        instruction, which writes esi and edi, so it is deliberately not preserved."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 1, "movsd", "dword ptr es:[edi], dword ptr [esi]"],
             [0x401100, 2, "call", "eax"],
         ]
 

--- a/tests/testIndirectCallAnalyzer.py
+++ b/tests/testIndirectCallAnalyzer.py
@@ -113,6 +113,70 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         # eax should have 0x402000
         self.assertEqual(registers.get("eax"), 0x402000, f"Expected eax to be 0x402000, but got {registers.get('eax')}")
 
+    def _resolveThrough(self, block, register_name="eax", calling_addr=0x401100):
+        """Run the backward walk over `block` and return the register values it recovered.
+
+        The walk renames what it is tracking as it follows a copy chain, so the value can land
+        under a different key than the one it started from - the dict is what to assert on.
+        """
+        disassembler = MagicMock()
+        disassembler.resolveApi.return_value = (None, None)
+        analyzer = IndirectCallAnalyzer(disassembler)
+        analyzer.disassembly = MagicMock()
+        analyzer.disassembly.isAddrWithinMemoryImage.return_value = True
+        analyzer.current_calling_addr = calling_addr
+        analyzer.current_slot = None
+        analyzer.state = MagicMock()
+        registers = {}
+        analyzer.processBlock(analyzer.state, block, registers, register_name, [], 0)
+        return registers
+
+    def test_a_write_between_the_definition_and_the_call_stops_the_walk(self):
+        """The walk models mov and lea and read every other mnemonic as harmless, so an
+        instruction that changes the register in between was skipped and the value from before
+        it resolved - a wrong call target, not a missing one."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 3, "add", "eax, 4"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {})
+
+    def test_a_call_between_the_definition_and_the_call_stops_the_walk(self):
+        """Same class through the ABI rather than the operand: a call clobbers the register
+        without naming it at all."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 5, "call", "0x403000"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {})
+
+    def test_an_undisturbed_definition_still_resolves(self):
+        """Positive control: the walk still starts at the call being resolved - which is itself
+        a clobber - and still reads a definition that nothing in between touched. Without this,
+        a guard that gave up immediately would satisfy both cases above."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 1, "nop", ""],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block).get("eax"), 0x402000)
+
+    def test_a_copy_chain_still_resolves(self):
+        """Second control: the mnemonics the walk does model keep working, so the guard has not
+        simply disabled resolution."""
+        block = [
+            [0x401000, 5, "mov", "edx, 0x402000"],
+            [0x401005, 2, "mov", "eax, edx"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block).get("edx"), 0x402000)
+
     def test_processBlock_preserves_known_import_slot(self):
         import_slot = 0x403000
         memory_value = 0x500000

--- a/tests/testIndirectCallAnalyzer.py
+++ b/tests/testIndirectCallAnalyzer.py
@@ -132,7 +132,7 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         return registers
 
     def test_a_write_between_the_definition_and_the_call_stops_the_walk(self):
-        """The walk models mov and lea and read every other mnemonic as harmless, so an
+        """The walk modelled mov and lea and read every other mnemonic as harmless, so an
         instruction that changes the register in between was skipped and the value from before
         it resolved - a wrong call target, not a missing one."""
         block = [
@@ -149,6 +149,32 @@ class IndirectCallAnalyzerTestSuite(unittest.TestCase):
         block = [
             [0x401000, 5, "mov", "eax, 0x402000"],
             [0x401005, 5, "call", "0x403000"],
+            [0x401100, 2, "call", "eax"],
+        ]
+
+        self.assertEqual(self._resolveThrough(block), {})
+
+    def test_a_branch_between_the_definition_and_the_call_does_not_stop_the_walk(self):
+        """A backtracked window spans blocks, so a branch sits between the definition and the
+        call routinely - across the bundled fixtures it is what stopped 612 of 978 walks. A
+        branch writes rip and the flags and no general register, so the value survives it."""
+        for mnemonic in ("jne", "jmp"):
+            with self.subTest(mnemonic=mnemonic):
+                block = [
+                    [0x401000, 5, "mov", "eax, 0x402000"],
+                    [0x401005, 2, "cmp", "ecx, 1"],
+                    [0x401007, 2, mnemonic, "0x401100"],
+                    [0x401100, 2, "call", "eax"],
+                ]
+
+                self.assertEqual(self._resolveThrough(block).get("eax"), 0x402000)
+
+    def test_a_loop_between_the_definition_and_the_call_still_stops_the_walk(self):
+        """Control on the other side of the same set: `loop` is a branch too, and it decrements
+        rcx, so it is deliberately not preserved."""
+        block = [
+            [0x401000, 5, "mov", "eax, 0x402000"],
+            [0x401005, 2, "loop", "0x401100"],
             [0x401100, 2, "call", "eax"],
         ]
 

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -414,6 +414,51 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertIn(0x0, result.functions)
         self.assertEqual(result.ins2fn.get(0x10), 0x0)
 
+    def test_push_ret_through_a_register_does_not_reference_address_zero(self):
+        # `push eax; ret` names no literal, so the operand reader returns its
+        # "nothing found" 0 -- which a base-0 image accepts as a real address
+        buf = (
+            b"\xcc" * 0x100
+            + b"\x55"  # 0x100: push ebp
+            + b"\x89\xe5"  # 0x101: mov ebp, esp
+            + b"\x31\xc0"  # 0x103: xor eax, eax
+            + b"\x50"  # 0x105: push eax
+            + b"\xc3"  # 0x106: ret
+            + b"\xcc" * 0x100
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertIn(0x100, result.functions)
+        self.assertNotIn(0, result.code_refs_to)
+
+    def test_push_ret_through_a_literal_still_resolves(self):
+        """Positive control for the pair above, in the same layout: a push naming a
+        real address must still be followed, on either side of the register case."""
+        buf = (
+            b"\xcc" * 0x100
+            + b"\x55"  # 0x100: push ebp
+            + b"\x89\xe5"  # 0x101: mov ebp, esp
+            + b"\x68\x20\x02\x00\x00"  # 0x103: push 0x220
+            + b"\xc3"  # 0x108: ret
+            + b"\xcc" * 0x117
+            + b"\x31\xc0"  # 0x220: xor eax, eax
+            + b"\xc3"  # 0x222: ret
+        )
+        binary_info = BinaryInfo(buf)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+
+        result = IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+        self.assertIn(0x100, result.functions)
+        self.assertEqual(result.ins2fn.get(0x220), 0x100)
+
     def test_accepts_missing_timeout_callback(self):
         binary_info = BinaryInfo(b"\x90\xc3")
         binary_info.base_addr = 0

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -1,4 +1,5 @@
 import logging
+import struct
 import unittest
 from types import SimpleNamespace
 
@@ -458,6 +459,41 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertIn(0x100, result.functions)
         self.assertEqual(result.ins2fn.get(0x220), 0x100)
+
+    def _indirect_call_image(self, slot_value):
+        # 0x100: push ebp; mov ebp, esp; call dword ptr [0x300]; pop ebp; ret
+        buf = bytearray(0x400)
+        code = b"\x55" + b"\x89\xe5" + b"\xff\x15" + struct.pack("<I", 0x300) + b"\x5d" + b"\xc3"
+        buf[0x100 : 0x100 + len(code)] = code
+        struct.pack_into("<I", buf, 0x300, slot_value)
+        buf[0x200:0x203] = b"\x31\xc0\xc3"  # xor eax, eax; ret -- a real local target
+        binary_info = BinaryInfo(bytes(buf))
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+        return IntelDisassembler(SmdaConfig()).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+    def test_an_unrelocated_call_slot_books_the_slot_not_address_zero(self):
+        # a dumped import slot the loader never filled reads back 0, and a base-0 image
+        # accepts 0 as an address, so the call was booked against address 0
+        result = self._indirect_call_image(slot_value=0)
+
+        self.assertNotIn(0, result.code_refs_to)
+        self.assertIn(0x300, result.code_refs_from[0x103])
+
+    def test_a_slot_outside_the_image_books_the_slot(self):
+        result = self._indirect_call_image(slot_value=0x7FFFFFFF)
+
+        self.assertNotIn(0x7FFFFFFF, result.code_refs_to)
+        self.assertIn(0x300, result.code_refs_from[0x103])
+
+    def test_a_slot_holding_a_local_target_still_books_the_target(self):
+        """Positive control: an in-image slot value is the real destination and must keep
+        being booked as one, which is what the import-like arm must not swallow."""
+        result = self._indirect_call_image(slot_value=0x200)
+
+        self.assertIn(0x200, result.code_refs_from[0x103])
+        self.assertNotIn(0x300, result.code_refs_from[0x103])
 
     def test_accepts_missing_timeout_callback(self):
         binary_info = BinaryInfo(b"\x90\xc3")

--- a/tests/testIntelPdataCarving.py
+++ b/tests/testIntelPdataCarving.py
@@ -6,9 +6,12 @@ table. These tests pin the carver that recovers it from the raw image instead.
 """
 
 import struct
+import traceback
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
+import smda.intel.FunctionCandidateManager as intel_candidates
 from smda.common.BinaryInfo import BinaryInfo
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
@@ -161,6 +164,67 @@ class IntelPdataCarvingTestSuite(unittest.TestCase):
         manager.locateExceptionHandlerCandidates()
 
         self.assertEqual({}, manager.candidates)
+
+
+class IntelCarveBudgetTestSuite(unittest.TestCase):
+    """One exception table is walked inside a single call, so the poll in the pass around it
+    never comes round again. The record walk and the admit loop carry their own."""
+
+    POLL = 4
+
+    def _spentOnceTheTableIsFound(self, manager):
+        """A budget that is intact while the table is being located and spent afterwards.
+
+        Answering "spent" throughout would stop the locate instead, and the admit loop this
+        is about would never run - the test would pass while proving nothing.
+        """
+
+        def spent():
+            return not any(frame.name == "_locateExceptionRecordTable" for frame in traceback.extract_stack())
+
+        manager._cb_analysis_timeout = spent
+
+    def test_the_record_walk_gives_up_when_the_budget_is_spent(self):
+        manager = _manager(_image(24))
+        blob = manager.disassembly.binary_info.binary
+        manager._cb_analysis_timeout = lambda: True
+
+        with mock.patch.object(intel_candidates, "_TIMEOUT_POLL_INTERVAL", self.POLL):
+            counted = manager._countExceptionRecords(blob, len(blob), TABLE_RVA, 1000)
+
+        self.assertEqual(counted, self.POLL)
+
+    def test_the_same_walk_completes_within_budget(self):
+        """Positive control: with the budget intact the walk counts every record, so the stop
+        above is the poll rather than the records failing validation."""
+        manager = _manager(_image(24))
+        blob = manager.disassembly.binary_info.binary
+        manager._cb_analysis_timeout = None
+
+        with mock.patch.object(intel_candidates, "_TIMEOUT_POLL_INTERVAL", self.POLL):
+            counted = manager._countExceptionRecords(blob, len(blob), TABLE_RVA, 1000)
+
+        self.assertEqual(counted, 24)
+
+    def test_the_admit_loop_gives_up_when_the_budget_is_spent(self):
+        manager = _manager(_image(24))
+        self._spentOnceTheTableIsFound(manager)
+
+        with mock.patch.object(intel_candidates, "_TIMEOUT_POLL_INTERVAL", self.POLL):
+            manager._carveExceptionRecords(BASE, False)
+
+        self.assertEqual(len(manager.candidates), self.POLL)
+
+    def test_the_admit_loop_takes_every_record_within_budget(self):
+        """Positive control for the loop itself: the same table admits all 24 when nothing
+        stops it, so the count above is the poll and not the table being short."""
+        manager = _manager(_image(24))
+        manager._cb_analysis_timeout = None
+
+        with mock.patch.object(intel_candidates, "_TIMEOUT_POLL_INTERVAL", self.POLL):
+            manager._carveExceptionRecords(BASE, False)
+
+        self.assertEqual(len(manager.candidates), 24)
 
 
 if __name__ == "__main__":

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.JumpTableAnalyzer import JumpTableAnalyzer
 from smda.SmdaConfig import SmdaConfig
 
@@ -431,3 +432,170 @@ class DirectTableRecoveryTest(unittest.TestCase):
         # the three consumed entries are claimed as data, so the gap scan cannot seed
         # candidates inside the table
         self.assertEqual(sorted(report.data_refs_from[0x40000A]), [0x401000, 0x401004, 0x401008])
+
+
+class ZeroTableEntryTest(unittest.TestCase):
+    """A table entry of zero is what a run of zero bytes reads back as, and in an image
+    mapped at base 0 it is also inside the mapped range, so the image bound admits it."""
+
+    IMAGE_SIZE = 0x2000
+    LIVE = 0x1100
+    OUT_OF_IMAGE = 0xDEADBEEF
+
+    def _analyzer(self, entries, bitness=32):
+        analyzer = _makeAnalyzer(base_addr=0, binary_size=self.IMAGE_SIZE, bitness=bitness)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(
+            side_effect=lambda addr: addr is not None and 0 <= addr < self.IMAGE_SIZE
+        )
+        entry_format = "<I" if bitness == 32 else "<Q"
+        entry_size = struct.calcsize(entry_format)
+        table = b"".join(struct.pack(entry_format, entry) for entry in entries)
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - 0x1090 : addr - 0x1090 + size]
+        )
+        return analyzer, entry_size
+
+    def test_a_base_zero_image_really_admits_address_zero(self):
+        """Positive control for the class, asserted against the real predicate: without this
+        the tests below could pass because the image bound already rejected zero, which is
+        the case they exist for."""
+        disassembly = DisassemblyResult()
+        disassembly.binary_info = SimpleNamespace(base_addr=0, binary_size=self.IMAGE_SIZE)
+
+        self.assertTrue(disassembly.isAddrWithinMemoryImage(0))
+
+    def test_direct_scan_without_a_bound_stops_at_a_zero_entry(self):
+        analyzer, _ = self._analyzer([0, self.LIVE])
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(0, 0x1090), [])
+
+    def test_direct_scan_without_a_bound_reads_a_live_entry(self):
+        """Positive control: the same harness terminated out of the image instead of by a
+        zero must collect the live entry, and must do so on either side of the fix, so an
+        empty result above cannot come from the scan never running."""
+        analyzer, _ = self._analyzer([self.LIVE, self.OUT_OF_IMAGE])
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(0, 0x1090), [self.LIVE])
+
+    def test_a_recovered_bound_skips_a_zero_entry_and_keeps_scanning(self):
+        analyzer, _ = self._analyzer([0, self.LIVE])
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(2, 0x1090), [self.LIVE])
+
+    def test_explicit_table_stops_at_a_zero_entry(self):
+        analyzer, _ = self._analyzer([0, self.LIVE], bitness=64)
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+
+        self.assertEqual(analyzer._resolveExplicitTable(0x2000, state, 0x1090), [])
+        self.assertEqual(state.refs, [])
+
+    def test_explicit_table_refuses_a_table_base_of_zero(self):
+        """The base reaches the scan through the same operand reader, which returns its
+        "nothing found" 0 for a dispatch naming no displacement (`jmp qword ptr [rax*8]`)."""
+        analyzer, _ = self._analyzer([self.LIVE, self.LIVE], bitness=64)
+        analyzer.disassembly.getBytes = MagicMock(side_effect=lambda addr, size: struct.pack("<Q", self.LIVE)[:size])
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+
+        self.assertEqual(analyzer._resolveExplicitTable(0x2000, state, 0), [])
+        self.assertEqual(state.refs, [])
+
+    def test_explicit_table_reads_a_live_entry(self):
+        """Positive control for the explicit-table arm, terminated out of the image so it
+        reads the same on either side of the fix."""
+        analyzer, entry_size = self._analyzer([self.LIVE, self.OUT_OF_IMAGE], bitness=64)
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+
+        self.assertEqual(analyzer._resolveExplicitTable(0x2000, state, 0x1090), [self.LIVE])
+        self.assertEqual(state.refs, [(0x2000, 0x1090, entry_size)])
+
+
+class ZeroTableEntryRecoveryTest(unittest.TestCase):
+    """End to end, in an image mapped at base 0: a dispatch whose derived table base lands
+    on zero bytes read address 0 as its only case target, and the function reaching the
+    dispatch was discarded whole rather than kept with an unresolved jump."""
+
+    FUNCTION = 0x100
+    TABLE = 0x1000
+    CASES = (0x40, 0x50, 0x60)
+
+    def _buffer(self, table_is_populated):
+        buffer = bytearray(0x2000)
+        code = bytes.fromhex("55")  # push ebp
+        code += bytes.fromhex("89e5")  # mov ebp, esp
+        code += bytes.fromhex("8b0485") + struct.pack("<I", self.TABLE)  # mov eax, [eax*4 + table]
+        code += bytes.fromhex("ffe0")  # jmp eax
+        buffer[self.FUNCTION : self.FUNCTION + len(code)] = code
+        for case in self.CASES:
+            buffer[self.FUNCTION + case : self.FUNCTION + case + 3] = bytes.fromhex("31c0c3")  # xor eax, eax; ret
+        if table_is_populated:
+            for index, case in enumerate(self.CASES):
+                struct.pack_into("<I", buffer, self.TABLE + index * 4, self.FUNCTION + case)
+            struct.pack_into("<I", buffer, self.TABLE + len(self.CASES) * 4, 0xDEADBEEF)
+        return bytes(buffer)
+
+    def _functions(self, table_is_populated):
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        report = Disassembler(config).disassembleBuffer(self._buffer(table_is_populated), 0, bitness=32)
+        self.assertEqual(report.status, "ok")
+        return report
+
+    def test_a_populated_table_dispatches_as_one_function(self):
+        """Positive control: the same image with a readable table must recover the dispatch
+        and its cases as one function, and does so on either side of the fix."""
+        report = self._functions(table_is_populated=True)
+
+        functions = list(report.getFunctions())
+        self.assertEqual([function.offset for function in functions], [self.FUNCTION])
+        self.assertEqual(
+            sorted(block.offset for block in functions[0].getBlocks()),
+            [self.FUNCTION] + [self.FUNCTION + case for case in self.CASES],
+        )
+
+    def test_a_zero_table_leaves_the_dispatching_function_recovered(self):
+        report = self._functions(table_is_populated=False)
+
+        self.assertIn(self.FUNCTION, [function.offset for function in report.getFunctions()])
+
+
+class PushRetZeroRecoveryTest(unittest.TestCase):
+    """End to end: `push <reg>; ret` names no literal, so the operand reader returns its
+    "nothing found" 0, which a base-0 image accepts - and address 0 was queued for decoding
+    as the return's destination, taking the whole function with it."""
+
+    FUNCTION = 0x100
+
+    def _report(self, through_a_register):
+        buffer = bytearray(0x400)
+        code = bytes.fromhex("55")  # push ebp
+        code += bytes.fromhex("89e5")  # mov ebp, esp
+        if through_a_register:
+            code += bytes.fromhex("31c0")  # xor eax, eax
+            code += bytes.fromhex("50")  # push eax
+        else:
+            code += b"\x68" + struct.pack("<I", 0x200)  # push 0x200
+        code += bytes.fromhex("c3")  # ret
+        buffer[self.FUNCTION : self.FUNCTION + len(code)] = code
+        buffer[0x200:0x203] = bytes.fromhex("31c0c3")  # xor eax, eax; ret
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        return Disassembler(config).disassembleBuffer(bytes(buffer), 0, bitness=32)
+
+    def test_a_register_destination_leaves_the_function_recovered(self):
+        report = self._report(through_a_register=True)
+
+        self.assertIn(self.FUNCTION, [function.offset for function in report.getFunctions()])
+
+    def test_a_literal_destination_is_still_followed(self):
+        """Positive control: the push-ret idiom naming a real address must keep working,
+        and reads the same on either side of the change."""
+        report = self._report(through_a_register=False)
+
+        self.assertIn(self.FUNCTION, [function.offset for function in report.getFunctions()])

--- a/tests/testJumpTableIndexBound.py
+++ b/tests/testJumpTableIndexBound.py
@@ -64,7 +64,7 @@ class DispatchIndexKeyTestSuite(unittest.TestCase):
     def test_unscaled_memory_operand_is_read_whole(self):
         analyzer = _makeAnalyzer()
 
-        self.assertEqual(analyzer._dispatchIndexKeys("byte ptr [rdi + rcx]"), {"[rdi + rcx]"})
+        self.assertEqual(analyzer._dispatchIndexKeys("byte ptr [rdi + rcx]"), {"byte ptr [rdi + rcx]"})
 
     def test_operand_naming_nothing_trackable_yields_no_key(self):
         analyzer = _makeAnalyzer()
@@ -116,6 +116,84 @@ class IndexTiedBoundTestSuite(unittest.TestCase):
 
         self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 6)
 
+    def test_a_shift_of_the_index_drops_the_tie(self):
+        """`shr eax, 8` redefines the index, so the compare further back bounds the value
+        before the shift and not what the dispatch ends up indexing with. Reporting it tied
+        would size the table at 1001 entries where the truth is 4."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 2, "ja", "0x1100"),
+            (0x1007, 3, "shr", "eax, 8"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0x3E9)
+
+    def test_any_non_copy_write_drops_the_tie(self):
+        """Several x86 instructions write a register they do not name first - xchg and xadd
+        write both operands, mul and div write rdx:rax, cpuid writes four - so a tie carried
+        across any non-copy write can bound a value the dispatch never indexes with. The tie
+        is dropped whole and the untied scan answers: here the nearer compare, not the tied
+        one further back."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 3, "add", "edx, 8"),
+            (0x1008, 5, "cmp", "esi, 0x3"),
+            (0x100D, 2, "mov", "ecx, eax"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 4)
+
+    def test_a_copy_between_the_index_and_its_bound_keeps_the_tie(self):
+        """Positive control: a copy is the one thing that carries the index forward, so the
+        same shape with a mov in place of the add still reaches the tied compare - without
+        this, the case above would pass even if the tie never worked at all."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 3, "mov", "edx, 8"),
+            (0x1008, 5, "cmp", "esi, 0x3"),
+            (0x100D, 2, "mov", "ecx, eax"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 0x3E9)
+
+    def test_a_write_to_a_tracked_cells_base_register_drops_the_tie(self):
+        """`add rax, 8` leaves the text "[rax]" naming a different cell, so the compare
+        against the old one is no longer a bound on what is loaded."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 6, "cmp", "dword ptr [rax], 0x3ff"),
+            (0x1006, 4, "add", "rax, 8"),
+            (0x100A, 2, "mov", "ecx, dword ptr [rax]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 0)
+
+    def test_the_same_cell_with_no_intervening_write_is_still_tied(self):
+        """Positive control for the rule above: without the `add` the cell is the same one
+        the compare bounds, so the tie must still be made."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 6, "cmp", "dword ptr [rax], 0x3ff"),
+            (0x1006, 2, "mov", "ecx, dword ptr [rax]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 0x400)
+
+    def test_a_compare_of_a_different_width_on_the_same_cell_is_not_the_bound(self):
+        """A dword compare does not bound a byte read of the same address - a byte index can
+        only reach 256 whatever the dword holds."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 7, "cmp", "dword ptr [rbp - 8], 0x3e8"),
+            (0x1007, 2, "ja", "0x1100"),
+            (0x1009, 4, "movzx", "eax, byte ptr [rbp - 8]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0)
+
     def test_untied_compare_is_still_used_when_the_index_is_unknown(self):
         """Without an index to tie to, the first register compare is the only evidence there
         is; dropping that fallback would abandon tables that the old scan sized correctly."""
@@ -162,11 +240,13 @@ class IndexTiedBoundTestSuite(unittest.TestCase):
 
 
 class OperandKeyTestSuite(unittest.TestCase):
-    def test_size_prefix_and_flat_segment_are_normalized_away(self):
+    def test_a_flat_segment_is_normalized_away_and_the_width_is_kept(self):
+        """The override names the same cell; the width does not. A dword compare and a byte
+        load of the same address read different values, so they must not share a key."""
         analyzer = _makeAnalyzer()
 
-        self.assertEqual(analyzer._operandKey("byte ptr ds:[rdi + rcx]"), "[rdi + rcx]")
-        self.assertEqual(analyzer._operandKey("qword ptr [rsp + 8]"), "[rsp + 8]")
+        self.assertEqual(analyzer._operandKey("byte ptr ds:[rdi + rcx]"), "byte ptr [rdi + rcx]")
+        self.assertNotEqual(analyzer._operandKey("dword ptr [rbp - 8]"), analyzer._operandKey("byte ptr [rbp - 8]"))
 
     def test_registers_normalize_to_their_family(self):
         analyzer = _makeAnalyzer()

--- a/tests/testJumpTableIndexBound.py
+++ b/tests/testJumpTableIndexBound.py
@@ -1,0 +1,242 @@
+import struct
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from smda.Disassembler import Disassembler
+from smda.intel.definitions import canonicalRegister
+from smda.intel.JumpTableAnalyzer import JumpTableAnalyzer
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+TEXT_RVA = 0x1000
+TABLE_RVA = 0x2000
+IMAGE_SIZE = 0x3000
+
+
+def _makeAnalyzer(binary=b"", base_addr=0x1000, bitness=64):
+    disassembler = MagicMock()
+    disassembly = MagicMock()
+    disassembly.binary_info = SimpleNamespace(
+        binary=binary, base_addr=base_addr, binary_size=len(binary) or 0x100, bitness=bitness
+    )
+    disassembler.disassembly = disassembly
+    disassembler.getBitMask.return_value = 0xFFFFFFFFFFFFFFFF
+    return JumpTableAnalyzer(disassembler)
+
+
+class CanonicalRegisterTestSuite(unittest.TestCase):
+    def test_every_spelling_maps_to_the_widest_name(self):
+        for spelling, expected in (
+            ("al", "rax"),
+            ("ah", "rax"),
+            ("ax", "rax"),
+            ("eax", "rax"),
+            ("rax", "rax"),
+            ("EAX", "rax"),
+            ("sil", "rsi"),
+            ("bpl", "rbp"),
+            ("r8d", "r8"),
+            ("r15b", "r15"),
+            ("r10w", "r10"),
+        ):
+            with self.subTest(spelling=spelling):
+                self.assertEqual(canonicalRegister(spelling), expected)
+
+    def test_non_registers_map_to_none(self):
+        for spelling in ("rip", "xmm0", "qword ptr [rax]", "0x10", ""):
+            with self.subTest(spelling=spelling):
+                self.assertIsNone(canonicalRegister(spelling))
+
+
+class DispatchIndexKeyTestSuite(unittest.TestCase):
+    def test_scaled_memory_operand_indexes_with_its_scaled_register(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._dispatchIndexKeys("qword ptr [rax*8 + 0x402018]"), {"rax"})
+        self.assertEqual(analyzer._dispatchIndexKeys("dword ptr [r11 + rdx*4]"), {"rdx"})
+
+    def test_register_operand_is_its_own_index(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._dispatchIndexKeys("rcx"), {"rcx"})
+
+    def test_unscaled_memory_operand_is_read_whole(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._dispatchIndexKeys("byte ptr [rdi + rcx]"), {"[rdi + rcx]"})
+
+    def test_operand_naming_nothing_trackable_yields_no_key(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._dispatchIndexKeys("0x401000"), set())
+
+
+class IndexTiedBoundTestSuite(unittest.TestCase):
+    """The bound that sizes a jump table is the one testing whatever the dispatch indexes
+    with. Taking the first `cmp <reg>, <imm>` instead finds an unrelated compare that happens
+    to sit closer to the dispatch, and misses a bound checked against the memory cell the
+    index is loaded from."""
+
+    def test_bound_is_followed_through_a_load_into_the_index_register(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "byte ptr [rdi + rcx], 0x19"),
+            (0x1003, 6, "ja", "0x1100"),
+            (0x1009, 3, "movzx", "eax, byte ptr [rdi + rcx]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0x1A)
+
+    def test_a_compare_on_an_unrelated_register_is_not_taken_as_the_bound(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "byte ptr [rdi + rcx], 0x19"),
+            (0x1003, 3, "movzx", "eax, byte ptr [rdi + rcx]"),
+            (0x1006, 3, "cmp", "edx, 0x3"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0x1A)
+
+    def test_a_sub_register_write_still_counts_as_the_index(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "byte ptr [rsi], 0x7"),
+            (0x1003, 3, "mov", "al, byte ptr [rsi]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 8)
+
+    def test_scaled_source_switches_tracking_to_the_scaled_register(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "edx, 0x5"),
+            (0x1003, 4, "movsxd", "rcx, dword ptr [r11 + rdx*4]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 6)
+
+    def test_untied_compare_is_still_used_when_the_index_is_unknown(self):
+        """Without an index to tie to, the first register compare is the only evidence there
+        is; dropping that fallback would abandon tables that the old scan sized correctly."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "eax, 0x9"),
+            (0x1003, 2, "mov", "ecx, 0x1"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, set()), 0xA)
+
+    def test_untied_compare_is_used_when_no_tied_one_exists(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "edx, 0x9"),
+            (0x1003, 2, "mov", "ecx, 0x1"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0xA)
+
+    def test_a_return_still_bounds_the_backtrack(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "eax, 0x9"),
+            (0x1003, 1, "bnd ret", ""),
+            (0x1004, 2, "mov", "ecx, 0x1"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0)
+
+    def test_a_bare_decimal_immediate_is_read_as_decimal(self):
+        """capstone prints an immediate below 10 without the 0x prefix, so parsing it as
+        base 16 would silently agree only for 0-9 and the parse has to say which it is."""
+        analyzer = _makeAnalyzer()
+        backtracked = [(0x1000, 3, "cmp", "eax, 9")]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 10)
+
+    def test_a_non_immediate_compare_is_ignored(self):
+        analyzer = _makeAnalyzer()
+        backtracked = [(0x1000, 3, "cmp", "eax, ecx")]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0)
+
+
+class OperandKeyTestSuite(unittest.TestCase):
+    def test_size_prefix_and_flat_segment_are_normalized_away(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._operandKey("byte ptr ds:[rdi + rcx]"), "[rdi + rcx]")
+        self.assertEqual(analyzer._operandKey("qword ptr [rsp + 8]"), "[rsp + 8]")
+
+    def test_registers_normalize_to_their_family(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._operandKey(" EAX "), "rax")
+
+    def test_an_immediate_has_no_key(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertIsNone(analyzer._operandKey("0x19"))
+
+
+class UnboundedTableOverreadTestSuite(unittest.TestCase):
+    """A table whose bound cannot be recovered is scanned to a 0xFF fallback, which walks
+    straight out of the table and into whatever follows it. With the bound recovered the scan
+    stops at the real end, so the functions stored behind the table stay their own."""
+
+    def _image(self, bound_is_tied):
+        image = bytearray(IMAGE_SIZE)
+        cases = 4
+        body = bytearray()
+        body += b"\x55\x48\x89\xe5"  # push rbp ; mov rbp, rsp
+        if bound_is_tied:
+            body += b"\x80\x3f" + bytes([cases - 1])  # cmp byte ptr [rdi], 3
+        else:
+            body += b"\x83\xfa" + bytes([cases - 1])  # cmp edx, 3 -- not the dispatch index
+        ja_at = len(body)
+        body += b"\x0f\x87" + struct.pack("<i", 0)
+        body += b"\x0f\xb6\x07"  # movzx eax, byte ptr [rdi]
+        body += b"\x3e\xff\x24\xc5" + struct.pack("<I", BASE + TABLE_RVA)
+        case_offsets = []
+        for index in range(cases):
+            case_offsets.append(len(body))
+            body += b"\xb8" + struct.pack("<I", index) + b"\x5d\xc3"
+        default_offset = len(body)
+        body += b"\x31\xc0\x5d\xc3"
+        struct.pack_into("<i", body, ja_at + 2, default_offset - (ja_at + 6))
+        neighbour_offset = len(body)
+        body += b"\x55\x48\x89\xe5\x5d\xc3"  # a separate function stored behind the switch
+        image[TEXT_RVA : TEXT_RVA + len(body)] = body
+
+        table = b"".join(struct.pack("<Q", BASE + TEXT_RVA + offset) for offset in case_offsets)
+        image[TABLE_RVA : TABLE_RVA + len(table)] = table
+        # what follows the table in .rodata: more in-image addresses, as a second table
+        # would be. An unbounded scan reads these as further jump targets.
+        trailing = b"".join(struct.pack("<Q", BASE + TEXT_RVA + neighbour_offset) for _ in range(8))
+        image[TABLE_RVA + len(table) : TABLE_RVA + len(table) + len(trailing)] = trailing
+        return bytes(image), BASE + TEXT_RVA + neighbour_offset
+
+    def _functions(self, bound_is_tied):
+        image, neighbour = self._image(bound_is_tied)
+        config = SmdaConfig()
+        config.CALCULATE_HASHING = False
+        config.TIMEOUT = 0
+        report = Disassembler(config=config).disassembleBuffer(image, BASE, bitness=64)
+        self.assertEqual(report.status, "ok")
+        return {function.offset for function in report.getFunctions()}, neighbour
+
+    def test_a_tied_bound_stops_the_scan_at_the_end_of_the_table(self):
+        functions, neighbour = self._functions(bound_is_tied=True)
+
+        self.assertIn(neighbour, functions)
+
+    def test_the_neighbour_is_a_function_either_way_when_the_bound_is_untied(self):
+        """Positive control: the untied shape must still analyse, so a difference between the
+        two cannot come from one of them failing outright."""
+        functions, _neighbour = self._functions(bound_is_tied=False)
+
+        self.assertIn(BASE + TEXT_RVA, functions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testLandingPadEntry.py
+++ b/tests/testLandingPadEntry.py
@@ -1,0 +1,192 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from smda.aarch64.definitions import BTI_C, BTI_JC
+from smda.aarch64.FunctionCandidate import FunctionCandidate as AArch64FunctionCandidate
+from smda.common.FunctionCandidate import FunctionCandidate as CommonFunctionCandidate
+from smda.common.RecursiveDisassembler import RecursiveDisassembler
+from smda.common.TailcallAnalyzer import TailcallAnalyzer
+from smda.intel.FunctionCandidate import FunctionCandidate as IntelFunctionCandidate
+
+ENDBR64 = b"\xf3\x0f\x1e\xfa"
+PROLOGUE = b"\x55\x48\x89\xe5"  # push rbp; mov rbp, rsp
+
+
+def _intelCandidate(payload, bitness=64, base_addr=0x400000):
+    binary_info = SimpleNamespace(
+        binary=payload,
+        base_addr=base_addr,
+        binary_size=len(payload),
+        bitness=bitness,
+        architecture="intel",
+    )
+    return IntelFunctionCandidate(binary_info, base_addr)
+
+
+class LandingPadEntryTestSuite(unittest.TestCase):
+    """`endbr64` marks an address an indirect branch may legally target, so a candidate
+    carrying one was declared by the image rather than guessed by a scan."""
+
+    def test_an_endbr64_entry_is_a_landing_pad(self):
+        self.assertTrue(_intelCandidate(ENDBR64 + PROLOGUE + b"\x90" * 16).isLandingPadEntry())
+
+    def test_a_bare_prologue_is_not_a_landing_pad(self):
+        """Positive control for the pair: the same prologue without the pad must answer False,
+        so the predicate is reading the pad and not the prologue behind it."""
+        self.assertFalse(_intelCandidate(PROLOGUE + b"\x90" * 16).isLandingPadEntry())
+
+    def test_the_pad_is_64_bit_only(self):
+        """`f3 0f 1e fa` decodes as `endbr64` only in 64-bit mode."""
+        self.assertFalse(_intelCandidate(ENDBR64 + PROLOGUE + b"\x90" * 16, bitness=32).isLandingPadEntry())
+
+    def test_a_backend_without_the_concept_answers_false(self):
+        candidate = CommonFunctionCandidate.__new__(CommonFunctionCandidate)
+
+        self.assertFalse(candidate.isLandingPadEntry())
+
+    def test_the_entry_shape_score_still_reads_the_prologue_behind_the_pad(self):
+        """The pad is not itself a prologue, so both spellings must score the same - which is
+        what makes the lower address win the tie in FunctionCandidate.__lt__."""
+        padded = _intelCandidate(ENDBR64 + PROLOGUE + b"\x90" * 16)
+        bare = _intelCandidate(PROLOGUE + b"\x90" * 16)
+
+        self.assertEqual(padded.getFunctionStartScore(), bare.getFunctionStartScore())
+        self.assertGreater(padded.getFunctionStartScore(), 0)
+
+
+def _aarch64Candidate(payload, base_addr=0x400000):
+    binary_info = SimpleNamespace(
+        binary=payload,
+        base_addr=base_addr,
+        binary_size=len(payload),
+        bitness=64,
+        architecture="aarch64",
+    )
+    return AArch64FunctionCandidate(binary_info, base_addr)
+
+
+class AArch64LandingPadEntryTestSuite(unittest.TestCase):
+    """AArch64Disassembler subclasses RecursiveDisassembler, so it reaches the same revert;
+    BTI is its landing pad and needs the same protection the intel pad gets."""
+
+    STP = (0xA9BF7BFD).to_bytes(4, "little")  # stp x29, x30, [sp, #-16]!
+
+    def test_a_bti_entry_is_a_landing_pad(self):
+        for word in (BTI_C, BTI_JC):
+            with self.subTest(word=hex(word)):
+                payload = word.to_bytes(4, "little") + self.STP
+                self.assertTrue(_aarch64Candidate(payload).isLandingPadEntry())
+
+    def test_a_frame_record_store_is_not_a_landing_pad(self):
+        """Positive control: the ordinary AArch64 entry must answer False, so the predicate is
+        reading BTI rather than any plausible-looking first word."""
+        self.assertFalse(_aarch64Candidate(self.STP + self.STP).isLandingPadEntry())
+
+    def test_a_short_candidate_is_not_a_landing_pad(self):
+        self.assertFalse(_aarch64Candidate(b"\x5f").isLandingPadEntry())
+
+
+class GapFunctionRevertTestSuite(unittest.TestCase):
+    """A gap function is reverted when a later candidate reaches its bytes, on the premise that
+    the gap scan claimed a fall-through it should not have. A landing-pad entry was not claimed
+    by guessing, so that premise does not apply to it."""
+
+    def _disassembler(self, candidate):
+        disassembler = RecursiveDisassembler.__new__(RecursiveDisassembler)
+        disassembler.disassembly = MagicMock()
+        disassembler.disassembly.ins2fn = {0x401010: 0x401000}
+        disassembler.disassembly.functions = {0x401000: []}
+        disassembler.fc_manager = MagicMock()
+        disassembler.fc_manager.candidates = {0x401000: candidate}
+        disassembler.backend = MagicMock()
+        return disassembler
+
+    def _candidate(self, payload):
+        candidate = _intelCandidate(payload, base_addr=0x401000)
+        candidate.setIsGapCandidate(True)
+        return candidate
+
+    def test_a_landing_pad_gap_function_is_not_reverted(self):
+        disassembler = self._disassembler(self._candidate(ENDBR64 + PROLOGUE + b"\x90" * 16))
+
+        self.assertFalse(disassembler._revertGapFunction(0x401010, 0x401020))
+        disassembler.backend.createAnalysisState.assert_not_called()
+
+    def test_a_gap_function_without_a_pad_is_still_reverted(self):
+        """Positive control: the exemption must be narrow, or it would disable the mechanism."""
+        disassembler = self._disassembler(self._candidate(PROLOGUE + b"\x90" * 16))
+
+        self.assertTrue(disassembler._revertGapFunction(0x401010, 0x401020))
+        disassembler.backend.createAnalysisState.assert_called_once()
+
+    def test_a_non_gap_candidate_is_never_reverted(self):
+        candidate = _intelCandidate(PROLOGUE + b"\x90" * 16, base_addr=0x401000)
+        disassembler = self._disassembler(candidate)
+
+        self.assertFalse(disassembler._revertGapFunction(0x401010, 0x401020))
+
+
+class TailcallAbsorptionTestSuite(unittest.TestCase):
+    """The tailcall pass reverts a function when an external jump lands inside it, then
+    re-creates it only if the new analysis did not swallow its start. A start the image
+    declared with a landing pad must be re-created even when it was swallowed."""
+
+    DESTINATION_FUNCTION = 0x400000
+    DESTINATION_ADDR = 0x400010
+
+    def _run(self, entry_payload):
+        analyzer = TailcallAnalyzer()
+        reverted = []
+        destination_function = SimpleNamespace(
+            start_addr=self.DESTINATION_FUNCTION,
+            is_tailcall_function=False,
+            revertAnalysis=lambda: reverted.append(True),
+        )
+        # the new analysis swallowed the old start, which is the branch under test
+        absorbing_function = SimpleNamespace(
+            start_addr=self.DESTINATION_ADDR,
+            is_tailcall_function=False,
+            instruction_start_bytes={self.DESTINATION_FUNCTION, self.DESTINATION_ADDR},
+        )
+        analyzer._TailcallAnalyzer__functions = [destination_function, absorbing_function]
+        analyzer.getTailcalls = lambda: [
+            {
+                "source_addr": 0x400100,
+                "destination_addr": self.DESTINATION_ADDR,
+                "destination_function": self.DESTINATION_FUNCTION,
+            }
+        ]
+
+        disassembler = MagicMock()
+        disassembler._analysisTimeoutTripped.return_value = False
+        disassembler.fc_manager.candidates = {
+            self.DESTINATION_FUNCTION: _intelCandidate(entry_payload, base_addr=self.DESTINATION_FUNCTION)
+        }
+
+        def analyze(addr):
+            if addr == self.DESTINATION_FUNCTION:
+                analyzer._TailcallAnalyzer__functions.append(destination_function)
+
+        disassembler.analyzeFunction.side_effect = analyze
+        analyzer.resolveTailcalls(disassembler)
+        analysed = [call.args[0] for call in disassembler.analyzeFunction.call_args_list]
+        return reverted, analysed
+
+    def test_a_swallowed_landing_pad_start_is_restored(self):
+        reverted, analysed = self._run(ENDBR64 + PROLOGUE + b"\x90" * 16)
+
+        self.assertEqual(reverted, [True])
+        self.assertIn(self.DESTINATION_FUNCTION, analysed)
+
+    def test_a_swallowed_ordinary_start_stays_absorbed(self):
+        """Positive control: absorbing a start the scan guessed is the mechanism working, so
+        the exemption must not reach it."""
+        reverted, analysed = self._run(PROLOGUE + b"\x90" * 16)
+
+        self.assertEqual(reverted, [True])
+        self.assertEqual(analysed, [self.DESTINATION_ADDR])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testMalpediaHarness.py
+++ b/tests/testMalpediaHarness.py
@@ -1,0 +1,109 @@
+"""Tests for the CI corpus harness (`.github/workflows/scripts/process_malpedia.py`).
+
+Only the sample-selection predicate is covered here: it decides which of the corpus files reach
+the benchmark at all, and a file it drops is invisible to every downstream check.
+"""
+
+import importlib.util
+import struct
+import unittest
+from pathlib import Path
+
+_TESTS = Path(__file__).resolve().parent
+_SCRIPT = _TESTS.parent / ".github" / "workflows" / "scripts" / "process_malpedia.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("process_malpedia", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pm = _load_module()
+
+EM_386 = 0x03
+EM_X86_64 = 0x3E
+EM_ARM = 0x28
+
+
+def _elf_header(machine, little_endian=True, bitness_class=2):
+    """The first 20 bytes of an ELF header - everything the predicate reads."""
+    header = bytearray(20)
+    header[0:4] = b"\x7fELF"
+    header[4] = bitness_class
+    header[5] = 1 if little_endian else 2
+    struct.pack_into(("<" if little_endian else ">") + "H", header, 0x12, machine)
+    return bytes(header)
+
+
+def _plain(fixture_name):
+    data = (_TESTS / fixture_name).read_bytes()[:64]
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
+
+
+class TestIntelElfPredicate(unittest.TestCase):
+    def test_the_two_machine_types_smda_reads_are_accepted(self):
+        for machine in (EM_386, EM_X86_64):
+            with self.subTest(machine=hex(machine)):
+                self.assertTrue(pm.isIntelElf(_elf_header(machine)))
+
+    def test_a_foreign_machine_type_is_refused(self):
+        self.assertFalse(pm.isIntelElf(_elf_header(EM_ARM)))
+
+    def test_the_declared_byte_order_decides_how_the_machine_field_reads(self):
+        """A big-endian header storing 0x3e00 reads back as EM_X86_64 if EI_DATA is ignored."""
+        header = _elf_header(0x3E00, little_endian=False)
+
+        self.assertFalse(pm.isIntelElf(header))
+
+    def test_a_truncated_or_non_elf_header_is_refused(self):
+        self.assertFalse(pm.isIntelElf(_elf_header(EM_X86_64)[:8]))
+        self.assertFalse(pm.isIntelElf(b"MZ" + bytes(30)))
+        self.assertFalse(pm.isIntelElf(b""))
+
+    def test_a_path_that_cannot_be_read_is_refused_rather_than_raising(self):
+        self.assertFalse(pm.isIntelElfFile(_TESTS / "does-not-exist"))
+
+
+class TestIntelElfPredicateOnRealSamples(unittest.TestCase):
+    """The predicate replaced a test on the file's PATH, so it has to be right about real files.
+
+    The bundled foreign-architecture mirai builds are the control: every one of them is an ELF
+    that the old path test would also have refused, and refusing them is the behaviour being
+    preserved. The x86 fixtures are the half the path test got wrong.
+    """
+
+    INTEL = ("mirai_i386_xored", "mirai_x64_xored", "bashlite_xored", "elf_ehframe_hdr_x64_xored")
+    FOREIGN = (
+        "mirai_arm_xored",
+        "mirai_m68k_xored",
+        "mirai_mips_xored",
+        "mirai_mipsel_xored",
+        "mirai_nios2_xored",
+        "mirai_openrisc_xored",
+        "mirai_ppc_xored",
+        "mirai_sh4_xored",
+        "mirai_sparc_xored",
+        "mirai_xtensa_xored",
+    )
+
+    def test_every_bundled_x86_elf_is_accepted(self):
+        for name in self.INTEL:
+            with self.subTest(fixture=name):
+                self.assertTrue(pm.isIntelElf(_plain(name)))
+
+    def test_every_bundled_foreign_architecture_elf_is_refused(self):
+        for name in self.FOREIGN:
+            with self.subTest(fixture=name):
+                self.assertFalse(pm.isIntelElf(_plain(name)))
+
+    def test_the_fixtures_really_are_elf_files(self):
+        """Without this the two suites above would agree on anything, including empty reads."""
+        for name in self.INTEL + self.FOREIGN:
+            with self.subTest(fixture=name):
+                self.assertEqual(_plain(name)[:4], b"\x7fELF")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testRawBufferArchProbe.py
+++ b/tests/testRawBufferArchProbe.py
@@ -55,6 +55,17 @@ class LooksLikeAArch64Test(unittest.TestCase):
     def testDenseEnoughReturnWordsAreAccepted(self):
         self.assertTrue(looksLikeAArch64(RET_X30_BYTES * MIN_RETURN_WORDS))
 
+    def testABufferDenseInMisalignedReturnWordsIsNotRecognized(self):
+        """A buffer can offer an occurrence at every position while none of them is aligned.
+        The scan resumes at the next aligned offset rather than the next byte, so this costs a
+        step per aligned slot instead of one per occurrence; the verdict is what is asserted."""
+        self.assertFalse(looksLikeAArch64(b"\x00" + RET_X30_BYTES * 4096))
+
+    def testTheSameWordsAlignedAreRecognized(self):
+        """Positive control: the buffer above is rejected for where its words sit, not for
+        how many there are."""
+        self.assertTrue(looksLikeAArch64(RET_X30_BYTES * 4096))
+
 
 class RawBufferArchitectureSelectionTest(unittest.TestCase):
     def testAArch64BufferIsNotDisassembledAsIntel(self):

--- a/tests/testSegmentQualifiedBranches.py
+++ b/tests/testSegmentQualifiedBranches.py
@@ -117,6 +117,61 @@ class NotrackDispatchRecoveryTestSuite(unittest.TestCase):
             self.assertIn(case, blocks)
 
 
+def _tableLoadSwitchImage(segment_prefix=b"\x3e"):
+    """A 32-bit switch whose table base is loaded through a segment-qualified operand.
+
+    The dispatch here is a plain `jmp eax`; what carries the override is the load of the
+    table entry, which the jump-table analyzer finds by matching an anchored pattern against
+    the instructions it walks back over. Those instructions are stored as capstone rendered
+    them, so a prefix on the load hides the table just as one on the branch hid the dispatch.
+    """
+    image = bytearray(IMAGE_SIZE)
+    body = bytearray(b"\x55\x89\xe5")  # push ebp ; mov ebp, esp
+    body += b"\x80\x3f" + bytes([CASES - 1])  # cmp byte ptr [edi], CASES-1
+    ja_at = len(body)
+    body += b"\x0f\x87" + struct.pack("<i", 0)  # ja default (patched below)
+    body += b"\x0f\xb6\x07"  # movzx eax, byte ptr [edi]
+    body += segment_prefix + b"\x8b\x04\x85" + struct.pack("<I", BASE + TABLE_RVA)
+    body += b"\xff\xe0"  # jmp eax
+    case_offsets = []
+    for index in range(CASES):
+        case_offsets.append(len(body))
+        body += b"\xb8" + struct.pack("<I", index) + b"\x5d\xc3"  # mov eax, i ; pop ebp ; ret
+    default_offset = len(body)
+    body += b"\x31\xc0\x5d\xc3"  # xor eax, eax ; pop ebp ; ret
+    struct.pack_into("<i", body, ja_at + 2, default_offset - (ja_at + 6))
+
+    image[TEXT_RVA : TEXT_RVA + len(body)] = body
+    table = b"".join(struct.pack("<I", BASE + TEXT_RVA + offset) for offset in case_offsets)
+    image[TABLE_RVA : TABLE_RVA + len(table)] = table
+    return bytes(image), [BASE + TEXT_RVA + offset for offset in case_offsets]
+
+
+class SegmentQualifiedTableLoadTestSuite(unittest.TestCase):
+    """Seeing the dispatch is not enough on its own: the same override defeats every anchored
+    pattern the jump-table analyzer matches against the instructions it walks back over."""
+
+    def _functions(self, segment_prefix):
+        image, cases = _tableLoadSwitchImage(segment_prefix)
+        report = Disassembler(config=_config()).disassembleBuffer(image, BASE, bitness=32)
+        self.assertEqual(report.status, "ok")
+        return {function.offset for function in report.getFunctions()}, cases
+
+    def test_a_segment_qualified_table_load_still_finds_the_table(self):
+        functions, cases = self._functions(b"\x3e")
+
+        self.assertEqual(functions, {BASE + TEXT_RVA})
+        self.assertEqual(functions & set(cases), set())
+
+    def test_an_unprefixed_table_load_recovers_identically(self):
+        """Positive control: the same switch with no override, which always worked - without
+        it a fixture that recovered nothing would satisfy the assertion above."""
+        functions, cases = self._functions(b"")
+
+        self.assertEqual(functions, {BASE + TEXT_RVA})
+        self.assertEqual(functions & set(cases), set())
+
+
 class SegmentQualifiedBranchClassificationTestSuite(unittest.TestCase):
     def _analyze(self, code, bitness=64):
         image = bytearray(IMAGE_SIZE)
@@ -172,6 +227,52 @@ class SegmentQualifiedBranchClassificationTestSuite(unittest.TestCase):
         self.assertEqual(report.status, "ok")
         caller = next(f for f in report.getFunctions() if f.offset == BASE + TEXT_RVA)
         return {xref.to_instruction.offset for xref in caller.getCodeOutrefs()}, callee
+
+    def _outrefsOf(self, image):
+        """Raw outref targets, not getCodeOutrefs(): a near indirect jump books the pointer
+        slot, which is data and therefore has no instruction to resolve to."""
+        report = Disassembler(config=_config()).disassembleBuffer(image, BASE, bitness=32)
+        self.assertEqual(report.status, "ok")
+        function = next((f for f in report.getFunctions() if f.offset == BASE + TEXT_RVA), None)
+        self.assertIsNotNone(function, "the fixture must recover a function at the code start")
+        return {target for targets in (function.outrefs or {}).values() for target in targets}
+
+    def _farIndirectTargets(self, segment_prefix):
+        """<prefix> ff 2d <disp32> -- a far indirect jump, which loads a seg:offset pair.
+
+        capstone renders it "ptr [0x...]" against a near indirect jump's "dword ptr [0x...]",
+        and the width is the only thing telling them apart once a zero-base override is
+        normalized away: both spell a colon while the prefix is still there.
+        """
+        image = bytearray(IMAGE_SIZE)
+        slot_rva = TEXT_RVA + 0x40
+        code = bytearray(b"\x55\x89\xe5")  # push ebp ; mov ebp, esp
+        code += segment_prefix + b"\xff\x2d" + struct.pack("<I", BASE + slot_rva)
+        image[TEXT_RVA : TEXT_RVA + len(code)] = code
+        image[slot_rva : slot_rva + 4] = struct.pack("<I", BASE + TEXT_RVA + 0x20)
+        callee = b"\x55\x89\xe5\x5d\xc3"
+        image[TEXT_RVA + 0x20 : TEXT_RVA + 0x20 + len(callee)] = callee
+        return self._outrefsOf(bytes(image))
+
+    def test_a_far_indirect_jump_books_no_target(self):
+        for segment_prefix, label in ((b"", "none"), (b"\x2e", "cs"), (b"\x3e", "ds")):
+            with self.subTest(prefix=label):
+                self.assertEqual(self._farIndirectTargets(segment_prefix), set())
+
+    def test_a_near_indirect_jump_through_the_same_slot_is_booked(self):
+        """Positive control: the same encoding one modrm bit away (ff 25, near) does reach an
+        address in this image, so the assertion above is about the far form and not about the
+        fixture being unreachable."""
+        image = bytearray(IMAGE_SIZE)
+        slot_rva = TEXT_RVA + 0x40
+        code = bytearray(b"\x55\x89\xe5")
+        code += b"\x3e\xff\x25" + struct.pack("<I", BASE + slot_rva)
+        image[TEXT_RVA : TEXT_RVA + len(code)] = code
+        image[slot_rva : slot_rva + 4] = struct.pack("<I", BASE + TEXT_RVA + 0x20)
+        callee = b"\x55\x89\xe5\x5d\xc3"
+        image[TEXT_RVA + 0x20 : TEXT_RVA + 0x20 + len(callee)] = callee
+
+        self.assertEqual(self._outrefsOf(bytes(image)), {BASE + slot_rva})
 
     def test_segment_qualified_indirect_call_is_booked(self):
         targets, callee = self._bookedCallTargets(b"\x3e")

--- a/tests/testSegmentQualifiedBranches.py
+++ b/tests/testSegmentQualifiedBranches.py
@@ -1,0 +1,189 @@
+import struct
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.intel.definitions import stripFlatSegmentOverride
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+TEXT_RVA = 0x1000
+TABLE_RVA = 0x2000
+IMAGE_SIZE = 0x3000
+CASES = 6
+
+
+def _config():
+    config = SmdaConfig()
+    config.CALCULATE_HASHING = False
+    config.CALCULATE_SCC = False
+    config.CALCULATE_NESTING = False
+    config.TIMEOUT = 0
+    return config
+
+
+def _notrackSwitchImage(segment_prefix=b"\x3e"):
+    """A 64-bit image whose one function dispatches a bounded switch through a jump table.
+
+    The shape is what gcc emits for a dense switch in a non-PIE x86-64 binary built with CET
+    branch protection: the bound is compared against the memory cell the index is loaded from,
+    and the indirect jump carries the 0x3e "notrack" prefix, which capstone renders as a ds:
+    segment override on the memory operand.
+    """
+    image = bytearray(IMAGE_SIZE)
+    body = bytearray()
+    body += b"\x55\x48\x89\xe5"  # push rbp ; mov rbp, rsp
+    body += b"\x80\x3f" + bytes([CASES - 1])  # cmp byte ptr [rdi], CASES-1
+    ja_at = len(body)
+    body += b"\x0f\x87" + struct.pack("<i", 0)  # ja default (patched once its offset is known)
+    body += b"\x0f\xb6\x07"  # movzx eax, byte ptr [rdi]
+    dispatch_at = len(body)
+    body += segment_prefix + b"\xff\x24\xc5" + struct.pack("<I", BASE + TABLE_RVA)
+    case_offsets = []
+    for index in range(CASES):
+        case_offsets.append(len(body))
+        body += b"\xb8" + struct.pack("<I", index) + b"\x5d\xc3"  # mov eax, i ; pop rbp ; ret
+    default_offset = len(body)
+    body += b"\x31\xc0\x5d\xc3"  # xor eax, eax ; pop rbp ; ret
+    struct.pack_into("<i", body, ja_at + 2, default_offset - (ja_at + 6))
+
+    image[TEXT_RVA : TEXT_RVA + len(body)] = body
+    table = b"".join(struct.pack("<Q", BASE + TEXT_RVA + offset) for offset in case_offsets)
+    image[TABLE_RVA : TABLE_RVA + len(table)] = table
+    return bytes(image), BASE + TEXT_RVA + dispatch_at, [BASE + TEXT_RVA + o for o in case_offsets]
+
+
+class FlatSegmentOverrideTestSuite(unittest.TestCase):
+    """CS/DS/ES/SS have a zero base, so their override is noise on an image address;
+    FS/GS carry a thread-local base and must keep the prefix that marks them unresolvable."""
+
+    def test_zero_base_overrides_are_removed(self):
+        for operand, expected in (
+            ("qword ptr ds:[rax*8 + 0x402018]", "qword ptr [rax*8 + 0x402018]"),
+            ("dword ptr cs:[0x8049000]", "dword ptr [0x8049000]"),
+            ("dword ptr es:[edi]", "dword ptr [edi]"),
+            ("qword ptr ss:[rsp + 8]", "qword ptr [rsp + 8]"),
+        ):
+            with self.subTest(operand=operand):
+                self.assertEqual(stripFlatSegmentOverride(operand), expected)
+
+    def test_thread_local_overrides_are_kept(self):
+        for operand in ("qword ptr fs:[0x30]", "qword ptr gs:[0x60]"):
+            with self.subTest(operand=operand):
+                self.assertEqual(stripFlatSegmentOverride(operand), operand)
+
+    def test_operands_without_an_override_are_unchanged(self):
+        for operand in ("qword ptr [rip + 0x2f31]", "rax", "0x33:0x401000", ""):
+            with self.subTest(operand=operand):
+                self.assertEqual(stripFlatSegmentOverride(operand), operand)
+
+
+class NotrackDispatchRecoveryTestSuite(unittest.TestCase):
+    """A jump whose memory operand carries a segment override used to be classified as a far
+    jump -- ":" appears in both spellings -- so the dispatch was dropped, its case bodies were
+    never linked, and the gap scan promoted each of them to a function of its own."""
+
+    def test_case_bodies_stay_inside_the_dispatching_function(self):
+        image, dispatch, cases = _notrackSwitchImage()
+        report = Disassembler(config=_config()).disassembleBuffer(image, BASE, bitness=64)
+
+        self.assertEqual(report.status, "ok")
+        functions = {function.offset for function in report.getFunctions()}
+        self.assertEqual(functions, {BASE + TEXT_RVA})
+        blocks = {
+            instruction.offset
+            for function in report.getFunctions()
+            for block in function.getBlocks()
+            for instruction in block.getInstructions()
+        }
+        for case in cases:
+            self.assertIn(case, blocks)
+        self.assertIn(dispatch, blocks)
+
+    def test_unprefixed_dispatch_recovers_identically(self):
+        """Positive control: the same switch without the notrack prefix always worked, so the
+        assertion above cannot be passing because the image is degenerate."""
+        image, _dispatch, cases = _notrackSwitchImage(segment_prefix=b"\x90")
+        report = Disassembler(config=_config()).disassembleBuffer(image, BASE, bitness=64)
+
+        self.assertEqual(report.status, "ok")
+        self.assertEqual({function.offset for function in report.getFunctions()}, {BASE + TEXT_RVA})
+        blocks = {
+            instruction.offset
+            for function in report.getFunctions()
+            for block in function.getBlocks()
+            for instruction in block.getInstructions()
+        }
+        for case in cases:
+            self.assertIn(case, blocks)
+
+
+class SegmentQualifiedBranchClassificationTestSuite(unittest.TestCase):
+    def _analyze(self, code, bitness=64):
+        image = bytearray(IMAGE_SIZE)
+        image[TEXT_RVA : TEXT_RVA + len(code)] = code
+        report = Disassembler(config=_config()).disassembleBuffer(bytes(image), BASE, bitness=bitness)
+        function = next((f for f in report.getFunctions() if f.offset == BASE + TEXT_RVA), None)
+        self.assertIsNotNone(function, "the fixture must recover a function at the code start")
+        return report, function
+
+    def test_thread_local_indirect_jump_books_no_target(self):
+        # push rbp ; mov rbp, rsp ; jmp qword ptr gs:[0x60] -- the base is not in the image,
+        # so no code reference can be booked for it
+        code = b"\x55\x48\x89\xe5\x65\xff\x24\x25\x60\x00\x00\x00"
+        _report, function = self._analyze(code)
+
+        self.assertEqual([xref.to_instruction.offset for xref in function.getCodeOutrefs()], [])
+
+    def test_far_jump_books_no_target(self):
+        """Positive control for the same arm: a real far pointer (seg:offset, no memory
+        operand) must still be dropped, which is what the colon test was there for."""
+        # push rbp ; mov rbp, rsp ; ljmp 0x33:0x401000
+        code = b"\x55\x48\x89\xe5\xff\x2c\x25\x00\x10\x40\x00"
+        _report, function = self._analyze(code)
+
+        self.assertEqual([xref.to_instruction.offset for xref in function.getCodeOutrefs()], [])
+
+    def _callThroughSlotImage(self, segment_prefix):
+        """push rbp ; mov rbp, rsp ; <prefix> call qword ptr [rip + disp] ; ret
+
+        The pointer slot sits at a displacement of at least 0x10 so capstone prints it
+        0x-prefixed: it renders a smaller one as a bare decimal, which the shared operand
+        reader deliberately does not match.
+        """
+        image = bytearray(IMAGE_SIZE)
+        slot_rva = TEXT_RVA + 0x40
+        callee_rva = slot_rva + 8
+        prologue = b"\x55\x48\x89\xe5"
+        call_rva = TEXT_RVA + len(prologue)
+        call_size = len(segment_prefix) + 6
+        displacement = (TEXT_RVA + 0x40) - (call_rva + call_size)
+        code = bytearray(prologue)
+        code += segment_prefix + b"\xff\x15" + struct.pack("<i", displacement)
+        code += b"\xc3"
+        image[TEXT_RVA : TEXT_RVA + len(code)] = code
+        image[slot_rva : slot_rva + 8] = struct.pack("<Q", BASE + callee_rva)
+        callee = b"\x55\x48\x89\xe5\x5d\xc3"
+        image[callee_rva : callee_rva + len(callee)] = callee
+        return bytes(image), BASE + callee_rva
+
+    def _bookedCallTargets(self, segment_prefix):
+        image, callee = self._callThroughSlotImage(segment_prefix)
+        report = Disassembler(config=_config()).disassembleBuffer(image, BASE, bitness=64)
+        self.assertEqual(report.status, "ok")
+        caller = next(f for f in report.getFunctions() if f.offset == BASE + TEXT_RVA)
+        return {xref.to_instruction.offset for xref in caller.getCodeOutrefs()}, callee
+
+    def test_segment_qualified_indirect_call_is_booked(self):
+        targets, callee = self._bookedCallTargets(b"\x3e")
+
+        self.assertIn(callee, targets)
+
+    def test_unprefixed_indirect_call_is_booked(self):
+        """Positive control: the same call without the notrack prefix always resolved."""
+        targets, callee = self._bookedCallTargets(b"\x90")
+
+        self.assertIn(callee, targets)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testUnsupportedInstructionSetProbe.py
+++ b/tests/testUnsupportedInstructionSetProbe.py
@@ -1,11 +1,16 @@
 import unittest
 from pathlib import Path
+from unittest import mock
 
+import smda.common.instruction_set_probe as probe
 from smda.common.instruction_set_probe import (
     MIN_RETURN_SITES,
+    NEIGHBOURHOOD_BYTES,
     RETURN_SIGNATURES,
-    countAlignedOccurrences,
+    WINDOW_BYTES,
+    countCodeReturnSites,
     detectUnsupportedInstructionSet,
+    looksLikeText,
 )
 from smda.Disassembler import Disassembler
 from smda.SmdaConfig import SmdaConfig
@@ -39,6 +44,8 @@ SUPPORTED_FIXTURES = (
     "njrat_xored",
 )
 
+OPENRISC_RETURN = RETURN_SIGNATURES["openrisc"][0][0]
+
 
 def _load(name):
     data = (FIXTURES / name).read_bytes()
@@ -54,15 +61,109 @@ def _config():
     return config
 
 
+def _plant(pattern, count, spacing, filler=b"\x00", size=None):
+    """`count` copies of `pattern`, `spacing` bytes apart, in filler that is not text."""
+    size = size if size is not None else count * spacing + spacing
+    buffer = bytearray(filler * (size // len(filler) + 1))[:size]
+    for index in range(count):
+        offset = index * spacing
+        buffer[offset : offset + len(pattern)] = pattern
+    return bytes(buffer)
+
+
 class ReturnSignatureCountTestSuite(unittest.TestCase):
     def test_only_aligned_occurrences_are_counted(self):
         buffer = b"\x00" + b"\x4e\x80\x00\x20" + b"\x00" * 3 + b"\x4e\x80\x00\x20"
 
-        self.assertEqual(countAlignedOccurrences(buffer, b"\x4e\x80\x00\x20", 4), 1)
-        self.assertEqual(countAlignedOccurrences(buffer, b"\x4e\x80\x00\x20", 1), 2)
+        self.assertEqual(countCodeReturnSites(buffer, b"\x4e\x80\x00\x20", 4, 8), 1)
+        self.assertEqual(countCodeReturnSites(buffer, b"\x4e\x80\x00\x20", 1, 8), 2)
 
     def test_a_missing_pattern_counts_zero(self):
-        self.assertEqual(countAlignedOccurrences(b"\x00" * 64, b"\x4e\x80\x00\x20", 4), 0)
+        self.assertEqual(countCodeReturnSites(b"\x00" * 64, b"\x4e\x80\x00\x20", 4, 8), 0)
+
+    def test_a_buffer_dense_in_misaligned_copies_counts_none(self):
+        """The scan resumes at the next aligned offset rather than the next byte, so a buffer
+        offering an occurrence at every position costs one step per aligned slot instead of
+        one per occurrence. The count is what matters here; the cost is why."""
+        buffer = b"\x00" + b"\x1d\xf0" * 4096
+
+        self.assertEqual(countCodeReturnSites(buffer, b"\x1d\xf0", 2, 8), 0)
+
+    def test_the_same_pattern_aligned_is_counted(self):
+        """Positive control: the buffer above reads zero because of where the copies sit, not
+        because the pattern is wrong."""
+        buffer = b"\x1d\xf0" * 4096
+
+        self.assertEqual(countCodeReturnSites(buffer, b"\x1d\xf0", 2, 10), 10)
+
+
+class ProbeCapTestSuite(unittest.TestCase):
+    """A buffer can hold an occurrence at every position while none of them is aligned, so
+    skipping to the next aligned offset still leaves one step per aligned slot. The cap bounds
+    that: reaching it means the buffer is denser in near-misses than any real code, and the
+    answer stays silence."""
+
+    CAP = 4
+
+    def test_the_walk_gives_up_once_the_cap_is_reached(self):
+        buffer = _plant(OPENRISC_RETURN, 64, 8)
+
+        with mock.patch.object(probe, "MAX_PROBES", self.CAP):
+            self.assertEqual(countCodeReturnSites(buffer, OPENRISC_RETURN, 4, 1000), self.CAP)
+
+    def test_the_same_buffer_is_counted_in_full_without_the_cap(self):
+        """Positive control: the buffer really does hold 64 of them, so the number above is
+        the cap and not the buffer running out."""
+        buffer = _plant(OPENRISC_RETURN, 64, 8)
+
+        self.assertEqual(countCodeReturnSites(buffer, OPENRISC_RETURN, 4, 1000), 64)
+
+    def test_a_capped_walk_names_no_instruction_set(self):
+        """The cap decides towards silence: a buffer it cannot finish reading is not claimed."""
+        buffer = _plant(OPENRISC_RETURN, MIN_RETURN_SITES * 4, 8)
+
+        with mock.patch.object(probe, "MAX_PROBES", self.CAP):
+            self.assertIsNone(detectUnsupportedInstructionSet(buffer))
+
+
+class TextNeighbourhoodTestSuite(unittest.TestCase):
+    """A return word surrounded by UTF-16 is a letter pair, not an instruction. This is what
+    separates real foreign code from a text table: over the ten bundled foreign samples not
+    one hit sits in a neighbourhood like this."""
+
+    def test_utf16_little_endian_surroundings_are_text(self):
+        buffer = b"D\x00H\x00" * 32
+
+        self.assertTrue(looksLikeText(buffer, 64))
+
+    def test_utf16_big_endian_surroundings_are_text(self):
+        buffer = b"\x00D\x00H" * 32
+
+        self.assertTrue(looksLikeText(buffer, 64))
+
+    def test_binary_surroundings_are_not_text(self):
+        """Positive control: the same hit offset in filler that is not text must be kept, or
+        the veto would reject every signature everywhere."""
+        buffer = _plant(OPENRISC_RETURN, 4, 64)
+
+        self.assertFalse(looksLikeText(buffer, 64))
+
+    def test_a_neighbourhood_too_short_to_judge_is_not_text(self):
+        self.assertFalse(looksLikeText(b"D\x00H\x00", 0))
+
+
+class WindowedReturnSiteCountTestSuite(unittest.TestCase):
+    def test_hits_inside_the_range_are_counted_and_text_is_skipped(self):
+        code = _plant(OPENRISC_RETURN, 4, 64)
+        text = b"D\x00H\x00" * 64
+
+        self.assertEqual(countCodeReturnSites(code, OPENRISC_RETURN, 4, 8), 4)
+        self.assertEqual(countCodeReturnSites(text, OPENRISC_RETURN, 4, 8), 0)
+
+    def test_counting_stops_at_the_limit(self):
+        code = _plant(OPENRISC_RETURN, 16, 64)
+
+        self.assertEqual(countCodeReturnSites(code, OPENRISC_RETURN, 4, 3), 3)
 
 
 class UnsupportedInstructionSetDetectionTestSuite(unittest.TestCase):
@@ -80,24 +181,43 @@ class UnsupportedInstructionSetDetectionTestSuite(unittest.TestCase):
                 self.assertIsNone(detectUnsupportedInstructionSet(_load(name)))
 
     def test_a_handful_of_return_words_is_below_the_threshold(self):
-        pattern = RETURN_SIGNATURES["ppc"][0][0]
-        buffer = pattern * (MIN_RETURN_SITES - 1)
-
-        self.assertIsNone(detectUnsupportedInstructionSet(buffer))
+        self.assertIsNone(detectUnsupportedInstructionSet(_plant(OPENRISC_RETURN, MIN_RETURN_SITES - 1, 64)))
 
     def test_the_same_words_at_the_threshold_are_recognized(self):
         """Positive control for the threshold itself, so the case above cannot be passing
         because the pattern is wrong rather than because the count is too low."""
-        pattern = RETURN_SIGNATURES["ppc"][0][0]
-        buffer = pattern * MIN_RETURN_SITES
+        self.assertEqual(detectUnsupportedInstructionSet(_plant(OPENRISC_RETURN, MIN_RETURN_SITES, 64)), "openrisc")
 
-        self.assertEqual(detectUnsupportedInstructionSet(buffer), "ppc")
+    def test_return_words_spread_wider_than_a_window_are_not_enough(self):
+        """The bar is density within one window, not a total. Sixteen hits scattered through
+        a megabyte is what a large dump of ordinary data looks like."""
+        spread = _plant(OPENRISC_RETURN, MIN_RETURN_SITES, WINDOW_BYTES // 2)
 
-    def test_return_words_too_sparse_for_the_buffer_are_ignored(self):
-        pattern = RETURN_SIGNATURES["ppc"][0][0]
-        buffer = pattern * MIN_RETURN_SITES + b"\x00" * (MIN_RETURN_SITES * 64 * 1024)
+        self.assertIsNone(detectUnsupportedInstructionSet(spread))
 
-        self.assertIsNone(detectUnsupportedInstructionSet(buffer))
+    def test_the_same_count_packed_into_one_window_is_recognized(self):
+        """Positive control for the window: the same buffer size and the same number of hits,
+        close enough together to be a code region rather than noise."""
+        packed = _plant(OPENRISC_RETURN, MIN_RETURN_SITES, 64, size=MIN_RETURN_SITES * (WINDOW_BYTES // 2))
+
+        self.assertEqual(detectUnsupportedInstructionSet(packed), "openrisc")
+
+
+class TextTableFalsePositiveTestSuite(unittest.TestCase):
+    """`\\x44\\x00\\x48\\x00` is the openrisc return word and "DH" in UTF-16LE. A real stripped
+    x86-64 shared object carried 21 aligned copies in an index table, at the same density as
+    the sparsest bundled foreign sample, and the probe refused a legitimate x86 dump."""
+
+    def test_a_utf16_table_spelling_the_return_word_is_not_claimed(self):
+        table = b"D\x00H\x00" * (WINDOW_BYTES // 4)
+
+        self.assertIsNone(detectUnsupportedInstructionSet(table))
+
+    def test_the_same_words_outside_text_are_claimed(self):
+        """Positive control: the veto rejects the company the hits keep, not the hits."""
+        code = _plant(OPENRISC_RETURN, MIN_RETURN_SITES, NEIGHBOURHOOD_BYTES * 4)
+
+        self.assertEqual(detectUnsupportedInstructionSet(code), "openrisc")
 
 
 class UnsupportedBufferReportTestSuite(unittest.TestCase):

--- a/tests/testUnsupportedInstructionSetProbe.py
+++ b/tests/testUnsupportedInstructionSetProbe.py
@@ -1,0 +1,131 @@
+import unittest
+from pathlib import Path
+
+from smda.common.instruction_set_probe import (
+    MIN_RETURN_SITES,
+    RETURN_SIGNATURES,
+    countAlignedOccurrences,
+    detectUnsupportedInstructionSet,
+)
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+FIXTURES = Path(__file__).resolve().parent
+
+# every bundled sample of an instruction set SMDA has no backend for
+UNSUPPORTED_FIXTURES = {
+    "mirai_arm_xored": "arm",
+    "mirai_mips_xored": "mips",
+    "mirai_mipsel_xored": "mips",
+    "mirai_ppc_xored": "ppc",
+    "mirai_sparc_xored": "sparc",
+    "mirai_nios2_xored": "nios2",
+    "mirai_openrisc_xored": "openrisc",
+    "mirai_sh4_xored": "sh4",
+    "mirai_m68k_xored": "m68k",
+    "mirai_xtensa_xored": "xtensa",
+}
+
+# the instruction sets SMDA does have a backend for, which must never be claimed
+SUPPORTED_FIXTURES = (
+    "mirai_x64_xored",
+    "mirai_i386_xored",
+    "asprox_0x008D0000_xored",
+    "cutwail_xored",
+    "komplex_xored",
+    "rust_pe_gnu_xored",
+    "aarch64_static_xored",
+    "blockblast_classes_xored",
+    "njrat_xored",
+)
+
+
+def _load(name):
+    data = (FIXTURES / name).read_bytes()
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
+
+
+def _config():
+    config = SmdaConfig()
+    config.CALCULATE_HASHING = False
+    config.CALCULATE_SCC = False
+    config.CALCULATE_NESTING = False
+    config.TIMEOUT = 0
+    return config
+
+
+class ReturnSignatureCountTestSuite(unittest.TestCase):
+    def test_only_aligned_occurrences_are_counted(self):
+        buffer = b"\x00" + b"\x4e\x80\x00\x20" + b"\x00" * 3 + b"\x4e\x80\x00\x20"
+
+        self.assertEqual(countAlignedOccurrences(buffer, b"\x4e\x80\x00\x20", 4), 1)
+        self.assertEqual(countAlignedOccurrences(buffer, b"\x4e\x80\x00\x20", 1), 2)
+
+    def test_a_missing_pattern_counts_zero(self):
+        self.assertEqual(countAlignedOccurrences(b"\x00" * 64, b"\x4e\x80\x00\x20", 4), 0)
+
+
+class UnsupportedInstructionSetDetectionTestSuite(unittest.TestCase):
+    """Positive and negative controls together: without both, a probe that always answered
+    "no" and one that always answered "yes" would each look correct from one side."""
+
+    def test_every_unsupported_fixture_is_named(self):
+        for name, expected in UNSUPPORTED_FIXTURES.items():
+            with self.subTest(fixture=name):
+                self.assertEqual(detectUnsupportedInstructionSet(_load(name)), expected)
+
+    def test_no_supported_fixture_is_claimed(self):
+        for name in SUPPORTED_FIXTURES:
+            with self.subTest(fixture=name):
+                self.assertIsNone(detectUnsupportedInstructionSet(_load(name)))
+
+    def test_a_handful_of_return_words_is_below_the_threshold(self):
+        pattern = RETURN_SIGNATURES["ppc"][0][0]
+        buffer = pattern * (MIN_RETURN_SITES - 1)
+
+        self.assertIsNone(detectUnsupportedInstructionSet(buffer))
+
+    def test_the_same_words_at_the_threshold_are_recognized(self):
+        """Positive control for the threshold itself, so the case above cannot be passing
+        because the pattern is wrong rather than because the count is too low."""
+        pattern = RETURN_SIGNATURES["ppc"][0][0]
+        buffer = pattern * MIN_RETURN_SITES
+
+        self.assertEqual(detectUnsupportedInstructionSet(buffer), "ppc")
+
+    def test_return_words_too_sparse_for_the_buffer_are_ignored(self):
+        pattern = RETURN_SIGNATURES["ppc"][0][0]
+        buffer = pattern * MIN_RETURN_SITES + b"\x00" * (MIN_RETURN_SITES * 64 * 1024)
+
+        self.assertIsNone(detectUnsupportedInstructionSet(buffer))
+
+
+class UnsupportedBufferReportTestSuite(unittest.TestCase):
+    """Analysing foreign machine code as intel returns a full report whose every block is
+    wrong; naming the instruction set and refusing is the more useful answer."""
+
+    def test_a_foreign_buffer_is_reported_as_an_error(self):
+        report = Disassembler(config=_config()).disassembleBuffer(_load("mirai_ppc_xored"), 0x400000)
+
+        self.assertEqual(report.status, "error")
+        self.assertEqual(len(list(report.getFunctions())), 0)
+        self.assertIn("ppc", report.message)
+
+    def test_an_explicitly_named_architecture_still_wins(self):
+        """A caller that hands foreign bytes to a named backend on purpose - the buffer fuzz
+        target does exactly this - must not be overruled by the probe."""
+        report = Disassembler(config=_config()).disassembleBuffer(
+            _load("mirai_ppc_xored"), 0x400000, architecture="intel"
+        )
+
+        self.assertEqual(report.status, "ok")
+
+    def test_an_x86_buffer_is_analysed_as_before(self):
+        report = Disassembler(config=_config()).disassembleBuffer(_load("mirai_x64_xored"), 0x400000)
+
+        self.assertEqual(report.status, "ok")
+        self.assertGreater(len(list(report.getFunctions())), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rebased continuation of #275 (@r0ny123's stack base) onto master after #265–#274 were squash-merged. Tree content is identical to the original branch; only the duplicated commits for the ten already-merged PRs were dropped during the rebase. See #275 for the full write-up, measurements and deliberate fixture moves (`mirai_x64`, `mirai_i386`, `rust_pe_gnu`). Locally validated: pytest green (1512 passed, 2 skipped), tree byte-identical pre/post rebase.