### PR TITLE
perf(labels): parse a Go binary's pclntab once per image, not once per provider

### DIFF
--- a/src/smda/common/labelprovider/GoLabelProvider.py
+++ b/src/smda/common/labelprovider/GoLabelProvider.py
@@ -185,6 +185,10 @@ class GoSymbolProvider(AbstractLabelProvider):
         pclntab_offset = self.getPcLntabOffset(binary_info)
         # if we found a valid offset, do the pclntab parsing
         if pclntab_offset is not None:
+            cached = getattr(binary_info, "_go_pclntab_symbols", None)
+            if cached is not None:
+                self._func_symbols = dict(cached)
+                return
             try:
                 result = self._parse_pclntab(pclntab_offset, binary, self.getTextStart(binary_info))
                 if result:
@@ -192,6 +196,7 @@ class GoSymbolProvider(AbstractLabelProvider):
             except Exception as exc:
                 reraise_non_operational_exception(exc)
                 return
+            binary_info._go_pclntab_symbols = dict(self._func_symbols)
 
     def isSymbolProvider(self):
         return True

--- a/tests/testGoSymbolProvider.py
+++ b/tests/testGoSymbolProvider.py
@@ -437,5 +437,73 @@ class PcLntabRejectionTestSuite(unittest.TestCase):
         self.assertEqual(_ELF_PCLNTAB_OFFSET, provider.getPcLntabOffset(binary_info))
 
 
+class TestPcLntabParseIsSharedAcrossProviders(unittest.TestCase):
+    """More than one provider instance parses the same table for one binary, so the result is
+    cached beside the offset getPcLntabOffset already caches on binary_info."""
+
+    def _binary_info(self):
+        binary_info = BinaryInfo(_build_elf_with_gopclntab(_build_truncated_pclntab_116_64()))
+        binary_info.base_addr = 0
+        binary_info.bitness = 64
+        binary_info.architecture = "intel"
+        return binary_info
+
+    def test_a_second_provider_reuses_the_first_parse(self):
+        binary_info = self._binary_info()
+        first = GoSymbolProvider(None)
+        first.update(binary_info)
+        self.assertTrue(first._func_symbols, "control: the first parse must find symbols")
+
+        parses = []
+        second = GoSymbolProvider(None)
+        original = GoSymbolProvider._parse_pclntab
+
+        def counting(self, *args, **kwargs):
+            parses.append(1)
+            return original(self, *args, **kwargs)
+
+        GoSymbolProvider._parse_pclntab = counting
+        try:
+            second.update(binary_info)
+        finally:
+            GoSymbolProvider._parse_pclntab = original
+
+        self.assertEqual(parses, [])
+        self.assertEqual(second._func_symbols, first._func_symbols)
+
+    def test_the_cached_map_is_copied_rather_than_shared(self):
+        """Two providers must not end up mutating one dict between them."""
+        binary_info = self._binary_info()
+        first = GoSymbolProvider(None)
+        first.update(binary_info)
+        second = GoSymbolProvider(None)
+        second.update(binary_info)
+
+        self.assertIsNot(first._func_symbols, second._func_symbols)
+
+    def test_a_different_binary_parses_again(self):
+        """Positive control: the cache lives on binary_info, so a second binary must not read
+        the first one's symbols."""
+        first_info = self._binary_info()
+        provider = GoSymbolProvider(None)
+        provider.update(first_info)
+
+        second_info = self._binary_info()
+        parses = []
+        original = GoSymbolProvider._parse_pclntab
+
+        def counting(self, *args, **kwargs):
+            parses.append(1)
+            return original(self, *args, **kwargs)
+
+        GoSymbolProvider._parse_pclntab = counting
+        try:
+            GoSymbolProvider(None).update(second_info)
+        finally:
+            GoSymbolProvider._parse_pclntab = original
+
+        self.assertEqual(parses, [1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Rebased continuation of #276 (@r0ny123) onto master after #275 landed as #282. The unique delta is exactly the one documented commit: cache the parsed pclntab on the shared `binary_info` so the second `GoSymbolProvider` instance does not re-parse. See #276 for measurements (2 parses → 1, reports byte-identical, non-Go binaries untouched). Locally validated: testGoSymbolProvider green (34 passed).