### PR TITLE
fix(intel): record a data reference for an absolute memory operand

### DIFF
--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -230,6 +230,13 @@ class FunctionAnalysisState:
                 return False
         # in case we have a successful analysis, forward results to disassembly
         if self.num_blocks_analyzed:
+            if self.start_addr not in self.instruction_start_bytes:
+                # analyzeFunction declines to book an instruction whose address is already
+                # claimed as data, so a candidate landing inside a datum can reach here with
+                # blocks decoded from a branch target but nothing at its own entry. Recording
+                # that as a function yields one whose offset is not the start of any of its
+                # blocks, and whose borders and ins2fn describe a different range entirely.
+                return False
             self._finalizeRegularAnalysis()
         return True
 

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -37,6 +37,11 @@ LOGGER = logging.getLogger(__name__)
 # an absolute memory operand: "dword ptr [0x401000]", "[0x401000]". A base or index
 # register, or a rip-relative displacement, makes the effective address unknown here, so
 # those forms deliberately do not match.
+# A bracket whose first character is a hex prefix or a lone decimal digit: the only two forms
+# the full operand pattern below can accept. Scanning for that once over the whole operand
+# string is cheaper than splitting it and matching each part, and this runs per instruction.
+ABSOLUTE_OPERAND_HINT = re.compile(r"\[(?:0x|[0-9]\])")
+
 ABSOLUTE_MEM_OPERAND_RE = re.compile(
     r"^(?:(?P<width>byte|word|dword|qword|xword|tbyte|xmmword|ymmword|zmmword) ptr )?"
     r"\[(?P<address>0x[0-9a-fA-F]{1,16}|[0-9])\]$"
@@ -289,14 +294,19 @@ class X86Backend(ArchBackend):
         form read here. A bracketed branch operand names the pointer slot the branch reads
         through, which is data whatever the branch analyzers do with the value found in it.
         """
-        if not i_op_str:
+        # This runs for every instruction the engine decodes, so the two cheapest facts about
+        # the form being looked for come first: an absolute memory operand is written in
+        # brackets, and only an operand carrying a segment override needs one stripped. On a
+        # static x86-64 ELF two thirds of operands have no bracket at all.
+        if not i_op_str or ABSOLUTE_OPERAND_HINT.search(i_op_str) is None:
             return
         binary_info = d.disassembly.binary_info
         if binary_info is None:
             return
         declares_code_areas = bool(getattr(binary_info, "code_areas", None))
         emitted = set()
-        for operand in stripFlatSegmentOverride(i_op_str).split(", "):
+        normalized = stripFlatSegmentOverride(i_op_str) if ":" in i_op_str else i_op_str
+        for operand in normalized.split(", "):
             match = ABSOLUTE_MEM_OPERAND_RE.match(operand.strip())
             if match is None:
                 continue
@@ -525,7 +535,10 @@ class X86Backend(ArchBackend):
         if " " in i_mnemonic_noprefix:
             i_mnemonic_noprefix = i_mnemonic_noprefix.rpartition(" ")[2]
         i_kind = _INS_KIND.get(i_mnemonic_noprefix)
-        self._recordAbsoluteDataRefs(d, i_address, i_op_str, state)
+        # the engine calls this for every decoded instruction, so the operand is screened for a
+        # bracket here rather than paying a call to find out there is nothing to record
+        if i_op_str and "[" in i_op_str:
+            self._recordAbsoluteDataRefs(d, i_address, i_op_str, state)
         if i_kind == _KIND_CALL:
             self._analyzeCallInstruction(d, i, state)
         elif i_kind == _KIND_JMP:

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -124,8 +124,6 @@ _KIND_TABLES = (
 # one lookup replaces the membership chain that 77% of instructions fell all the way through;
 # collapsing to a single dict is only valid while the tables stay disjoint
 _INS_KIND = {mnemonic: kind for table, kind in _KIND_TABLES for mnemonic in table}
-# a branch's operand names a code target, which the branch analyzers already record
-_BRANCH_KINDS = frozenset({_KIND_CALL, _KIND_JMP, _KIND_LOOP, _KIND_CJMP})
 if len(_INS_KIND) != sum(len(table) for table, _ in _KIND_TABLES):
     raise AssertionError("intel control-flow mnemonic tables overlap")
 
@@ -262,7 +260,7 @@ class X86Backend(ArchBackend):
             self._collectMemRegSlot(state, i_address, i_op_str)
 
     @staticmethod
-    def _recordAbsoluteDataRefs(d, i_address, i_op_str, state, i_kind):
+    def _recordAbsoluteDataRefs(d, i_address, i_op_str, state):
         """Book a data reference for every absolute memory operand naming an image address.
 
         Until now the intel backend recorded a data reference only from JumpTableAnalyzer, so
@@ -270,10 +268,11 @@ class X86Backend(ArchBackend):
         pointer - left no trace in the report at all, and nothing downstream could see it.
         The AArch64 backend has always recorded these from its own operands.
 
-        A branch's operand is a code reference and is handled by the branch analyzers; only
-        the remaining instructions are read here.
+        A direct branch names its target as a bare immediate, so it cannot match the bracketed
+        form read here. A bracketed branch operand names the pointer slot the branch reads
+        through, which is data whatever the branch analyzers do with the value found in it.
         """
-        if i_kind in _BRANCH_KINDS or not i_op_str:
+        if not i_op_str:
             return
         binary_info = d.disassembly.binary_info
         if binary_info is None:
@@ -509,7 +508,7 @@ class X86Backend(ArchBackend):
         if " " in i_mnemonic_noprefix:
             i_mnemonic_noprefix = i_mnemonic_noprefix.rpartition(" ")[2]
         i_kind = _INS_KIND.get(i_mnemonic_noprefix)
-        self._recordAbsoluteDataRefs(d, i_address, i_op_str, state, i_kind)
+        self._recordAbsoluteDataRefs(d, i_address, i_op_str, state)
         if i_kind == _KIND_CALL:
             self._analyzeCallInstruction(d, i, state)
         elif i_kind == _KIND_JMP:

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -38,9 +38,26 @@ LOGGER = logging.getLogger(__name__)
 # register, or a rip-relative displacement, makes the effective address unknown here, so
 # those forms deliberately do not match.
 ABSOLUTE_MEM_OPERAND_RE = re.compile(
-    r"^(?:(?:byte|word|dword|qword|tbyte|xmmword|ymmword|zmmword) ptr )?"
+    r"^(?:(?P<width>byte|word|dword|qword|xword|tbyte|xmmword|ymmword|zmmword) ptr )?"
     r"\[(?P<address>0x[0-9a-fA-F]{1,16}|[0-9])\]$"
 )
+
+# What each size keyword capstone prints is worth in bytes, so a reference covers the whole
+# datum rather than only its first byte. Both 80-bit keywords are here and they are not
+# interchangeable: capstone prints `xword ptr` for the x87 extended-precision operand of
+# fld/fstp, and `tbyte ptr` only for the packed-BCD operand of fbld/fbstp. An operand capstone
+# prints with no size keyword names no width, and stays at one byte.
+_OPERAND_WIDTHS = {
+    "byte": 1,
+    "word": 2,
+    "dword": 4,
+    "qword": 8,
+    "xword": 10,
+    "tbyte": 10,
+    "xmmword": 16,
+    "ymmword": 32,
+    "zmmword": 64,
+}
 
 MEM_REG_SLOT_RE = re.compile(
     r"^(?P<size>dword|qword) ptr \[(?P<reg>[a-z][a-z0-9]{1,3})"
@@ -289,7 +306,7 @@ class X86Backend(ArchBackend):
             if declares_code_areas and binary_info.isInCodeAreas(address):
                 continue
             emitted.add(address)
-            state.addDataRef(i_address, address)
+            state.addDataRef(i_address, address, size=_OPERAND_WIDTHS.get(match.group("width"), 1))
 
     @staticmethod
     def _collectMemRegSlot(state, i_address, i_op_str):

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -34,6 +34,14 @@ LOGGER = logging.getLogger(__name__)
 # purpose: the slot is then not a single address, and those operands belong to jump tables.
 # capstone prints a displacement below 10 as a bare decimal digit, so "[esi + 8]" - the most
 # common slot stride - has no 0x prefix to match on.
+# an absolute memory operand: "dword ptr [0x401000]", "[0x401000]". A base or index
+# register, or a rip-relative displacement, makes the effective address unknown here, so
+# those forms deliberately do not match.
+ABSOLUTE_MEM_OPERAND_RE = re.compile(
+    r"^(?:(?:byte|word|dword|qword|tbyte|xmmword|ymmword|zmmword) ptr )?"
+    r"\[(?P<address>0x[0-9a-fA-F]{1,16}|[0-9])\]$"
+)
+
 MEM_REG_SLOT_RE = re.compile(
     r"^(?P<size>dword|qword) ptr \[(?P<reg>[a-z][a-z0-9]{1,3})"
     r"(?: (?P<sign>[+-]) (?P<disp>0x[0-9a-f]{1,16}|[0-9]))?\]$"
@@ -116,6 +124,8 @@ _KIND_TABLES = (
 # one lookup replaces the membership chain that 77% of instructions fell all the way through;
 # collapsing to a single dict is only valid while the tables stay disjoint
 _INS_KIND = {mnemonic: kind for table, kind in _KIND_TABLES for mnemonic in table}
+# a branch's operand names a code target, which the branch analyzers already record
+_BRANCH_KINDS = frozenset({_KIND_CALL, _KIND_JMP, _KIND_LOOP, _KIND_CJMP})
 if len(_INS_KIND) != sum(len(table) for table, _ in _KIND_TABLES):
     raise AssertionError("intel control-flow mnemonic tables overlap")
 
@@ -250,6 +260,37 @@ class X86Backend(ArchBackend):
         elif i_op_str.startswith("qword ptr ["):
             # case = "QWORD-PTR-REG"
             self._collectMemRegSlot(state, i_address, i_op_str)
+
+    @staticmethod
+    def _recordAbsoluteDataRefs(d, i_address, i_op_str, state, i_kind):
+        """Book a data reference for every absolute memory operand naming an image address.
+
+        Until now the intel backend recorded a data reference only from JumpTableAnalyzer, so
+        an address a function loads outright - a dispatch table, a global, a stored method
+        pointer - left no trace in the report at all, and nothing downstream could see it.
+        The AArch64 backend has always recorded these from its own operands.
+
+        A branch's operand is a code reference and is handled by the branch analyzers; only
+        the remaining instructions are read here.
+        """
+        if i_kind in _BRANCH_KINDS or not i_op_str:
+            return
+        binary_info = d.disassembly.binary_info
+        if binary_info is None:
+            return
+        declares_code_areas = bool(getattr(binary_info, "code_areas", None))
+        emitted = set()
+        for operand in stripFlatSegmentOverride(i_op_str).split(", "):
+            match = ABSOLUTE_MEM_OPERAND_RE.match(operand.strip())
+            if match is None:
+                continue
+            address = int(match.group("address"), 0)
+            if address in emitted or not d.disassembly.isAddrWithinMemoryImage(address):
+                continue
+            if declares_code_areas and binary_info.isInCodeAreas(address):
+                continue
+            emitted.add(address)
+            state.addDataRef(i_address, address)
 
     @staticmethod
     def _collectMemRegSlot(state, i_address, i_op_str):
@@ -468,6 +509,7 @@ class X86Backend(ArchBackend):
         if " " in i_mnemonic_noprefix:
             i_mnemonic_noprefix = i_mnemonic_noprefix.rpartition(" ")[2]
         i_kind = _INS_KIND.get(i_mnemonic_noprefix)
+        self._recordAbsoluteDataRefs(d, i_address, i_op_str, state, i_kind)
         if i_kind == _KIND_CALL:
             self._analyzeCallInstruction(d, i, state)
         elif i_kind == _KIND_JMP:

--- a/tests/testAbsoluteDataRefs.py
+++ b/tests/testAbsoluteDataRefs.py
@@ -8,11 +8,8 @@ from smda.intel.IntelDisassembler import IntelDisassembler
 from smda.intel.X86Backend import X86Backend
 from smda.SmdaConfig import SmdaConfig
 
-_KIND_CALL = 0
-_KIND_RET = 4
 
-
-def _record(op_str, *, image_size=0x1000, base_addr=0x400000, code_areas=None, kind=_KIND_RET):
+def _record(op_str, *, image_size=0x1000, base_addr=0x400000, code_areas=None):
     """Run the absolute-operand data-ref pass and return the refs it booked."""
     disassembly = MagicMock()
     disassembly.binary_info = SimpleNamespace(
@@ -31,7 +28,7 @@ def _record(op_str, *, image_size=0x1000, base_addr=0x400000, code_areas=None, k
         state.data_refs.add((a, b)),
         state.data_bytes.update(range(b, b + size)),
     )
-    X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, op_str, state, kind)
+    X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, op_str, state)
     return {ref[1] for ref in state.data_refs}
 
 
@@ -63,9 +60,6 @@ class AbsoluteOperandTestSuite(unittest.TestCase):
     def test_an_address_outside_the_image_is_not_recorded(self):
         self.assertEqual(_record("edx, dword ptr [0x7fff0000]"), set())
 
-    def test_a_branch_operand_is_left_to_the_branch_analyzers(self):
-        self.assertEqual(_record("dword ptr [0x400500]", kind=_KIND_CALL), set())
-
     def test_a_declared_code_area_is_not_data(self):
         self.assertEqual(_record("edx, dword ptr [0x400500]", code_areas=[(0x400000, 0x400800)]), set())
 
@@ -86,7 +80,7 @@ class AbsoluteOperandTestSuite(unittest.TestCase):
         state = SimpleNamespace(data_refs=set())
         state.addDataRef = lambda a, b, size=1: state.data_refs.add((a, b))
 
-        X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, "edx, dword ptr [0x400500]", state, _KIND_RET)
+        X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, "edx, dword ptr [0x400500]", state)
 
         self.assertEqual(state.data_refs, set())
 
@@ -103,15 +97,7 @@ class AbsoluteDataRefEndToEndTestSuite(unittest.TestCase):
     BASE = 0x400000
     TABLE = 0x400800
 
-    def _report(self):
-        buffer = bytearray(0x1000)
-        code = b"\x55"  # push ebp
-        code += b"\x8b\xec"  # mov ebp, esp
-        code += b"\x8b\x15" + struct.pack("<I", self.TABLE)  # mov edx, dword ptr [0x400800]
-        code += b"\x5d"  # pop ebp
-        code += b"\xc3"  # ret
-        buffer[0x100 : 0x100 + len(code)] = code
-        struct.pack_into("<I", buffer, self.TABLE - self.BASE, self.BASE + 0x100)
+    def _analyze(self, buffer):
         binary_info = BinaryInfo(bytes(buffer))
         binary_info.base_addr = self.BASE
         binary_info.bitness = 32
@@ -121,9 +107,44 @@ class AbsoluteDataRefEndToEndTestSuite(unittest.TestCase):
         return IntelDisassembler(config).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
 
     def test_the_loaded_table_address_is_referenced(self):
-        result = self._report()
+        buffer = bytearray(0x1000)
+        code = b"\x55"  # push ebp
+        code += b"\x8b\xec"  # mov ebp, esp
+        code += b"\x8b\x15" + struct.pack("<I", self.TABLE)  # mov edx, dword ptr [0x400800]
+        code += b"\x5d"  # pop ebp
+        code += b"\xc3"  # ret
+        buffer[0x100 : 0x100 + len(code)] = code
+        struct.pack_into("<I", buffer, self.TABLE - self.BASE, self.BASE + 0x100)
+
+        result = self._analyze(buffer)
 
         self.assertIn(self.TABLE, result.data_refs_from.get(0x400103, set()))
+
+    def test_a_call_through_an_absolute_slot_records_the_slot(self):
+        """The slot an indirect call reads through holds a pointer, so it is data - whatever
+        the branch analyzers then do with the target they find in it."""
+        buffer = bytearray(0x1000)
+        buffer[0x100:0x107] = b"\x55\xff\x15" + struct.pack("<I", self.TABLE)  # push ebp ; call dword ptr [0x400800]
+        buffer[0x107] = 0xC3  # ret
+        struct.pack_into("<I", buffer, self.TABLE - self.BASE, self.BASE + 0x200)
+        buffer[0x200] = 0xC3  # ret, so the slot names a real callee
+
+        result = self._analyze(buffer)
+
+        self.assertIn(self.TABLE, result.data_refs_from.get(0x400101, set()))
+
+    def test_a_direct_call_records_no_data_reference(self):
+        """Control for the rule above: a direct branch names its target as a bare immediate,
+        so there is no slot for this pass to see and nothing may be booked as data."""
+        buffer = bytearray(0x1000)
+        buffer[0x100:0x106] = b"\x55\xe8" + struct.pack("<i", 0xFA)  # push ebp ; call 0x400200
+        buffer[0x106] = 0xC3  # ret
+        buffer[0x200] = 0xC3  # ret
+
+        result = self._analyze(buffer)
+
+        self.assertEqual(result.data_refs_from.get(0x400101, set()), set())
+        self.assertIn(0x400200, result.functions)
 
 
 if __name__ == "__main__":

--- a/tests/testAbsoluteDataRefs.py
+++ b/tests/testAbsoluteDataRefs.py
@@ -32,6 +32,31 @@ def _record(op_str, *, image_size=0x1000, base_addr=0x400000, code_areas=None):
     return {ref[1] for ref in state.data_refs}
 
 
+def _covered(op_str, **kwargs):
+    """The bytes the pass marked as data, not merely the addresses it named."""
+    disassembly = MagicMock()
+    base_addr = kwargs.get("base_addr", 0x400000)
+    image_size = kwargs.get("image_size", 0x1000)
+    disassembly.binary_info = SimpleNamespace(
+        binary=b"\x00" * image_size,
+        base_addr=base_addr,
+        binary_size=image_size,
+        bitness=32,
+        code_areas=[],
+        isInCodeAreas=lambda addr: False,
+    )
+    disassembly.isAddrWithinMemoryImage = lambda addr: base_addr <= addr < base_addr + image_size
+    disassembler = MagicMock()
+    disassembler.disassembly = disassembly
+    state = SimpleNamespace(data_refs=set(), data_bytes=set())
+    state.addDataRef = lambda a, b, size=1: (
+        state.data_refs.add((a, b)),
+        state.data_bytes.update(range(b, b + size)),
+    )
+    X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, op_str, state)
+    return state.data_bytes
+
+
 class AbsoluteOperandTestSuite(unittest.TestCase):
     def test_an_absolute_source_is_recorded(self):
         self.assertEqual(_record("edx, dword ptr [0x400500]"), {0x400500})
@@ -59,6 +84,41 @@ class AbsoluteOperandTestSuite(unittest.TestCase):
 
     def test_an_address_outside_the_image_is_not_recorded(self):
         self.assertEqual(_record("edx, dword ptr [0x7fff0000]"), set())
+
+    def test_an_x87_extended_operand_is_recorded(self):
+        """capstone prints the 80-bit x87 operand of fld/fstp as `xword ptr`, not `tbyte ptr`,
+        so a long-double global left no trace until that keyword was recognized."""
+        self.assertEqual(_record("xword ptr [0x400500]"), {0x400500})
+
+    def test_a_packed_bcd_operand_is_recorded(self):
+        """The sibling 80-bit keyword: `tbyte ptr` is what fbld/fbstp get."""
+        self.assertEqual(_record("tbyte ptr [0x400500]"), {0x400500})
+
+    def test_a_reference_covers_the_whole_datum(self):
+        """A dword read touches four bytes. Marking only the first leaves the other three
+        eligible for the gap scan to promote into a function start."""
+        self.assertEqual(_covered("edx, dword ptr [0x400500]"), set(range(0x400500, 0x400504)))
+
+    def test_each_size_keyword_covers_its_own_width(self):
+        for keyword, width in (
+            ("byte", 1),
+            ("word", 2),
+            ("dword", 4),
+            ("qword", 8),
+            ("xword", 10),
+            ("tbyte", 10),
+            ("xmmword", 16),
+            ("ymmword", 32),
+            ("zmmword", 64),
+        ):
+            with self.subTest(keyword=keyword):
+                covered = _covered(f"edx, {keyword} ptr [0x400500]")
+                self.assertEqual(covered, set(range(0x400500, 0x400500 + width)))
+
+    def test_an_operand_with_no_size_keyword_covers_one_byte(self):
+        """Control for the rule above: capstone prints no keyword when the form names no
+        width, and inventing one would mark bytes the instruction never reads."""
+        self.assertEqual(_covered("[0x400500]"), {0x400500})
 
     def test_a_declared_code_area_is_not_data(self):
         self.assertEqual(_record("edx, dword ptr [0x400500]", code_areas=[(0x400000, 0x400800)]), set())

--- a/tests/testAbsoluteDataRefs.py
+++ b/tests/testAbsoluteDataRefs.py
@@ -1,0 +1,130 @@
+import struct
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.intel.IntelDisassembler import IntelDisassembler
+from smda.intel.X86Backend import X86Backend
+from smda.SmdaConfig import SmdaConfig
+
+_KIND_CALL = 0
+_KIND_RET = 4
+
+
+def _record(op_str, *, image_size=0x1000, base_addr=0x400000, code_areas=None, kind=_KIND_RET):
+    """Run the absolute-operand data-ref pass and return the refs it booked."""
+    disassembly = MagicMock()
+    disassembly.binary_info = SimpleNamespace(
+        binary=b"\x00" * image_size,
+        base_addr=base_addr,
+        binary_size=image_size,
+        bitness=32,
+        code_areas=code_areas or [],
+        isInCodeAreas=lambda addr: any(start <= addr < end for start, end in (code_areas or [])),
+    )
+    disassembly.isAddrWithinMemoryImage = lambda addr: base_addr <= addr < base_addr + image_size
+    disassembler = MagicMock()
+    disassembler.disassembly = disassembly
+    state = SimpleNamespace(data_refs=set(), data_bytes=set())
+    state.addDataRef = lambda a, b, size=1: (
+        state.data_refs.add((a, b)),
+        state.data_bytes.update(range(b, b + size)),
+    )
+    X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, op_str, state, kind)
+    return {ref[1] for ref in state.data_refs}
+
+
+class AbsoluteOperandTestSuite(unittest.TestCase):
+    def test_an_absolute_source_is_recorded(self):
+        self.assertEqual(_record("edx, dword ptr [0x400500]"), {0x400500})
+
+    def test_an_absolute_destination_is_recorded(self):
+        """A store names the address just as a load does; a global written to is still data."""
+        self.assertEqual(_record("dword ptr [0x400500], eax"), {0x400500})
+
+    def test_a_bare_absolute_operand_is_recorded(self):
+        self.assertEqual(_record("[0x400500]"), {0x400500})
+
+    def test_a_segment_override_is_normalized_away(self):
+        self.assertEqual(_record("edx, dword ptr ds:[0x400500]"), {0x400500})
+
+    def test_a_register_relative_operand_is_not_an_absolute_address(self):
+        """Positive control for the whole class: the effective address is unknown here, so
+        recording the displacement would name something the instruction never touches."""
+        self.assertEqual(_record("edx, dword ptr [eax + 0x400500]"), set())
+
+    def test_a_scaled_index_operand_is_not_recorded(self):
+        self.assertEqual(_record("edx, dword ptr [eax*4 + 0x400500]"), set())
+
+    def test_a_rip_relative_operand_is_not_recorded(self):
+        self.assertEqual(_record("rdx, qword ptr [rip + 0x400500]"), set())
+
+    def test_an_address_outside_the_image_is_not_recorded(self):
+        self.assertEqual(_record("edx, dword ptr [0x7fff0000]"), set())
+
+    def test_a_branch_operand_is_left_to_the_branch_analyzers(self):
+        self.assertEqual(_record("dword ptr [0x400500]", kind=_KIND_CALL), set())
+
+    def test_a_declared_code_area_is_not_data(self):
+        self.assertEqual(_record("edx, dword ptr [0x400500]", code_areas=[(0x400000, 0x400800)]), set())
+
+    def test_a_declared_code_area_still_admits_an_address_outside_it(self):
+        """Control for the rule above: the code-area veto must narrow the result, not empty it."""
+        self.assertEqual(_record("edx, dword ptr [0x400900]", code_areas=[(0x400000, 0x400800)]), {0x400900})
+
+    def test_an_image_declaring_no_code_areas_still_records(self):
+        """A raw memory dump declares none, and isInCodeAreas then answers True for the whole
+        image - consulting it there would refuse every reference, which is the case this
+        pass exists for."""
+        self.assertEqual(_record("edx, dword ptr [0x400500]", code_areas=[]), {0x400500})
+
+    def test_an_image_with_no_binary_info_records_nothing(self):
+        """Tests build partial disassembly doubles, so the pass must survive one."""
+        disassembler = MagicMock()
+        disassembler.disassembly = SimpleNamespace(binary_info=None)
+        state = SimpleNamespace(data_refs=set())
+        state.addDataRef = lambda a, b, size=1: state.data_refs.add((a, b))
+
+        X86Backend._recordAbsoluteDataRefs(disassembler, 0x401000, "edx, dword ptr [0x400500]", state, _KIND_RET)
+
+        self.assertEqual(state.data_refs, set())
+
+    def test_both_operands_are_read(self):
+        self.assertEqual(_record("dword ptr [0x400500], dword ptr [0x400600]"), {0x400500, 0x400600})
+
+    def test_the_same_address_twice_is_recorded_once(self):
+        self.assertEqual(_record("dword ptr [0x400500], dword ptr [0x400500]"), {0x400500})
+
+
+class AbsoluteDataRefEndToEndTestSuite(unittest.TestCase):
+    """A dispatch table a function loads outright leaves no trace without this pass."""
+
+    BASE = 0x400000
+    TABLE = 0x400800
+
+    def _report(self):
+        buffer = bytearray(0x1000)
+        code = b"\x55"  # push ebp
+        code += b"\x8b\xec"  # mov ebp, esp
+        code += b"\x8b\x15" + struct.pack("<I", self.TABLE)  # mov edx, dword ptr [0x400800]
+        code += b"\x5d"  # pop ebp
+        code += b"\xc3"  # ret
+        buffer[0x100 : 0x100 + len(code)] = code
+        struct.pack_into("<I", buffer, self.TABLE - self.BASE, self.BASE + 0x100)
+        binary_info = BinaryInfo(bytes(buffer))
+        binary_info.base_addr = self.BASE
+        binary_info.bitness = 32
+        binary_info.architecture = "intel"
+        config = SmdaConfig()
+        config.TIMEOUT = 0
+        return IntelDisassembler(config).analyzeBuffer(binary_info, cbAnalysisTimeout=None)
+
+    def test_the_loaded_table_address_is_referenced(self):
+        result = self._report()
+
+        self.assertIn(self.TABLE, result.data_refs_from.get(0x400103, set()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -1,8 +1,10 @@
 import unittest
 
 from smda.cil.FunctionAnalysisState import FunctionAnalysisState as CilFunctionAnalysisState
+from smda.common.BinaryInfo import BinaryInfo
 from smda.common.FunctionAnalysisState import FunctionAnalysisState
 from smda.dalvik.DalvikFunctionAnalysisState import DalvikFunctionAnalysisState
+from smda.DisassemblyResult import DisassemblyResult
 
 
 class _BareState(FunctionAnalysisState):
@@ -266,3 +268,55 @@ class CilBlockCollisionTestSuite(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FunctionEntryIntegrityTestSuite(unittest.TestCase):
+    """A recorded function's entry must be the start of one of its own blocks.
+
+    analyzeFunction declines to book an instruction whose address is already claimed as data,
+    so a candidate that lands inside a datum can finish analysis with blocks decoded from a
+    branch target and nothing at its own entry. Recording that produces a function whose
+    offset is not in any of its blocks, and whose borders and ins2fn describe a different
+    address range than the offset it is filed under.
+    """
+
+    def _state(self, start_addr):
+        disassembly = DisassemblyResult()
+        disassembly.binary_info = BinaryInfo(b"\x00" * 0x200)
+        state = FunctionAnalysisState(start_addr, disassembly)
+        state.CALL_MNEMONICS = frozenset(["call"])
+        state.END_MNEMONICS = frozenset(["ret", "jmp"])
+        state.label = ""
+        return state, disassembly
+
+    def test_a_function_whose_entry_produced_no_instruction_is_declined(self):
+        state, disassembly = self._state(0x100)
+        state.addInstruction(0x80, 1, "ret", "", b"\xc3")
+        state.endBlock()
+
+        self.assertFalse(state.finalizeAnalysis())
+        self.assertNotIn(0x100, disassembly.functions)
+        self.assertNotIn(0x100, disassembly.function_borders)
+
+    def test_a_function_whose_entry_produced_an_instruction_is_kept(self):
+        """Control for the rule above: the guard must decline only the malformed shape."""
+        state, disassembly = self._state(0x100)
+        state.addInstruction(0x100, 1, "ret", "", b"\xc3")
+        state.endBlock()
+
+        self.assertTrue(state.finalizeAnalysis())
+        self.assertIn(0x100, disassembly.functions)
+        self.assertEqual({block[0][0] for block in disassembly.functions[0x100]}, {0x100})
+
+    def test_a_block_below_the_entry_is_kept_when_the_entry_itself_decoded(self):
+        """A backward branch into a block that starts below the entry is ordinary - a shared
+        tail or thunk - and must not be confused with the malformed shape above."""
+        state, disassembly = self._state(0x100)
+        state.addInstruction(0x100, 2, "jmp", "0x80", b"\xeb\x7e")
+        state.endBlock()
+        state.addInstruction(0x80, 1, "ret", "", b"\xc3")
+        state.endBlock()
+
+        self.assertTrue(state.finalizeAnalysis())
+        self.assertIn(0x100, disassembly.functions)
+        self.assertIn(0x100, {block[0][0] for block in disassembly.functions[0x100]})

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -266,10 +266,6 @@ class CilBlockCollisionTestSuite(unittest.TestCase):
         self.assertEqual([[0x100, 0x102]], [[ins[0] for ins in block] for block in blocks])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class FunctionEntryIntegrityTestSuite(unittest.TestCase):
     """A recorded function's entry must be the start of one of its own blocks.
 
@@ -320,3 +316,7 @@ class FunctionEntryIntegrityTestSuite(unittest.TestCase):
         self.assertTrue(state.finalizeAnalysis())
         self.assertIn(0x100, disassembly.functions)
         self.assertIn(0x100, {block[0][0] for block in disassembly.functions[0x100]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testIntegration.py
+++ b/tests/testIntegration.py
@@ -63,9 +63,12 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         cls.cutwail_unmapped_disassembly = disasm.disassembleUnmappedBuffer(cls.cutwail_binary)
 
     def testAsproxDisassemblyCoverage(self):
-        # 106 (was 105): scanning the tail of the mapped image (past the last already-discovered
-        # instruction) recovers one additional gap-candidate function.
-        assert len(list(self.asprox_disassembly.getFunctions())) == 106
+        # 105: scanning the tail of the mapped image recovered one extra gap-candidate
+        # function (105 -> 106), and booking the slot an indirect call reads through as data
+        # dropped 0x8de000 again (106 -> 105). That address is not a function: its only inbound
+        # reference is `call dword ptr [0x8de000]` at 0x8d31f4, so it is the pointer slot
+        # itself, decoded as `lodsb ; wait ; fidiv word ptr [edi + 0x51]`.
+        assert len(list(self.asprox_disassembly.getFunctions())) == 105
 
     def testOep(self):
         # PE header from buffers are not parsed, so we don't get header infos
@@ -111,7 +114,8 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
         report_as_dict = self.asprox_disassembly.toDict()
         assert report_as_dict["status"] == "ok"
         assert report_as_dict["base_addr"] == 0x8D0000
-        assert report_as_dict["statistics"]["num_instructions"] == 15714
+        # 15706: the eight instructions decoded out of the 0x8de000 pointer slot are gone
+        assert report_as_dict["statistics"]["num_instructions"] == 15706
         assert report_as_dict["sha256"] == "db8a133fed1b706608a4492079b702ded6b70369a980d2b5ae355a6adc78ef00"
         SmdaReport.fromDict(report_as_dict)
 


### PR DESCRIPTION
Rebased continuation of #278 (@r0ny123) onto master after #282/#283 landed — cherry-picked the branch's five commits (the two documented in the original description, plus three later additions: width-carrying references, operand pre-screening, test tweak). See #278 for the full write-up, measurements and the deliberate `testIntegration` fixture move. Locally validated: full pytest green (1540 passed, 2 skipped).