### PR TITLE
fix(intel): recover the function starts four boundary defects were hiding

### DIFF
--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -13,6 +13,12 @@ from smda.utility.MachoFileLoader import MachoFileLoader
 LOGGER = logging.getLogger(__name__)
 
 
+# lief spells the ELF header's type as an enum member; read it the way the symbol providers
+# read theirs, so a lief that names it differently leaves every ELF looking relocated rather
+# than raising in the middle of an analysis
+_ELF_TYPE_EXEC = getattr(getattr(lief.ELF.Header, "FILE_TYPE", None), "EXEC", None)
+
+
 class BinaryInfo:
     """simple DTO to contain most information related to the binary/buffer to be analyzed
 
@@ -72,6 +78,7 @@ class BinaryInfo:
         self.has_backend = False
         self._lief_binary = None
         self._lief_type = None
+        self._position_independent_elf = None
         self._symbol_provider = None
         self.abi = ""
 
@@ -91,6 +98,27 @@ class BinaryInfo:
             else:
                 self._lief_type = "OTHER"
         return self._lief_type
+
+    def isPositionIndependentElf(self):
+        """Whether this is an ELF the loader places at a base of its own choosing.
+
+        Every absolute address such an image stores has to be relocated when it is loaded, and
+        no compiler emits a switch table that way: it emits offsets from a base the code
+        computes for itself, precisely so the table needs no relocation. An absolute table of
+        code addresses in a shared object is therefore something else - the function pointers a
+        tail call dispatches through, whose targets are separate functions.
+
+        An ELF whose header type cannot be read answers True as well. The caller uses this to
+        refuse to read a table, and refusing one costs a switch its case bodies where admitting
+        one merges whole functions together.
+        """
+        if self._position_independent_elf is None:
+            self._position_independent_elf = False
+            if self._getLiefType() == "ELF":
+                header = getattr(self.getLiefBinary(), "header", None)
+                file_type = getattr(header, "file_type", None)
+                self._position_independent_elf = file_type is None or file_type != _ELF_TYPE_EXEC
+        return self._position_independent_elf
 
     def getBinaryData(self):
         """Safely retrieves binary data from either raw_data or a file path."""

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -162,10 +162,14 @@ class FunctionCandidateManager:
                     self.identified_alignment
                     and candidate.alignment < self.identified_alignment
                     and not candidate.is_exception_handler
+                    and not candidate.call_ref_sources
                 ):
                     # The floor is inferred from call-referenced candidates, so it only bounds
-                    # a guess; an exception record is the image's own declaration. Exempting
-                    # symbols as well was measured to cost true positives -- do not widen this.
+                    # a guess; an exception record is the image's own declaration, and so is a
+                    # direct call to the address. The inference tolerates a twentieth of that
+                    # population sitting off the alignment, so applying the floor to all of it
+                    # discards exactly what the inference allowed for. Exempting symbols as
+                    # well was measured to cost true positives -- do not widen this.
                     continue
                 yield candidate
 

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -462,6 +462,15 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # matches one byte into the prologue and names the body instead of the entry - the
             # same shape as the hotpatch adjustment below, where the match is real and its
             # address is one instruction late.
+            # The scan reads raw bytes and establishes no instruction boundary, so this cannot
+            # prove the 0x55 starts an instruction rather than ending one - `push 0x55` spells
+            # the same byte. Requiring the byte before it to end a function was tried and is
+            # unsound: a function can end with a tail `jmp` or a `ud2`, whose last byte is
+            # arbitrary, and that shape is ordinary in Rust output. It cost four real functions
+            # on the bundled Rust PE, whose entries sit directly behind `eb`/`e9` jumps and
+            # `0f 0b`. Measured instead over 404 matches across four images: 347 of them shift
+            # onto a byte SMDA independently recovers as an instruction start, 30 land in bytes
+            # it never decodes either way, and none shift onto the interior of an instruction.
             if offset and prologue_match.group() == _PUSH_PAIR_PROLOGUE and binary[offset - 1] == _PUSH_RBP:
                 offset -= 1
             candidate_addr = (self.disassembly.binary_info.base_addr + offset) & self.getBitMask()

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -67,6 +67,8 @@ _PDATA_ENTRY_SIZE = 12
 # _TIMEOUT_POLL_BLOCKS in the engine. A whole exception table is walked inside one call, so
 # the poll in the pass around it never comes round again while that walk is running
 _TIMEOUT_POLL_INTERVAL = 4096
+_PUSH_RBP = 0x55
+_PUSH_PAIR_PROLOGUE = b"\x41\x57\x41\x56"  # push r15; push r14
 _PDATA_MIN_ENTRIES = 16
 _PDATA_SEED_ENTRIES = 4
 # A sample only finds a table if it lands inside one with a whole seed window left, so this
@@ -454,6 +456,14 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
                 return True
             offset = prologue_match.start()
+            # `push r15; push r14` is a run of callee-saved pushes rather than a distinguishing
+            # first instruction, so it matches wherever such a run reaches r15. clang orders
+            # `push rbp` first in a function that keeps no frame pointer, and the pair then
+            # matches one byte into the prologue and names the body instead of the entry - the
+            # same shape as the hotpatch adjustment below, where the match is real and its
+            # address is one instruction late.
+            if offset and prologue_match.group() == _PUSH_PAIR_PROLOGUE and binary[offset - 1] == _PUSH_RBP:
+                offset -= 1
             candidate_addr = (self.disassembly.binary_info.base_addr + offset) & self.getBitMask()
             if not self._passesCodeFilter(candidate_addr):
                 continue

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -69,6 +69,9 @@ _PDATA_ENTRY_SIZE = 12
 _TIMEOUT_POLL_INTERVAL = 4096
 _PUSH_RBP = 0x55
 _PUSH_PAIR_PROLOGUE = b"\x41\x57\x41\x56"  # push r15; push r14
+# How far back a declared entry has to sit for the byte in question to be inside it rather
+# than an entry itself: one instruction's worth of the openings this pattern appears behind.
+_DECLARED_START_WINDOW = 8
 _PDATA_MIN_ENTRIES = 16
 _PDATA_SEED_ENTRIES = 4
 # A sample only finds a table if it lands inside one with a whole seed window left, so this
@@ -448,6 +451,24 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                     )
                     self.setInitialCandidate(function_addr)
 
+    def _followsDeclaredStart(self, addr):
+        """Whether a function the image itself declares begins in the bytes just before addr.
+
+        Symbols, call references and exception records are all located before the prologue
+        scan runs, so this asks a question the raw bytes cannot: if a declared entry sits a
+        few bytes back, addr is inside that entry's opening instruction rather than being an
+        entry of its own. The window is one instruction's worth of the shortest openings -
+        widening it to a full 15 costs a real shift on the reference images, and eight covers
+        every shape measured.
+        """
+        for candidate_addr in range(max(0, addr - _DECLARED_START_WINDOW), addr):
+            candidate = self.candidates.get(candidate_addr & self.getBitMask())
+            if candidate is not None and (
+                candidate.call_ref_sources or candidate.is_symbol or candidate.is_exception_handler
+            ):
+                return True
+        return False
+
     def _seedPrologueMatches(self, pattern):
         """returns True once the analysis timeout trips, so callers can stop scanning
         further patterns instead of each one re-discovering the timeout on its own first match."""
@@ -462,16 +483,22 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # matches one byte into the prologue and names the body instead of the entry - the
             # same shape as the hotpatch adjustment below, where the match is real and its
             # address is one instruction late.
-            # The scan reads raw bytes and establishes no instruction boundary, so this cannot
-            # prove the 0x55 starts an instruction rather than ending one - `push 0x55` spells
-            # the same byte. Requiring the byte before it to end a function was tried and is
-            # unsound: a function can end with a tail `jmp` or a `ud2`, whose last byte is
-            # arbitrary, and that shape is ordinary in Rust output. It cost four real functions
-            # on the bundled Rust PE, whose entries sit directly behind `eb`/`e9` jumps and
-            # `0f 0b`. Measured instead over 404 matches across four images: 347 of them shift
-            # onto a byte SMDA independently recovers as an instruction start, 30 land in bytes
-            # it never decodes either way, and none shift onto the interior of an instruction.
+            # The scan reads raw bytes and establishes no instruction boundary, so a 0x55 here
+            # is equally `push rbp` or the last byte of something else - `push 0x55` spells the
+            # same byte, and shifting onto it books an address one byte inside the real entry.
+            # The image itself settles it: symbols, call references and exception records are
+            # all located before this scan runs, so a declared entry opening in the bytes just
+            # before that 0x55 places it inside that entry's first instruction. That is the
+            # same kind of evidence the hotpatch adjustment below defers to.
             if offset and prologue_match.group() == _PUSH_PAIR_PROLOGUE and binary[offset - 1] == _PUSH_RBP:
+                if self._followsDeclaredStart(
+                    (self.disassembly.binary_info.base_addr + offset - 1) & self.getBitMask()
+                ):
+                    # A declared entry opens in the bytes just before that 0x55, so the byte is
+                    # inside its first instruction - `push 0x55` spells one - and neither this
+                    # match nor the byte before it starts a function. Seeding either books an
+                    # address inside a function the image already names.
+                    continue
                 offset -= 1
             candidate_addr = (self.disassembly.binary_info.base_addr + offset) & self.getBitMask()
             if not self._passesCodeFilter(candidate_addr):

--- a/src/smda/intel/IndirectCallAnalyzer.py
+++ b/src/smda/intel/IndirectCallAnalyzer.py
@@ -3,14 +3,10 @@ import logging
 import re
 import struct
 
-from .definitions import CALL_INS, CJMP_INS, JMP_INS, canonicalRegister, stripFlatSegmentOverride
+from .definitions import CALL_INS, VALUE_PRESERVING_MNEMONICS, canonicalRegister, stripFlatSegmentOverride
 
 LOGGER = logging.getLogger(__name__)
 
-# The walk models `mov` and `lea`; a value may only be carried past another mnemonic that is
-# known to write no general register. These write none - a branch touches rip and the flags, the
-# rest compare or read. LOOP_INS is absent deliberately: `loop` decrements rcx.
-_VALUE_PRESERVING_MNEMONICS = frozenset({"cmp", "test", "push", "bt", "nop"}) | CJMP_INS | JMP_INS
 # Vector moves whose destination is a vector register or memory. `movd`/`movq` are absent because
 # they also spell a vector-to-general move, and `movsd` because capstone spells the string
 # instruction - which writes esi and edi - with the same mnemonic as the scalar-double move.
@@ -185,7 +181,7 @@ class IndirectCallAnalyzer:
             if (
                 ins[0] != self.current_calling_addr
                 and mnemonic not in ("mov", "lea")
-                and mnemonic not in _VALUE_PRESERVING_MNEMONICS
+                and mnemonic not in VALUE_PRESERVING_MNEMONICS
                 and mnemonic not in _VECTOR_MOVE_MNEMONICS
                 and not self._callPreserves(mnemonic, register_name)
             ):

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -306,9 +306,17 @@ class JumpTableAnalyzer:
         if mnemonic in VALUE_PRESERVING_MNEMONICS:
             return False
         implicit = _IMPLICIT_REGISTER_WRITES.get(mnemonic)
+        # Only the implicit *form* makes those writes. Every entry here is operand-less or
+        # single-operand except `imul`, whose two- and three-operand forms write nothing but
+        # the register they name - so applying the pair to those stops a walk chasing a base
+        # held in rax or rdx at an `imul rcx, rsi` that cannot touch it, and abandons the
+        # table. The syscall walk in the backend already draws the same distinction.
+        names_its_destination = implicit is not None
+        if implicit is not None and operands.count(",") > 0:
+            implicit = None
         if implicit is not None and canonical_register in implicit:
             return True
-        if implicit is not None or mnemonic in _NAMED_DESTINATION_MNEMONICS:
+        if names_its_destination or mnemonic in _NAMED_DESTINATION_MNEMONICS:
             return canonicalRegister(operands.split(",")[0]) == canonical_register
         return None
 

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -2,17 +2,101 @@ import logging
 import re
 import struct
 
-from smda.intel.definitions import RET_INS, canonicalRegister, stripFlatSegmentOverride
+from smda.intel.definitions import (
+    CALL_INS,
+    RET_INS,
+    VALUE_PRESERVING_MNEMONICS,
+    canonicalRegister,
+    stripFlatSegmentOverride,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 _DIRECT_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, dword ptr \[[^ ]+ \+ 0x[0-9a-f]+\]")
+# A 64-bit absolute table stores whole pointers, so its entries are qword rather than dword.
+# Deliberately narrower than the dword form above: it requires the scaled index and admits no
+# base register, because an 8-byte load off a plain base - `mov rax, qword ptr [rbp + 0x10]`,
+# an ordinary stack read - would otherwise be taken for a table whose base is the displacement.
+# With a base register present the effective address is not the displacement at all.
+_DIRECT_TABLE_QWORD_RE = re.compile(r"[a-z0-9]{2,3}, qword ptr \[[a-z][a-z0-9]{1,3}\*[1248] \+ 0x[0-9a-f]+\]")
+# Capstone spells a displacement below 10 as bare decimal and a zero one as plain "[rip]", so
+# neither form matches. Both would put the table within ten bytes of the `lea` that addresses it,
+# which no compiler emits - a switch table lives in a read-only section, not in the middle of the
+# code reading it - and the walk that consults this stops at an unmatched `lea` rather than
+# resolving one, so the residue is a table not found and never a wrong one.
 _X64_LEA_TABLE_RE = re.compile(r"[a-z0-9]{2,3}, \[rip (\+|\-) 0x[0-9a-f]+\]")
+# The other 64-bit absolute form keeps the table base in a register, so the operand carries no
+# displacement to recognize it by and the base is what has to be resolved. It is written either
+# into the branch register ("rax, qword ptr [rsi + rax*8]") or read by the branch itself
+# ("qword ptr [rax + rdx*8]"), hence the optional destination.
+_BASEREG_TABLE_RE = re.compile(
+    r"(?:[a-z][a-z0-9]{1,3}, )?qword ptr \[(?P<base>[a-z][a-z0-9]{1,3}) \+ [a-z][a-z0-9]{1,3}\*8\]$"
+)
 _X64_BONUS_OFFSET_RE = re.compile(r"[a-z0-9]{2,3},.*0x[0-9a-f]+\]")
 _SCALED_INDEX_RE = re.compile(r"\[(?:[a-z][a-z0-9]{1,3} \+ )?(?P<index>[a-z][a-z0-9]{1,3})\*[1248]")
 _IMMEDIATE_RE = re.compile(r"^(?:0x[0-9a-f]+|[0-9]+)$")
 _IDENTIFIER_RE = re.compile(r"[a-z][a-z0-9]{1,4}")
 _INDEX_COPY_MNEMONICS = frozenset({"mov", "movzx", "movsx", "movsxd", "movabs"})
+# Mnemonics whose only register write is the operand they name first, so a backward walk can
+# carry a value past one that names a different register.
+_NAMED_DESTINATION_MNEMONICS = frozenset(
+    {
+        "adc",
+        "add",
+        "and",
+        "bswap",
+        "dec",
+        "inc",
+        "lea",
+        "mov",
+        "movabs",
+        "movsx",
+        "movsxd",
+        "movzx",
+        "neg",
+        "not",
+        "or",
+        "rol",
+        "ror",
+        "sal",
+        "sar",
+        "sbb",
+        "shl",
+        "shr",
+        "sub",
+        "xor",
+    }
+)
+# What these write on top of whatever operand they name. A walk only has to stop at one when the
+# register it is chasing is among them: a `cdqe` sign-extending the switch index sits between the
+# table read and the `lea` that produced its base in ordinary compiler output, and stopping there
+# would abandon the table. The one-operand forms of mul and imul write rdx:rax and name their
+# other factor, so the pair is listed for both; the multi-operand `imul` writes only what it
+# names, and _writesRegister asks that question separately.
+#
+# Two deliberate imprecisions, both of which only ever stop a walk that could have carried on.
+# The pair is listed for mul and div without regard to operand size, though the 8-bit forms
+# write ax alone and leave rdx untouched. And cwd/cdq/cqo are listed as writing rdx only,
+# where capstone reports rax as written too: the value of rax is unchanged by them, so
+# following capstone here would abandon a table for no reason. Do not "fix" either against a
+# regs_write sweep without a measurement showing the precision is worth something.
+_IMPLICIT_REGISTER_WRITES = {
+    "cbw": ("rax",),
+    "cwde": ("rax",),
+    "cdqe": ("rax",),
+    "cwd": ("rdx",),
+    "cdq": ("rdx",),
+    "cqo": ("rdx",),
+    "mul": ("rax", "rdx"),
+    "imul": ("rax", "rdx"),
+    "div": ("rax", "rdx"),
+    "idiv": ("rax", "rdx"),
+    "rdtsc": ("rax", "rdx"),
+    "rdtscp": ("rax", "rcx", "rdx"),
+    "xgetbv": ("rax", "rdx"),
+    "cpuid": ("rax", "rbx", "rcx", "rdx"),
+    "syscall": ("rax", "rcx", "r11"),
+}
 # first operand read but not written, so it redefines no index
 _INDEX_READ_ONLY_MNEMONICS = frozenset({"test", "push", "bt", "nop"})
 
@@ -120,6 +204,19 @@ class JumpTableAnalyzer:
         key = cls._operandKey(operand)
         return {key} if key else set()
 
+    def _isCodePointer(self, address):
+        """Whether an absolute table entry holds an address a case body could start at.
+
+        The mapped image is too coarse a test on its own: whatever follows the table reads as
+        more entries, and a data address comes back as a case target - measured at 49 entries
+        running out of .text and into .rodata on a static glibc, which cost 20 recovered
+        functions across the labelled corpus. A case body is code, so an entry outside the
+        executable areas is not one, whether it is past the end of a table or a bound recovered
+        from the sample's own compare was too large. A memory dump carries no section table,
+        and isInCodeAreas then answers for the whole image exactly as the image bound alone did.
+        """
+        return self.disassembly.isAddrWithinMemoryImage(address) and self.disassembly.binary_info.isInCodeAreas(address)
+
     def _findJumpTableSize(self, backtracked, index_keys=None):
         """Recover the switch bound, preferring a compare against the dispatch's own index.
 
@@ -148,6 +245,13 @@ class JumpTableAnalyzer:
                 continue
             if not tracked or mnemonic in _INDEX_READ_ONLY_MNEMONICS:
                 continue
+            if mnemonic in CALL_INS:
+                # A call returns its value in rax and clobbers what the ABI lets it, but its
+                # operand is a bare address, so the destination parse below reads no key and
+                # the tie survived it. The window is address-ordered rather than a path, so a
+                # compare from before a call is not a bound this dispatch was checked against.
+                tracked = set()
+                continue
             destination, _, source = operands.partition(",")
             destination_key = self._operandKey(destination)
             if destination_key is None:
@@ -165,14 +269,18 @@ class JumpTableAnalyzer:
         return untied_size
 
     def _directHandler(self, jump_instruction_op_str, state, backtracked):
+        """Locate an absolute jump table and the width of one of its entries."""
         register = jump_instruction_op_str.lower()
         data_ref_instruction_addr = None
         off_jumptable = None
+        entry_size = 4
         for instr in backtracked[::-1]:
-            if instr[2] == "mov" and _DIRECT_TABLE_RE.match(instr[3]):
+            qword_table = instr[2] == "mov" and _DIRECT_TABLE_QWORD_RE.match(instr[3])
+            if instr[2] == "mov" and (qword_table or _DIRECT_TABLE_RE.match(instr[3])):
+                entry_size = 8 if qword_table else 4
                 data_ref_instruction_addr = instr[0]
                 off_jumptable = self.disassembler.getReferencedAddr(instr[3])
-                state.addDataRef(data_ref_instruction_addr, off_jumptable, size=4)
+                state.addDataRef(data_ref_instruction_addr, off_jumptable, size=entry_size)
                 # print("    0x%x: _directHandler() found potential jump table offset (mov) with backtracking: 0x%x (%s %s)" % (instr[0], off_jumptable, instr[2], instr[3]))
                 break
             elif instr[2] == "add" and instr[3].startswith(register):
@@ -181,7 +289,105 @@ class JumpTableAnalyzer:
                 state.addDataRef(data_ref_instruction_addr, off_jumptable, size=4)
                 # print("  0x%x: _directHandler() found potential jump table offset (add) with backtracking: 0x%x (%s %s)" % (instr[0], off_jumptable, instr[2], instr[3]))
                 break
-        return off_jumptable
+        return off_jumptable, entry_size
+
+    @staticmethod
+    def _writesRegister(mnemonic, operands, canonical_register):
+        """Whether this instruction writes canonical_register, or None when that is unknowable.
+
+        An unnamed write is one the instruction makes *in addition* to the operand it names,
+        so a mnemonic that has one is still asked about its named destination: `imul rbx, rcx`
+        writes rbx and leaves rdx:rax alone, while `imul rcx` writes rdx:rax and leaves rcx.
+
+        Anything neither table describes writes something the operand text does not show - a
+        call writes whatever its ABI allows, xchg writes both its operands - so it answers None
+        rather than False, and a walk relying on this has to stop there.
+        """
+        if mnemonic in VALUE_PRESERVING_MNEMONICS:
+            return False
+        implicit = _IMPLICIT_REGISTER_WRITES.get(mnemonic)
+        if implicit is not None and canonical_register in implicit:
+            return True
+        if implicit is not None or mnemonic in _NAMED_DESTINATION_MNEMONICS:
+            return canonicalRegister(operands.split(",")[0]) == canonical_register
+        return None
+
+    def _ripRelativeBase(self, base_register, preceding, state):
+        """The address a rip-relative `lea` left in base_register, reading back from the table.
+
+        Carrying the value past a write the walk does not model would resolve the base from
+        before that write, which names a different table rather than none, so the walk ends at
+        the first instruction that is not known to leave the register alone. The window is the
+        instructions at lower addresses, not the path that reached the dispatch, so a `lea` on
+        a branch of the switch that was not taken reads here as if it had been - the same
+        window every other arm of this analyzer already backtracks over.
+        """
+        canonical_base = canonicalRegister(base_register)
+        if canonical_base is None:
+            return None
+        for instruction in preceding[::-1]:
+            mnemonic = instruction[2].split(" ")[-1]
+            operands = instruction[3]
+            if (
+                mnemonic == "lea"
+                and _X64_LEA_TABLE_RE.match(operands)
+                and canonicalRegister(operands.split(",")[0]) == canonical_base
+            ):
+                # getReferencedAddr() preserves the displacement sign
+                off_jumptable = instruction[0] + instruction[1] + self.disassembler.getReferencedAddr(operands)
+                state.addDataRef(instruction[0], off_jumptable, size=8)
+                return off_jumptable
+            if self._writesRegister(mnemonic, operands, canonical_base) is not False:
+                return None
+        return None
+
+    def _resolveRegisterBaseTable(
+        self, jump_instruction_address, jump_instruction_op_str, state, backtracked, jumptable_size
+    ):
+        """Targets of a 64-bit absolute table whose base a rip-relative `lea` put in a register.
+
+        The displacement forms are recognized by the table address standing in the operand
+        text. Here the operand names only registers, so the base is chased back to the `lea`
+        that produced it instead. Entries are whole pointers and one that does not address the
+        image ends the table, so a table of some other shape read this way yields nothing.
+        """
+        if self.disassembly.binary_info.isPositionIndependentElf():
+            # A shared object stores no absolute address a compiler did not have to relocate,
+            # and a switch table is emitted as offsets exactly so that it needs no relocation.
+            # An absolute table here is the function-pointer table a tail call dispatches
+            # through, whose entries are separate functions: reading it as a switch merged
+            # four of them into one 14 KB routine in libc and two multi-megabyte ones in
+            # libcrypto, all of which the labelled corpus - executables only - could not see.
+            return []
+        branch_operand = stripFlatSegmentOverride(jump_instruction_op_str)
+        match = _BASEREG_TABLE_RE.match(branch_operand)
+        preceding = backtracked
+        if match is None:
+            branch_register = canonicalRegister(branch_operand)
+            if branch_register is None:
+                return []
+            for position, instruction in enumerate(backtracked[::-1]):
+                mnemonic = instruction[2].split(" ")[-1]
+                if self._writesRegister(mnemonic, instruction[3], branch_register) is False:
+                    continue
+                # whatever last wrote the branch register decides the dispatch; if it is not a
+                # table read of this shape there is nothing here to resolve
+                if mnemonic == "mov":
+                    match = _BASEREG_TABLE_RE.match(instruction[3])
+                preceding = backtracked[: len(backtracked) - 1 - position]
+                break
+            if match is None:
+                return []
+        off_jumptable = self._ripRelativeBase(match.group("base"), preceding, state)
+        if off_jumptable is None:
+            return []
+        return self._extractDirectTableOffsets(
+            jumptable_size,
+            off_jumptable,
+            state=state,
+            jump_instruction_address=jump_instruction_address,
+            entry_size=8,
+        )
 
     def _x64Handler(self, state, backtracked, target_register=None):
         off_jumptable = None
@@ -206,23 +412,26 @@ class JumpTableAnalyzer:
                 break
         return bonus_offset
 
-    def _extractDirectTableOffsets(self, jumptable_size, off_jumptable, state=None, jump_instruction_address=None):
+    def _extractDirectTableOffsets(
+        self, jumptable_size, off_jumptable, state=None, jump_instruction_address=None, entry_size=4
+    ):
         bound_was_recovered = bool(jumptable_size)
         jumptable_size = jumptable_size if bound_was_recovered else 0xFF
+        unpack_format = "<Q" if entry_size == 8 else "<I"
         jump_targets = set()
         if off_jumptable and self.disassembly.isAddrWithinMemoryImage(off_jumptable):
             for index in range(jumptable_size):
-                raw_entry_bytes = self.disassembly.getBytes(off_jumptable + index * 4, 4)
-                if raw_entry_bytes is None or len(raw_entry_bytes) < 4:
+                raw_entry_bytes = self.disassembly.getBytes(off_jumptable + index * entry_size, entry_size)
+                if raw_entry_bytes is None or len(raw_entry_bytes) < entry_size:
                     break
-                entry = struct.unpack("<I", raw_entry_bytes)[0]
-                if not entry or not self.disassembly.isAddrWithinMemoryImage(entry):
+                entry = struct.unpack(unpack_format, raw_entry_bytes)[0]
+                if not entry or not self._isCodePointer(entry):
                     if bound_was_recovered:
                         continue
                     break
                 jump_targets.add(entry)
                 if state is not None:
-                    state.addDataRef(jump_instruction_address, off_jumptable + index * 4, size=4)
+                    state.addDataRef(jump_instruction_address, off_jumptable + index * entry_size, size=entry_size)
         return sorted(jump_targets)
 
     def _extractRelativeTableOffsets(
@@ -261,7 +470,11 @@ class JumpTableAnalyzer:
                 if index and (off_jumptable + index * 4) in self.table_offsets:
                     # print("  Hit limit for jump table: 0x%x" % (off_jumptable + index * 4))
                     break
-                if not self.disassembly.isAddrWithinMemoryImage((jump_base + entry) & self.disassembler.getBitMask()):
+                # the same test the absolute forms apply: what the scan reads back past the end
+                # of a table is whatever follows it, and a relative entry resolving into a data
+                # section is not a case body. 221 of 5045 entries admitted by the image bound
+                # alone resolve outside every code area across five of the labelled binaries.
+                if not self._isCodePointer((jump_base + entry) & self.disassembler.getBitMask()):
                     break
                 if entry:
                     target = (jump_base + entry) & self.disassembler.getBitMask()
@@ -301,7 +514,7 @@ class JumpTableAnalyzer:
                 if raw_entry_bytes is None or len(raw_entry_bytes) < entry_size:
                     break
                 table_entry = struct.unpack(entry_format, raw_entry_bytes)[0]
-                if not table_entry or not self.disassembly.isAddrWithinMemoryImage(table_entry):
+                if not table_entry or not self._isCodePointer(table_entry):
                     break
                 state.addDataRef(
                     jump_instruction_address,
@@ -340,12 +553,13 @@ class JumpTableAnalyzer:
         else:
             # 32bit cases typically load into target register directly
             if backtracked_sequence.startswith("mov"):
-                off_jumptable = self._directHandler(jump_instruction_op_str, state, backtracked)
+                off_jumptable, entry_size = self._directHandler(jump_instruction_op_str, state, backtracked)
                 table_offsets = self._extractDirectTableOffsets(
                     jumptable_size,
                     off_jumptable,
                     state=state,
                     jump_instruction_address=jump_instruction_address,
+                    entry_size=entry_size,
                 )
             elif backtracked_sequence.startswith("add-movsxd"):
                 off_jumptable = self._x64Handler(state, backtracked)
@@ -374,6 +588,14 @@ class JumpTableAnalyzer:
                     state=state,
                     jump_instruction_address=jump_instruction_address,
                 )
+        if not table_offsets:
+            # Every arm above recognizes its table by an address standing in the operand text of
+            # the dispatch or of the instruction feeding it. A base register holds no address,
+            # so those arms come back empty on a table the compiler addressed that way and this
+            # is the only place it can be recovered.
+            table_offsets = self._resolveRegisterBaseTable(
+                jump_instruction_address, jump_instruction_op_str, state, backtracked, jumptable_size
+            )
         # if False and off_jumptable and table_offsets:
         #     print("  Found jump table: 0x%x -> %d" % (off_jumptable, len(table_offsets)))
         #     for offset in sorted(list(set(table_offsets))):

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -29,6 +29,9 @@ from .MnemonicTfIdf import MnemonicTfIdf
 
 LOGGER = logging.getLogger(__name__)
 
+# what a toolchain that emits CET landing pads aligns a function entry to
+_ENTRY_ALIGNMENT = 16
+
 # a call/jmp through a pointer slot the sample computes itself ("dword ptr [ebx + 0x2c]"),
 # the shape a runtime-built import table is used through. An index register is excluded on
 # purpose: the slot is then not a single address, and those operands belong to jump tables.
@@ -461,6 +464,32 @@ class X86Backend(ArchBackend):
             state.setThunkCall(True)
         return resolved_api
 
+    @staticmethod
+    def _isPaddedLandingPad(d, state, i_address, previous_instruction, start_addr):
+        """Whether this landing pad starts the function the decode is about to absorb.
+
+        Only a pad reached by falling through padding qualifies. One that begins a block is
+        the target of a branch already inside this function - which is how a switch case body
+        is spelled in CET code - and cutting there would carve every one of them out.
+
+        A function that has already booked an instruction past this address wraps around it,
+        so cutting there would leave one function nested inside another. The alignment cut
+        below declines for the same reason.
+
+        Being a candidate is the weakest of these: every landing pad inside a code area is one,
+        because the prologue scan seeds them all. It only rules out an address that candidate
+        discovery already refused - one outside the code areas, or past the candidate cap.
+        """
+        if (
+            previous_instruction is None
+            or i_address == start_addr
+            or i_address % _ENTRY_ALIGNMENT
+            or previous_instruction[2].rpartition(" ")[2] != "nop"
+            or not d.fc_manager.isFunctionCandidate(i_address)
+        ):
+            return False
+        return state.max_instruction_start <= i_address
+
     def _analyzeEndInstruction(self, state):
         state.setSanelyEnding(True)
         state.setNextInstructionReachable(False)
@@ -534,6 +563,23 @@ class X86Backend(ArchBackend):
         i_mnemonic_noprefix = i_mnemonic
         if " " in i_mnemonic_noprefix:
             i_mnemonic_noprefix = i_mnemonic_noprefix.rpartition(" ")[2]
+        if i_mnemonic_noprefix == "endbr64" and self._isPaddedLandingPad(
+            d, state, i_address, previous_instruction, start_addr
+        ):
+            # The alignment cut below fires only where the padding follows a call, so a
+            # function that ends any other way and is padded up to the next entry runs
+            # straight into it and reports the pair as one. A CET landing pad is emitted only
+            # where an indirect branch can arrive, which is the entry-shape evidence that
+            # alignment and padding alone do not carry.
+            #
+            # The fall-through reference is deliberately kept. Where the pad belongs to
+            # another function this edge is what a tail call into it looks like, and where it
+            # is a switch case body the dispatch already owns, removing it would delete a real
+            # edge and leave the block before it with no successor at all.
+            state.setBlockEndingInstruction(True)
+            state.endBlock()
+            state.setSanelyEnding(True)
+            return True
         i_kind = _INS_KIND.get(i_mnemonic_noprefix)
         # the engine calls this for every decoded instruction, so the operand is screened for a
         # bracket here rather than paying a call to find out there is nothing to record

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -43,6 +43,19 @@ LOOP_INS = frozenset({"loop", "loopne", "loope"})
 JMP_INS = frozenset({"jmp", "ljmp"})
 CALL_INS = frozenset({"call", "lcall"})
 RET_INS = frozenset({"ret", "retn", "retf", "retfq", "iret", "iretd", "iretq"})
+# A backward def-use walk models a few mnemonics and may only carry a value past one that is
+# known to leave the register it is chasing alone. A branch touches rip and the flags, the rest
+# compare or read. LOOP_INS is absent deliberately: `loop` decrements rcx.
+#
+# `push` is the exception to the heading and is here on narrower grounds: it writes rsp. The
+# jump-table walk never chases rsp, because a table base arrives from a rip-relative `lea`. The
+# indirect-call walk can be handed one, since the slot pattern it starts from accepts any base
+# register and a spilled function pointer is called through `[rsp + disp]`; there a `push`
+# between the spill and the call is wrongly read as leaving rsp alone. Nothing in that walk
+# assigns a value to a destination spelled rsp, so today it can only miss a clobber rather than
+# resolve a wrong target. Excluding push here would stop that walk more often, and stopping it
+# costs recovered functions rather than API names -- measure before changing it.
+VALUE_PRESERVING_MNEMONICS = frozenset({"cmp", "test", "push", "bt", "nop"}) | CJMP_INS | JMP_INS
 END_INS = frozenset(
     {
         "ret",

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -296,6 +296,20 @@ class PushPairPrologueOffsetTest(unittest.TestCase):
     def test_a_match_at_the_very_start_of_the_image_is_left_alone(self):
         self.assertEqual(self._seeded(self.PUSH_PAIR + b"\xc3"), [self.BASE])
 
+    def test_an_entry_packed_behind_a_tail_jump_still_moves_the_seed(self):
+        """Requiring the byte before the 0x55 to end a function was tried and reverted. A
+        function can end with a tail `jmp` or a `ud2`, whose last byte is arbitrary, and Rust
+        packs the next entry straight behind one: keying on that byte cost four real functions
+        on the bundled Rust PE. These are the endings it got wrong."""
+        for label, ending in (
+            ("jmp short", b"\xeb\xc6"),
+            ("jmp rel32", b"\xe9\x30\xed\xff\xff"),
+            ("ud2", b"\x0f\x0b"),
+        ):
+            with self.subTest(ending=label):
+                binary = b"\x00" * 0x10 + ending + b"\x55" + self.PUSH_PAIR + b"\xc3"
+                self.assertEqual(self._seeded(binary), [self.BASE + 0x10 + len(ending)])
+
     def test_another_seeded_prologue_keeps_its_own_address(self):
         """Control: the adjustment is scoped to the one seeded pattern that is a run of
         callee-saved pushes. The other two open with `sub rsp` behind a single push, which is

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -223,16 +223,21 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class ExceptionRecordAlignmentExemptionTest(unittest.TestCase):
-    """An exception record is the image's own declaration of a function start, so the
-    inferred alignment floor must not filter it out of the analysis queue."""
+class DeclaredStartAlignmentExemptionTest(unittest.TestCase):
+    """The alignment floor is inferred from where call-referenced candidates happen to sit, so
+    it bounds a guess about an unknown function. An exception record and a direct call are both
+    the image's own declaration of a start, and neither must be filtered out of the queue."""
 
     def _manager(self, alignment):
         manager = FunctionCandidateManager(SmdaConfig())
         manager.bitness = 32
         manager.identified_alignment = alignment
         manager._code_areas = []
-        binary_info = types.SimpleNamespace(bitness=32, base_addr=0, binary=b"\x00" * 0x1000)
+        # a real prologue at the unaligned address, so a candidate can score without an
+        # inbound call and the floor is the only thing that can filter it
+        binary = bytearray(b"\x00" * 0x1000)
+        binary[0x1001:0x1004] = b"\x55\x8b\xec"  # push ebp; mov ebp, esp
+        binary_info = types.SimpleNamespace(bitness=32, base_addr=0, binary=bytes(binary))
         manager.disassembly = types.SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
         return manager
 
@@ -246,8 +251,16 @@ class ExceptionRecordAlignmentExemptionTest(unittest.TestCase):
     def test_unaligned_exception_record_is_still_analyzed(self):
         self.assertEqual(self._yielded(4, lambda c: c.setIsExceptionHandler(True)), [0x1001])
 
-    def test_unaligned_inferred_candidate_is_still_filtered(self):
-        self.assertEqual(self._yielded(4, lambda c: c.addCallRef(0x2000)), [])
+    def test_unaligned_call_referenced_candidate_is_analyzed(self):
+        """The inference itself tolerates a twentieth of the call-referenced population sitting
+        off the alignment, so filtering all of it discards what the inference allowed for:
+        `abort` in a static glibc is at an odd address and is reached by 37 direct calls."""
+        self.assertEqual(self._yielded(4, lambda c: c.addCallRef(0x2000)), [0x1001])
+
+    def test_unaligned_candidate_with_no_inbound_call_is_still_filtered(self):
+        """Control: the floor still bounds a guess. A byte pattern matching a prologue at an
+        odd address is exactly the guess it exists to refuse."""
+        self.assertEqual(self._yielded(4, lambda c: c.setInitialCandidate(True)), [])
 
     def test_alignment_floor_of_zero_filters_nothing(self):
-        self.assertEqual(self._yielded(0, lambda c: c.addCallRef(0x2000)), [0x1001])
+        self.assertEqual(self._yielded(0, lambda c: c.setInitialCandidate(True)), [0x1001])

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import logging
+import re
 import struct
 import types
 import unittest
@@ -264,3 +265,41 @@ class DeclaredStartAlignmentExemptionTest(unittest.TestCase):
 
     def test_alignment_floor_of_zero_filters_nothing(self):
         self.assertEqual(self._yielded(0, lambda c: c.setInitialCandidate(True)), [0x1001])
+
+
+class PushPairPrologueOffsetTest(unittest.TestCase):
+    """`push r15; push r14` is seeded as a prologue, but it is a run of callee-saved pushes
+    rather than a distinguishing first instruction. clang orders `push rbp` first in a
+    function that keeps no frame pointer, and the pair then matches one byte in and names the
+    body: `main` in every clang -O1 and above build of the reference corpus was recovered one
+    byte late, counted as a body split rather than as the function it is."""
+
+    BASE = 0x400000
+    PUSH_PAIR = b"\x41\x57\x41\x56"
+
+    def _seeded(self, binary, pattern=PUSH_PAIR):
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 64
+        manager._code_areas = []
+        binary_info = types.SimpleNamespace(bitness=64, base_addr=self.BASE, binary=binary)
+        manager.disassembly = types.SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        manager._seedPrologueMatches(re.escape(pattern))
+        return sorted(manager.candidates)
+
+    def test_a_leading_push_rbp_moves_the_seed_to_the_entry(self):
+        self.assertEqual(self._seeded(b"\x00" * 0x10 + b"\x55" + self.PUSH_PAIR + b"\xc3"), [self.BASE + 0x10])
+
+    def test_another_leading_byte_leaves_the_seed_where_it_matched(self):
+        """Control: only a `push rbp` immediately before the pair can be the same prologue."""
+        self.assertEqual(self._seeded(b"\x00" * 0x10 + b"\x90" + self.PUSH_PAIR + b"\xc3"), [self.BASE + 0x11])
+
+    def test_a_match_at_the_very_start_of_the_image_is_left_alone(self):
+        self.assertEqual(self._seeded(self.PUSH_PAIR + b"\xc3"), [self.BASE])
+
+    def test_another_seeded_prologue_keeps_its_own_address(self):
+        """Control: the adjustment is scoped to the one seeded pattern that is a run of
+        callee-saved pushes. The other two open with `sub rsp` behind a single push, which is
+        a frame setup rather than a run, so a stray 0x55 in front of one does not extend it
+        and must not move the seed."""
+        opener = b"\x40\x53\x48\x83\xec"  # push rbx; sub rsp, imm8
+        self.assertEqual(self._seeded(b"\x00" * 0x10 + b"\x55" + opener, pattern=opener), [self.BASE + 0x11])

--- a/tests/testCandidateSafeguards.py
+++ b/tests/testCandidateSafeguards.py
@@ -296,6 +296,39 @@ class PushPairPrologueOffsetTest(unittest.TestCase):
     def test_a_match_at_the_very_start_of_the_image_is_left_alone(self):
         self.assertEqual(self._seeded(self.PUSH_PAIR + b"\xc3"), [self.BASE])
 
+    def _seededWithDeclared(self, binary, declared):
+        """As _seeded, but with addresses the image declares already registered - the state the
+        prologue scan actually runs in, since symbols, call references and exception records
+        are all located before it."""
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.bitness = 64
+        manager._code_areas = []
+        binary_info = types.SimpleNamespace(bitness=64, base_addr=self.BASE, binary=binary)
+        manager.disassembly = types.SimpleNamespace(binary_info=binary_info, analysis_timeout=False)
+        for addr in declared:
+            manager.ensureCandidate(addr)
+            manager.candidates[addr].addCallRef(addr - 0x100)
+        manager._seedPrologueMatches(re.escape(self.PUSH_PAIR))
+        return sorted(a for a in manager.candidates if a not in declared)
+
+    def test_a_declared_entry_just_before_the_0x55_suppresses_the_seed(self):
+        """`push 0x55` ends in the same byte a `push rbp` is spelled with, so the raw-byte
+        check cannot tell them apart and the shift books an address one byte inside the real
+        entry. The image settles it: a declared start in the bytes just before means the 0x55
+        is inside its opening instruction, so neither address begins a function and no seed
+        belongs here at all."""
+        binary = b"\x00" * 0x10 + b"\x6a\x55" + self.PUSH_PAIR + b"\xc3"
+
+        self.assertEqual(self._seededWithDeclared(binary, [self.BASE + 0x10]), [])
+
+    def test_a_declared_entry_far_from_the_0x55_still_moves_the_seed(self):
+        """Control: the suppression keys on a declared entry being close enough for the 0x55 to
+        sit inside its first instruction. One further back is an ordinary neighbouring function
+        and must not stop a genuine `push rbp` entry being seeded."""
+        binary = b"\x00" * 0x10 + b"\x55" + self.PUSH_PAIR + b"\xc3"
+
+        self.assertEqual(self._seededWithDeclared(binary, [self.BASE]), [self.BASE + 0x10])
+
     def test_an_entry_packed_behind_a_tail_jump_still_moves_the_seed(self):
         """Requiring the byte before the 0x55 to end a function was tried and reverted. A
         function can end with a tail `jmp` or a `ud2`, whose last byte is arbitrary, and Rust

--- a/tests/testEhFrameCandidates.py
+++ b/tests/testEhFrameCandidates.py
@@ -19,6 +19,7 @@ import lief
 from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager as AArch64FunctionCandidateManager
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.EhFrameDecoder import PT_GNU_EH_FRAME, decodeEhFrameFdeRanges, decodeEhFrameHdrStarts
+from smda.common.FunctionCandidateManager import FunctionCandidateManager as CommonFunctionCandidateManager
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.FunctionCandidateManager import FunctionCandidateManager as IntelFunctionCandidateManager
@@ -172,6 +173,11 @@ class EhFrameDecoderTestSuite(unittest.TestCase):
 
     def test_intel_manager_yields_nothing_while_the_sources_are_off(self):
         self.assertEqual(tuple(IntelFunctionCandidateManager(SmdaConfig()).locateDeferredCandidates()), ())
+
+    def test_the_shared_base_contributes_no_deferred_source(self):
+        """The base class documents itself as having no deferred sources, so a backend that
+        does not override it must get an empty pass rather than an error."""
+        self.assertEqual(tuple(CommonFunctionCandidateManager(SmdaConfig()).locateDeferredCandidates()), ())
 
 
 def _build_aarch64_elf_with_ehframe(code, eh_frame, base=0x400000, vaddr=0x401000, eh_vaddr=0x402000):

--- a/tests/testIntelCorrectnessSweep.py
+++ b/tests/testIntelCorrectnessSweep.py
@@ -186,7 +186,8 @@ class JumpTableBacktrackWindowTestSuite(unittest.TestCase):
             (0x1006, 2, "nop", "", b""),
         ]
 
-        self.assertEqual(analyzer._directHandler("eax", state, backtracked), 0x403000)
+        # the handler reports the width of an entry alongside the table it found
+        self.assertEqual(analyzer._directHandler("eax", state, backtracked), (0x403000, 4))
         self.assertEqual(state.data_refs, [(0x1000, 0x403000, 4)])
 
 
@@ -235,7 +236,18 @@ class JumpTableDirectEntriesTestSuite(unittest.TestCase):
         analyzer = JumpTableAnalyzer.__new__(JumpTableAnalyzer)
         table = b"\x00\x10\x40\x00" + b"\x20\x10\x40\x00"
 
+        class _StubBinaryInfo:
+            @staticmethod
+            def isInCodeAreas(addr):
+                return True
+
+            @staticmethod
+            def isPositionIndependentElf():
+                return False
+
         class _StubDisassembly:
+            binary_info = _StubBinaryInfo()
+
             @staticmethod
             def isAddrWithinMemoryImage(addr):
                 return True

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -637,6 +637,15 @@ class RegisterWriteVerdictTest(unittest.TestCase):
         self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rbx, rcx", "rbx"), True)
         self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rbx, rcx, 5", "rbx"), True)
 
+    def test_a_multi_operand_imul_leaves_the_pair_the_implicit_form_writes(self):
+        """The other direction: only the one-operand form writes rdx:rax. Answering for the pair
+        regardless of form stops a walk chasing a base held in rax or rdx at an `imul` that
+        cannot touch it, which abandons the table rather than resolving it wrongly."""
+        for operands in ("rbx, rcx", "rbx, rcx, 5"):
+            for register in ("rax", "rdx"):
+                with self.subTest(operands=operands, register=register):
+                    self.assertIs(JumpTableAnalyzer._writesRegister("imul", operands, register), False)
+
     def test_a_one_operand_imul_writes_the_pair_it_does_not_name(self):
         self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rcx", "rax"), True)
         self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rcx", "rdx"), True)

--- a/tests/testJumpTableAnalyzer.py
+++ b/tests/testJumpTableAnalyzer.py
@@ -3,6 +3,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from smda.common.BinaryInfo import BinaryInfo
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.intel.JumpTableAnalyzer import JumpTableAnalyzer
@@ -23,6 +24,12 @@ def _makeAnalyzer(binary=b"", base_addr=0x1000, binary_size=0x100, bitness=32):
         base_addr=base_addr,
         binary_size=binary_size,
         bitness=bitness,
+        # a binary with no section table - a memory dump - has no code areas, and BinaryInfo
+        # then answers for the whole image; tests needing the section-bounded answer set it
+        isInCodeAreas=MagicMock(return_value=True),
+        # an executable, the permissive case: an image the loader relocates holds no absolute
+        # table a compiler emitted, so tests for that arm set it
+        isPositionIndependentElf=MagicMock(return_value=False),
     )
     disassembler.disassembly = disassembly
     disassembler.getBitMask.return_value = 0xFFFFFFFF
@@ -382,7 +389,7 @@ class DirectTableScanTest(unittest.TestCase):
 
     def test_getJumpTargets_forwards_the_state_for_the_direct_shape(self):
         analyzer = self._analyzer()
-        analyzer._directHandler = MagicMock(return_value=0x1090)
+        analyzer._directHandler = MagicMock(return_value=(0x1090, 4))
         state = SimpleNamespace(refs=[])
         state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
         state.backtrackInstructions = MagicMock(
@@ -599,3 +606,501 @@ class PushRetZeroRecoveryTest(unittest.TestCase):
         report = self._report(through_a_register=False)
 
         self.assertIn(self.FUNCTION, [function.offset for function in report.getFunctions()])
+
+
+class RegisterWriteVerdictTest(unittest.TestCase):
+    """The predicate the two backward walks share: it must answer "unknown" - not "no" -
+    for anything whose register writes the operand text does not spell out."""
+
+    def test_a_named_destination_answers_for_the_register_it_names(self):
+        self.assertIs(JumpTableAnalyzer._writesRegister("mov", "rsi, rdx", "rsi"), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("mov", "rdx, rsi", "rsi"), False)
+
+    def test_a_narrower_spelling_of_the_same_register_still_counts_as_a_write(self):
+        self.assertIs(JumpTableAnalyzer._writesRegister("mov", "esi, 1", "rsi"), True)
+
+    def test_a_memory_destination_writes_no_register(self):
+        self.assertIs(JumpTableAnalyzer._writesRegister("mov", "qword ptr [rbp - 8], rsi", "rsi"), False)
+
+    def test_a_comparison_or_a_branch_writes_nothing(self):
+        for mnemonic, operands in (("cmp", "eax, 0x17"), ("test", "rax, rax"), ("ja", "0x1941")):
+            with self.subTest(mnemonic=mnemonic):
+                self.assertIs(JumpTableAnalyzer._writesRegister(mnemonic, operands, "rsi"), False)
+
+    def test_an_implicit_write_answers_for_the_register_it_does_not_name(self):
+        self.assertIs(JumpTableAnalyzer._writesRegister("cdqe", "", "rax"), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("cdqe", "", "rsi"), False)
+
+    def test_a_multi_operand_imul_writes_the_register_it_names(self):
+        """`imul rbx, rcx` writes rbx and leaves rdx:rax alone; treating its unnamed write as
+        the only one it makes let a walk carry a value straight past a genuine clobber."""
+        self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rbx, rcx", "rbx"), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rbx, rcx, 5", "rbx"), True)
+
+    def test_a_one_operand_imul_writes_the_pair_it_does_not_name(self):
+        self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rcx", "rax"), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rcx", "rdx"), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("imul", "rcx", "rsi"), False)
+
+    def test_an_unmodelled_mnemonic_answers_unknown(self):
+        for mnemonic, operands in (("call", "rax"), ("xchg", "rdx, rsi"), ("pop", "rsi")):
+            with self.subTest(mnemonic=mnemonic):
+                self.assertIsNone(JumpTableAnalyzer._writesRegister(mnemonic, operands, "rsi"))
+
+    def test_the_other_spelling_of_a_shift_names_its_destination_too(self):
+        """Capstone decodes the shift group's /6 opcode as `sal`, a mnemonic of its own; the
+        walk answered "unknown" for it and stopped on an instruction that names what it writes."""
+        self.assertIs(JumpTableAnalyzer._writesRegister("sal", "eax, cl", "rax"), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("sal", "eax, cl", "rsi"), False)
+
+    def test_a_timestamp_read_writes_the_three_registers_it_does_not_name(self):
+        """`rdtscp` writes rcx as well as the rdx:rax pair `rdtsc` writes; the syscall walk in
+        the backend already models it, and this table disagreed with it."""
+        for register in ("rax", "rcx", "rdx"):
+            with self.subTest(register=register):
+                self.assertIs(JumpTableAnalyzer._writesRegister("rdtscp", "", register), True)
+        self.assertIs(JumpTableAnalyzer._writesRegister("rdtscp", "", "rsi"), False)
+
+
+class RipRelativeBaseTest(unittest.TestCase):
+    """Chasing a table base back to the rip-relative `lea` that produced it."""
+
+    LEA = (0x1000, 7, "lea", "rsi, [rip + 0x100]")
+
+    def _analyzer(self):
+        analyzer = _makeAnalyzer(bitness=64)
+        analyzer.disassembler.getReferencedAddr = MagicMock(side_effect=lambda op_str: 0x100)
+        return analyzer
+
+    @staticmethod
+    def _state():
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        return state
+
+    def test_the_lea_resolves_to_the_address_it_computes(self):
+        state = self._state()
+
+        self.assertEqual(self._analyzer()._ripRelativeBase("rsi", [self.LEA], state), 0x1107)
+        self.assertEqual(state.refs, [(0x1000, 0x1107, 8)])
+
+    def test_a_lea_naming_another_register_is_not_the_base(self):
+        window = [(0x1000, 7, "lea", "rdi, [rip + 0x100]")]
+
+        self.assertIsNone(self._analyzer()._ripRelativeBase("rsi", window, self._state()))
+
+    def test_an_intervening_write_of_the_base_abandons_the_walk(self):
+        window = [self.LEA, (0x1007, 3, "mov", "rsi, rdx")]
+
+        self.assertIsNone(self._analyzer()._ripRelativeBase("rsi", window, self._state()))
+
+    def test_an_intervening_write_of_another_register_is_carried_past(self):
+        """Positive control for the guard above: the same window disturbing a register the
+        walk is not chasing still resolves, so an abandoned walk cannot be the harness."""
+        window = [self.LEA, (0x1007, 3, "mov", "rdx, rsi")]
+
+        self.assertEqual(self._analyzer()._ripRelativeBase("rsi", window, self._state()), 0x1107)
+
+    def test_an_unmodelled_mnemonic_abandons_the_walk(self):
+        window = [self.LEA, (0x1007, 5, "call", "0x2000")]
+
+        self.assertIsNone(self._analyzer()._ripRelativeBase("rsi", window, self._state()))
+
+    def test_a_sign_extension_of_another_register_is_carried_past(self):
+        """`cdqe` writes rax without naming it and sits between the table read and its `lea`
+        in ordinary compiler output; stopping there would abandon every such table."""
+        window = [self.LEA, (0x1007, 2, "cdqe", "")]
+
+        self.assertEqual(self._analyzer()._ripRelativeBase("rsi", window, self._state()), 0x1107)
+
+    def test_a_base_that_names_no_general_register_resolves_nothing(self):
+        """The base comes out of the dispatch's operand text, which can spell something that is
+        not a general register at all - `[rip + rax*8]` reads as a base of "rip"."""
+        self.assertIsNone(self._analyzer()._ripRelativeBase("rip", [self.LEA], self._state()))
+
+    def test_a_multi_operand_imul_on_the_base_abandons_the_walk(self):
+        window = [self.LEA, (0x1007, 4, "imul", "rsi, rdx")]
+
+        self.assertIsNone(self._analyzer()._ripRelativeBase("rsi", window, self._state()))
+
+    def test_a_sign_extension_of_the_base_itself_abandons_the_walk(self):
+        window = [(0x1000, 7, "lea", "rax, [rip + 0x100]"), (0x1007, 2, "cdqe", "")]
+
+        self.assertIsNone(self._analyzer()._ripRelativeBase("rax", window, self._state()))
+
+
+class RegisterBaseTableTest(unittest.TestCase):
+    """A 64-bit absolute table whose base a rip-relative `lea` left in a register: the
+    operand text of the dispatch names no address at all, so every other arm comes back
+    empty and the switch bodies were carved out of their function."""
+
+    TABLE = 0x1100
+    CASES = (0x1200, 0x1220, 0x1240)
+
+    def _analyzer(self):
+        analyzer = _makeAnalyzer(base_addr=0x1000, binary_size=0x1000, bitness=64)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(
+            side_effect=lambda addr: addr is not None and 0x1000 <= addr < 0x2000
+        )
+        table = b"".join(struct.pack("<Q", case) for case in self.CASES) + struct.pack("<Q", 0)
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - self.TABLE : addr - self.TABLE + size]
+        )
+        analyzer.disassembler.getReferencedAddr = MagicMock(side_effect=lambda op_str: 0xF9)
+        return analyzer
+
+    @staticmethod
+    def _state(window):
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        state.backtrackInstructions = MagicMock(return_value=window)
+        return state
+
+    LEA = (0x1000, 7, "lea", "rsi, [rip + 0xf9]")
+
+    def test_a_table_read_into_the_branch_register_is_resolved(self):
+        window = [self.LEA, (0x1007, 4, "mov", "rax, qword ptr [rsi + rax*8]")]
+        state = self._state(window)
+
+        self.assertEqual(self._analyzer().getJumpTargets((0x100B, 2, "jmp", "rax"), state), list(self.CASES))
+
+    def test_the_branch_reading_the_table_itself_is_resolved(self):
+        state = self._state([self.LEA])
+
+        targets = self._analyzer().getJumpTargets((0x1007, 3, "jmp", "qword ptr [rsi + rax*8]"), state)
+
+        self.assertEqual(targets, list(self.CASES))
+
+    def test_every_entry_consumed_is_claimed_as_data(self):
+        state = self._state([self.LEA])
+        self._analyzer().getJumpTargets((0x1007, 3, "jmp", "qword ptr [rsi + rax*8]"), state)
+
+        self.assertEqual(
+            state.refs,
+            [(0x1000, self.TABLE, 8)] + [(0x1007, self.TABLE + index * 8, 8) for index in range(len(self.CASES))],
+        )
+
+    def test_a_branch_register_written_by_something_else_resolves_nothing(self):
+        """Whatever last wrote the branch register decides the dispatch, and a `pop` is not a
+        table read however many table-shaped loads precede it."""
+        window = [
+            self.LEA,
+            (0x1007, 4, "mov", "rax, qword ptr [rsi + rax*8]"),
+            (0x100B, 1, "pop", "rax"),
+        ]
+
+        self.assertEqual(self._analyzer().getJumpTargets((0x100C, 2, "jmp", "rax"), self._state(window)), [])
+
+    def test_a_base_that_no_lea_produced_resolves_nothing(self):
+        window = [(0x1000, 3, "mov", "rsi, rdx"), (0x1007, 4, "mov", "rax, qword ptr [rsi + rax*8]")]
+
+        self.assertEqual(self._analyzer().getJumpTargets((0x100B, 2, "jmp", "rax"), self._state(window)), [])
+
+    def test_a_dispatch_through_a_stack_slot_is_not_a_table(self):
+        """An 8-byte load off a plain base is an ordinary memory read, and resolving the image
+        at whatever that base happens to hold would manufacture case targets for every
+        indirect tail call."""
+        window = [self.LEA, (0x1007, 4, "mov", "rax, qword ptr [rbp - 0x10]")]
+
+        self.assertEqual(self._analyzer().getJumpTargets((0x100B, 2, "jmp", "rax"), self._state(window)), [])
+
+
+class CodePointerEntryTest(unittest.TestCase):
+    """The mapped image is too coarse a test for an absolute table: whatever follows the table
+    reads as more entries and a data address comes back as a case target. A case body is code,
+    so an entry outside the executable areas is not one - whether the scan has run off the end
+    of the table or the bound recovered from the sample's own compare was too large."""
+
+    TABLE = 0x1090
+    CODE = 0x1100
+    SECOND = 0x1180
+    DATA = 0x1900
+
+    def _analyzer(self, entries, code_areas):
+        analyzer = _makeAnalyzer(base_addr=0x1000, binary_size=0x1000, bitness=64)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(
+            side_effect=lambda addr: addr is not None and 0x1000 <= addr < 0x2000
+        )
+        analyzer.disassembly.binary_info.isInCodeAreas = MagicMock(
+            side_effect=lambda addr: any(low <= addr < high for low, high in code_areas)
+        )
+        table = b"".join(struct.pack("<Q", entry) for entry in entries)
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - self.TABLE : addr - self.TABLE + size]
+        )
+        return analyzer
+
+    def test_a_scan_without_a_bound_stops_at_an_entry_outside_the_code_areas(self):
+        analyzer = self._analyzer([self.CODE, self.DATA], [(0x1000, 0x1800)])
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(0, self.TABLE, entry_size=8), [self.CODE])
+
+    def test_a_scan_without_a_bound_takes_the_same_entry_when_it_is_code(self):
+        """Positive control: only the code-area answer differs between the two, so a shorter
+        result above cannot come from the scan stopping for some other reason."""
+        analyzer = self._analyzer([self.CODE, self.DATA], [(0x1000, 0x2000)])
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(0, self.TABLE, entry_size=8), [self.CODE, self.DATA])
+
+    def test_a_recovered_bound_skips_the_entry_without_truncating_the_table(self):
+        """A recovered bound already says how long the table is, so one entry that is not code
+        is skipped exactly as one outside the image is - the declared rest of the table is
+        still read, rather than the scan ending on the first case a sample dispatches
+        somewhere unexpected."""
+        analyzer = self._analyzer([self.CODE, self.DATA, self.SECOND], [(0x1000, 0x1800)])
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(3, self.TABLE, entry_size=8), [self.CODE, self.SECOND])
+
+    def test_the_branch_reading_the_table_stops_at_the_same_entry(self):
+        """The other scan over the same kind of table. It never stopped here on any binary
+        measured, so it is pinned by a test rather than by a corpus: leaving one of two
+        identical reads of absolute code pointers unbounded is what a sweep exists to catch."""
+        analyzer = self._analyzer([self.CODE, self.DATA], [(0x1000, 0x1800)])
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+
+        self.assertEqual(analyzer._resolveExplicitTable(0x2000, state, self.TABLE), [self.CODE])
+
+    def test_the_branch_reading_the_table_takes_the_same_entry_when_it_is_code(self):
+        analyzer = self._analyzer([self.CODE, self.DATA], [(0x1000, 0x2000)])
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+
+        self.assertEqual(analyzer._resolveExplicitTable(0x2000, state, self.TABLE), [self.CODE, self.DATA])
+
+    def test_the_relative_scan_stops_at_an_entry_that_resolves_outside_the_code_areas(self):
+        """The third reader of the same class. Its entries are int32 deltas rather than whole
+        pointers, but what it reads past the end of a table is still whatever follows it, and a
+        delta resolving into a data section is not a case body either. Measured across five of
+        the labelled binaries, 221 of 5045 entries the image bound admits here resolve outside
+        every code area."""
+        analyzer = self._relativeAnalyzer([self.CODE, self.DATA], [(0x1000, 0x1800)])
+
+        self.assertEqual(analyzer._extractRelativeTableOffsets(2, self.TABLE, self.TABLE), [self.CODE])
+
+    def test_the_relative_scan_takes_the_same_entry_when_it_resolves_to_code(self):
+        """Positive control: only the code-area answer differs, so the shorter result above
+        cannot come from the scan stopping for some other reason."""
+        analyzer = self._relativeAnalyzer([self.CODE, self.DATA], [(0x1000, 0x2000)])
+
+        self.assertEqual(analyzer._extractRelativeTableOffsets(2, self.TABLE, self.TABLE), [self.CODE, self.DATA])
+
+    def _relativeAnalyzer(self, targets, code_areas):
+        """Entries are int32 deltas from the table base. The scan reads them by image offset,
+        so the byte source is keyed on `off_jumptable - base_addr` the way the code computes it."""
+        analyzer = self._analyzer([], code_areas)
+        table = b"".join(struct.pack("<i", target - self.TABLE) for target in targets)
+        rebased = self.TABLE - 0x1000
+        analyzer.disassembly.getRawBytes = MagicMock(
+            side_effect=lambda offset, size: table[offset - rebased : offset - rebased + size]
+        )
+        analyzer.disassembler.getBitMask = MagicMock(return_value=0xFFFFFFFFFFFFFFFF)
+        analyzer.table_offsets = set()
+        return analyzer
+
+    def test_an_image_with_no_code_areas_still_admits_every_mapped_entry(self):
+        """A memory dump carries no section table, and BinaryInfo then answers for the whole
+        image - asserted through the analyzer against the real predicate, because the bound
+        must not cost a dump the cases it used to recover."""
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x1000
+        binary_info.binary_size = 0x1000
+        binary_info.code_areas = []
+        analyzer = self._analyzer([self.CODE, self.DATA], [])
+        analyzer.disassembly.binary_info.isInCodeAreas = binary_info.isInCodeAreas
+
+        self.assertEqual(analyzer._extractDirectTableOffsets(0, self.TABLE, entry_size=8), [self.CODE, self.DATA])
+
+
+class RegisterBaseTableRecoveryTest(unittest.TestCase):
+    """End to end: a 64-bit switch dispatching through a table whose base is held in a
+    register. Every case body is reachable only through that table, so leaving it
+    unresolved leaves them to the gap scan, which promotes each one to a function of its
+    own and carves the switch out of the function it belongs to."""
+
+    FUNCTION = 0x100
+    TABLE = 0x1000
+    CASES = 4
+    PROLOGUE = bytes.fromhex("554889e5")  # push rbp; mov rbp, rsp
+    BOUND = bytes.fromhex("83ff03")  # cmp edi, 3
+    INDEX = bytes.fromhex("89f8")  # mov eax, edi
+    DISPATCH = bytes.fromhex("ffe0")  # jmp rax
+    CASE_BODY = 6  # mov eax, <case>; ret
+
+    @property
+    def _first_case(self):
+        return self.FUNCTION + len(self.PROLOGUE) + len(self.BOUND) + 2 + len(self.INDEX) + 11 + len(self.DISPATCH)
+
+    @property
+    def _case_targets(self):
+        return [self._first_case + index * self.CASE_BODY for index in range(self.CASES)]
+
+    @property
+    def _default(self):
+        return self._first_case + self.CASES * self.CASE_BODY
+
+    def _load(self, through_a_register):
+        """The eleven bytes that read one table entry, in either spelling of the same table."""
+        if not through_a_register:
+            # mov rax, qword ptr [rax*8 + table], padded to keep both layouts identical
+            return bytes.fromhex("909090") + bytes.fromhex("488b04c5") + struct.pack("<I", self.TABLE)
+        lea_end = self.FUNCTION + len(self.PROLOGUE) + len(self.BOUND) + 2 + len(self.INDEX) + 7
+        # lea rsi, [rip + disp32]; mov rax, qword ptr [rsi + rax*8]
+        return bytes.fromhex("488d35") + struct.pack("<i", self.TABLE - lea_end) + bytes.fromhex("488b04c6")
+
+    def _report(self, through_a_register, populated=True):
+        load = self._load(through_a_register)
+        bodies = b"".join(
+            bytes.fromhex("b8") + struct.pack("<I", case) + bytes.fromhex("c3") for case in range(self.CASES)
+        )
+        # `ja` counts from its own end, which is where the index computation begins
+        to_default = len(self.INDEX) + len(load) + len(self.DISPATCH) + len(bodies)
+        code = self.PROLOGUE + self.BOUND + bytes.fromhex("77") + bytes([to_default])
+        code += self.INDEX + load + self.DISPATCH + bodies
+        code += bytes.fromhex("31c0c3")  # xor eax, eax; ret
+        buffer = bytearray(0x2000)
+        buffer[self.FUNCTION : self.FUNCTION + len(code)] = code
+        if populated:
+            buffer[self.TABLE : self.TABLE + 8 * self.CASES] = b"".join(
+                struct.pack("<Q", case) for case in self._case_targets
+            )
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        report = Disassembler(config).disassembleBuffer(bytes(buffer), 0, bitness=64)
+        self.assertEqual(report.status, "ok")
+        return report
+
+    def test_the_case_bodies_stay_inside_the_function(self):
+        report = self._report(through_a_register=True)
+
+        self.assertEqual([function.offset for function in report.getFunctions()], [self.FUNCTION])
+
+    def test_every_case_target_is_reached(self):
+        report = self._report(through_a_register=True)
+        function = next(iter(report.getFunctions()))
+
+        self.assertTrue(set(self._case_targets) | {self._default} <= {block.offset for block in function.getBlocks()})
+
+    def test_the_same_table_named_by_its_address_is_resolved(self):
+        """The other spelling of the same 64-bit table, whose base does stand in the operand
+        text: its entries are whole pointers too, and reading them four bytes wide carved the
+        cases out just as leaving the base unresolved did."""
+        report = self._report(through_a_register=False)
+
+        self.assertEqual([function.offset for function in report.getFunctions()], [self.FUNCTION])
+
+    def test_the_harness_recovers_the_dispatching_function_with_no_table_at_all(self):
+        """Positive control: the same image with the table left as zeros still recovers the
+        function the prologue seeds, on either side of the change - so a single recovered
+        function above is the dispatch being resolved and not the harness finding one
+        function whatever the image holds. It also shows what the unresolved dispatch costs:
+        the case bodies become functions of their own."""
+        offsets = [
+            function.offset for function in self._report(through_a_register=True, populated=False).getFunctions()
+        ]
+
+        self.assertIn(self.FUNCTION, offsets)
+        self.assertEqual(sorted(offsets), [self.FUNCTION] + self._case_targets)
+
+
+class AdjacentTableBoundTest(unittest.TestCase):
+    """Two switches whose tables sit next to each other in the same read-only section, which
+    is what a compiler emits for consecutive switches in one translation unit. Scanning the
+    first table without the bound its own compare recovered runs straight into the second and
+    hands the neighbour's case bodies to the wrong function."""
+
+    FIRST = 0x100
+    SECOND = 0x400
+    FIRST_TABLE = 0x1000
+    SECOND_TABLE = 0x1020
+    CASES = 4
+    CASE_BODY = 6
+
+    def _function(self, entry, table):
+        """cmp edi, 3; ja default; mov eax, edi; lea rsi, [rip+d]; mov rax, [rsi+rax*8]; jmp rax"""
+        prologue = bytes.fromhex("554889e5")
+        head = prologue + bytes.fromhex("83ff03")
+        lea_end = entry + len(head) + 2 + 2 + 7
+        load = bytes.fromhex("488d35") + struct.pack("<i", table - lea_end) + bytes.fromhex("488b04c6")
+        bodies = b"".join(
+            bytes.fromhex("b8") + struct.pack("<I", case) + bytes.fromhex("c3") for case in range(self.CASES)
+        )
+        to_default = 2 + len(load) + 2 + len(bodies)
+        code = head + bytes.fromhex("77") + bytes([to_default])
+        code += bytes.fromhex("89f8") + load + bytes.fromhex("ffe0") + bodies + bytes.fromhex("31c0c3")
+        first_case = entry + len(head) + 2 + 2 + len(load) + 2
+        return code, [first_case + index * self.CASE_BODY for index in range(self.CASES)]
+
+    def _report(self):
+        buffer = bytearray(0x2000)
+        targets = {}
+        for entry, table in ((self.FIRST, self.FIRST_TABLE), (self.SECOND, self.SECOND_TABLE)):
+            code, cases = self._function(entry, table)
+            buffer[entry : entry + len(code)] = code
+            buffer[table : table + 8 * self.CASES] = b"".join(struct.pack("<Q", case) for case in cases)
+            targets[entry] = cases
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        report = Disassembler(config).disassembleBuffer(bytes(buffer), 0, bitness=64)
+        self.assertEqual(report.status, "ok")
+        return report, targets
+
+    def test_each_switch_keeps_its_own_case_bodies(self):
+        report, targets = self._report()
+        functions = {function.offset: function for function in report.getFunctions()}
+
+        self.assertEqual(sorted(functions), [self.FIRST, self.SECOND])
+        for entry, cases in targets.items():
+            blocks = {block.offset for block in functions[entry].getBlocks()}
+            with self.subTest(function=hex(entry)):
+                self.assertTrue(set(cases) <= blocks)
+                self.assertFalse(set(targets[self.FIRST if entry == self.SECOND else self.SECOND]) & blocks)
+
+
+class SharedObjectAbsoluteTableTest(unittest.TestCase):
+    """An absolute table of code addresses cannot be a switch table in an image the loader
+    relocates: a compiler emits offsets there precisely so the table needs no relocation. What
+    it does find is the function-pointer table a tail call dispatches through, and reading that
+    as a switch merges its targets into the dispatching function."""
+
+    def _analyzer(self, position_independent):
+        analyzer = _makeAnalyzer(base_addr=0x1000, binary_size=0x1000, bitness=64)
+        analyzer.disassembly.binary_info.isPositionIndependentElf = MagicMock(return_value=position_independent)
+        analyzer.disassembly.isAddrWithinMemoryImage = MagicMock(
+            side_effect=lambda addr: addr is not None and 0x1000 <= addr < 0x2000
+        )
+        table = b"".join(struct.pack("<Q", entry) for entry in (0x1200, 0x1220)) + struct.pack("<Q", 0)
+        analyzer.disassembly.getBytes = MagicMock(
+            side_effect=lambda addr, size: table[addr - 0x1100 : addr - 0x1100 + size]
+        )
+        analyzer.disassembler.getReferencedAddr = MagicMock(side_effect=lambda op_str: 0xF9)
+        return analyzer
+
+    @staticmethod
+    def _state(window):
+        state = SimpleNamespace(refs=[])
+        state.addDataRef = lambda addr_from, addr_to, size=1: state.refs.append((addr_from, addr_to, size))
+        state.backtrackInstructions = MagicMock(return_value=window)
+        return state
+
+    WINDOW = [(0x1000, 7, "lea", "rsi, [rip + 0xf9]")]
+
+    def test_a_shared_object_yields_no_absolute_table(self):
+        analyzer = self._analyzer(position_independent=True)
+
+        targets = analyzer.getJumpTargets((0x1007, 3, "jmp", "qword ptr [rsi + rax*8]"), self._state(self.WINDOW))
+
+        self.assertEqual(targets, [])
+
+    def test_an_executable_yields_the_same_table(self):
+        """Positive control: the identical image, differing only in what the loader does with
+        it, still resolves - so an empty result above is the image type and not the harness."""
+        analyzer = self._analyzer(position_independent=False)
+
+        targets = analyzer.getJumpTargets((0x1007, 3, "jmp", "qword ptr [rsi + rax*8]"), self._state(self.WINDOW))
+
+        self.assertEqual(targets, [0x1200, 0x1220])

--- a/tests/testJumpTableIndexBound.py
+++ b/tests/testJumpTableIndexBound.py
@@ -18,7 +18,16 @@ def _makeAnalyzer(binary=b"", base_addr=0x1000, bitness=64):
     disassembler = MagicMock()
     disassembly = MagicMock()
     disassembly.binary_info = SimpleNamespace(
-        binary=binary, base_addr=base_addr, binary_size=len(binary) or 0x100, bitness=bitness
+        binary=binary,
+        base_addr=base_addr,
+        binary_size=len(binary) or 0x100,
+        bitness=bitness,
+        # a binary with no section table - a memory dump - has no code areas, and BinaryInfo
+        # then answers for the whole image; tests needing the section-bounded answer set it
+        isInCodeAreas=MagicMock(return_value=True),
+        # an executable, the permissive case: an image the loader relocates holds no absolute
+        # table a compiler emitted, so tests for that arm set it
+        isPositionIndependentElf=MagicMock(return_value=False),
     )
     disassembler.disassembly = disassembly
     disassembler.getBitMask.return_value = 0xFFFFFFFFFFFFFFFF
@@ -144,6 +153,36 @@ class IndexTiedBoundTestSuite(unittest.TestCase):
         ]
 
         self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 4)
+
+    def test_a_call_between_the_index_and_its_bound_drops_the_tie(self):
+        """A call returns its value in rax and clobbers whatever the ABI allows, but its
+        operand is a bare address, so the destination parse reads no key from it and the tie
+        used to survive it - reporting a compare from before the call as this dispatch's
+        bound. A recovered bound is trusted as exact, so an overlarge one runs the entry scan
+        past the end of its own table."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 5, "call", "0x2000"),
+            (0x100A, 5, "cmp", "esi, 0x3"),
+            (0x100F, 2, "mov", "ecx, eax"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 4)
+
+    def test_a_sign_extension_between_the_index_and_its_bound_keeps_the_tie(self):
+        """Control for the case above: an operand-less instruction is not a reason to drop the
+        tie by itself. `cdqe` widens the index in place and sits between the table read and
+        its bound in ordinary compiler output, so severing there would lose the bound outright
+        rather than fall back to the nearer compare."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 2, "cdqe", ""),
+            (0x1007, 2, "mov", "ecx, eax"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 1001)
 
     def test_a_copy_between_the_index_and_its_bound_keeps_the_tie(self):
         """Positive control: a copy is the one thing that carries the index forward, so the

--- a/tests/testPaddedLandingPad.py
+++ b/tests/testPaddedLandingPad.py
@@ -1,0 +1,236 @@
+#!/usr/bin/python
+
+import struct
+import types
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.intel.X86Backend import X86Backend
+from smda.SmdaConfig import SmdaConfig
+
+ENDBR64 = bytes.fromhex("f30f1efa")
+CALLER = 0x100
+STUB = 0x200
+TARGET = 0x210
+
+
+def _disassembler(is_candidate=True):
+    return types.SimpleNamespace(fc_manager=types.SimpleNamespace(isFunctionCandidate=lambda addr: is_candidate))
+
+
+def _state(max_instruction_start=0):
+    return types.SimpleNamespace(max_instruction_start=max_instruction_start)
+
+
+class PaddedLandingPadShapeTest(unittest.TestCase):
+    """What the cut requires, one condition at a time. Only a pad reached by falling through
+    padding starts a function: one that begins a block is the target of a branch already
+    inside the function, which is how a switch case body is spelled in CET code."""
+
+    NOP = (0x20C, 1, "nop", "")
+
+    def _isEntry(self, **overrides):
+        arguments = {
+            "d": _disassembler(),
+            "state": _state(),
+            "i_address": TARGET,
+            "previous_instruction": self.NOP,
+            "start_addr": STUB,
+        }
+        arguments.update(overrides)
+        return X86Backend._isPaddedLandingPad(**arguments)
+
+    def test_a_padded_landing_pad_at_the_boundary_is_an_entry(self):
+        self.assertTrue(self._isEntry())
+
+    def test_a_pad_that_begins_a_block_is_not(self):
+        self.assertFalse(self._isEntry(previous_instruction=None))
+
+    def test_the_function_s_own_entry_is_not(self):
+        self.assertFalse(self._isEntry(i_address=STUB, start_addr=STUB))
+
+    def test_a_pad_off_the_alignment_boundary_is_not(self):
+        self.assertFalse(self._isEntry(i_address=TARGET + 4))
+
+    def test_a_pad_reached_without_padding_is_not(self):
+        self.assertFalse(self._isEntry(previous_instruction=(0x20C, 3, "xor", "eax, eax")))
+
+    def test_an_address_that_is_no_candidate_is_not(self):
+        self.assertFalse(self._isEntry(d=_disassembler(is_candidate=False)))
+
+    def test_a_function_that_already_reaches_past_the_pad_is_not_cut(self):
+        """The function wraps around the pad, so cutting would nest one inside the other -
+        the alignment cut beside this one declines for the same reason."""
+        self.assertFalse(self._isEntry(state=_state(max_instruction_start=TARGET + 0x40)))
+
+    def test_a_prefixed_nop_still_reads_as_padding(self):
+        """Capstone spells the multi-byte pads with their prefix in the mnemonic."""
+        self.assertTrue(self._isEntry(previous_instruction=(0x20C, 4, "cs nop", "word ptr [rax + rax]")))
+
+
+class PaddedLandingPadRecoveryTest(unittest.TestCase):
+    """End to end: an entry stub that sets one argument and falls through padding into the
+    function it fronts. glibc's multiarch entries are exactly this shape, and decoding
+    straight through reports the pair as one function and loses the second entry."""
+
+    def _image(self, body, target=TARGET):
+        buffer = bytearray(0x2000)
+        # three calls, so the stub outranks the landing pad in the candidate queue and is
+        # the one that gets to run into it
+        caller = bytes.fromhex("554889e5")  # push rbp; mov rbp, rsp
+        for _ in range(3):
+            caller += bytes.fromhex("e8") + struct.pack("<i", STUB - (CALLER + len(caller) + 5))
+        caller += bytes.fromhex("5dc3")  # pop rbp; ret
+        buffer[CALLER : CALLER + len(caller)] = caller
+        stub = ENDBR64 + body
+        buffer[STUB : STUB + len(stub)] = stub
+        entry = ENDBR64 + bytes.fromhex("89f8c3")  # mov eax, edi; ret
+        buffer[target : target + len(entry)] = entry
+        return bytes(buffer)
+
+    def _offsets(self, body, target=TARGET):
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        report = Disassembler(config).disassembleBuffer(self._image(body, target), 0, bitness=64)
+        self.assertEqual(report.status, "ok")
+        return sorted(function.offset for function in report.getFunctions())
+
+    @staticmethod
+    def _padded(body, target=TARGET):
+        return body + b"\x90" * (target - STUB - len(ENDBR64) - len(body))
+
+    def test_both_entries_are_recovered(self):
+        self.assertEqual(self._offsets(self._padded(bytes.fromhex("bf01000000"))), [CALLER, STUB, TARGET])
+
+    def test_a_landing_pad_off_the_boundary_is_still_absorbed(self):
+        """Control: the same stub, the same padding, the same landing pad - only not at an
+        alignment boundary, so nothing says it is an entry. Reads the same on either side of
+        the change."""
+        body = self._padded(bytes.fromhex("bf01000000"), TARGET + 4)
+
+        self.assertEqual(self._offsets(body, target=TARGET + 4), [CALLER, STUB])
+
+    def test_a_landing_pad_reached_without_padding_is_still_absorbed(self):
+        """Control: the stub runs right up to the boundary. The padding is what says the next
+        address is an entry rather than the next statement, and this reads the same on either
+        side of the change."""
+        body = bytes.fromhex("bf01000000")  # mov edi, 1
+        body += bytes.fromhex("4831c0")  # xor rax, rax
+        body += bytes.fromhex("31c0") * ((TARGET - STUB - len(ENDBR64) - len(body)) // 2)  # xor eax, eax
+        self.assertEqual(STUB + len(ENDBR64) + len(body), TARGET)
+
+        self.assertEqual(self._offsets(body), [CALLER, STUB])
+
+
+class SwitchCaseLandingPadTest(unittest.TestCase):
+    """A CET switch lays its case bodies out on alignment boundaries, each behind padding and
+    each opening with a landing pad, so the cut fires between them. It must end the block and
+    nothing more: the bodies are targets of the dispatch and belong to the function that
+    dispatches, whether or not one case runs into the next."""
+
+    FUNCTION = 0x100
+    TABLE = 0x1000
+    FIRST_CASE = 0x200
+    STRIDE = 0x10
+    CASES = 4
+
+    def _case_targets(self):
+        return [self.FIRST_CASE + index * self.STRIDE for index in range(self.CASES)]
+
+    def _image(self, cases_fall_through):
+        buffer = bytearray(0x2000)
+        head = bytes.fromhex("554889e5") + bytes.fromhex("83ff03")  # push rbp; mov rbp, rsp; cmp edi, 3
+        lea_end = self.FUNCTION + len(head) + 2 + 7
+        load = bytes.fromhex("488d35") + struct.pack("<i", self.TABLE - lea_end) + bytes.fromhex("488b04c6")
+        code = head + bytes.fromhex("89f8") + load + bytes.fromhex("ffe0")  # mov eax, edi; ...; jmp rax
+        buffer[self.FUNCTION : self.FUNCTION + len(code)] = code
+        for index, target in enumerate(self._case_targets()):
+            body = ENDBR64 + bytes.fromhex("b8") + struct.pack("<I", index)  # endbr64; mov eax, <case>
+            if not (cases_fall_through and index < self.CASES - 1):
+                body += bytes.fromhex("c3")  # ret
+            buffer[target : target + len(body)] = body
+            for pad in range(target + len(body), target + self.STRIDE):
+                buffer[pad] = 0x90  # nop
+        buffer[self.TABLE : self.TABLE + 8 * self.CASES] = b"".join(
+            struct.pack("<Q", target) for target in self._case_targets()
+        )
+        return bytes(buffer)
+
+    def _functions(self, cases_fall_through):
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        report = Disassembler(config).disassembleBuffer(self._image(cases_fall_through), 0, bitness=64)
+        self.assertEqual(report.status, "ok")
+        return sorted(report.getFunctions(), key=lambda function: function.offset)
+
+    def test_the_switch_stays_one_function_when_each_case_returns(self):
+        functions = self._functions(cases_fall_through=False)
+
+        self.assertEqual([function.offset for function in functions], [self.FUNCTION])
+        blocks = {block.offset for block in functions[0].getBlocks()}
+        self.assertTrue(set(self._case_targets()) <= blocks)
+
+    def test_the_switch_stays_one_function_when_a_case_runs_into_the_next(self):
+        """The shape the cut could get wrong: arriving at the next landing pad by falling
+        through padding is exactly what it looks for, and it does fire here. It ends the
+        block; the body is still a target of the dispatch, so it stays in the function."""
+        functions = self._functions(cases_fall_through=True)
+
+        self.assertEqual([function.offset for function in functions], [self.FUNCTION])
+        blocks = {block.offset for block in functions[0].getBlocks()}
+        self.assertTrue(set(self._case_targets()) <= blocks)
+
+
+class ComputedGotoFallthroughTest(unittest.TestCase):
+    """A computed-goto interpreter built with CET and 16-byte label alignment, taken verbatim
+    from gcc 13.3 -O2 output. Its labels are landing pads on alignment boundaries behind
+    padding, and one label falls through into the next - the exact shape the cut looks for,
+    with a real edge across it. Ending the block must not delete that edge."""
+
+    BASE = 0x400000
+    FUNCTION = 0x401130
+    TABLE = 0x403E20
+    # interp(): endbr64; movzx eax,[rdi]; lea r8,[rip+..]; ...; jmp rcx; then four aligned
+    # landing-pad labels, of which the first falls through into the second
+    CODE = bytes.fromhex(
+        "f30f1efa0fb6074c8d05e22c000031d283e003498b0cc0b801000000ffe16690"
+        "f30f1efa83c201660f1f840000000000f30f1efa83f20339c67e350f1f440000"
+        "89c183c0010fb60c0f83e103498b0cc8ffe166662e0f1f8400000000000f1f00"
+        "f30f1efa8d149239f07cd50f1f44000089d0c366662e0f1f8400000000006690"
+        "f30f1efa83ea0739c67fb589d0c3"
+    )
+    LABELS = (0x401150, 0x401160, 0x401190, 0x4011B0)
+
+    def _function(self):
+        buffer = bytearray(0x4000)
+        buffer[self.FUNCTION - self.BASE : self.FUNCTION - self.BASE + len(self.CODE)] = self.CODE
+        buffer[self.TABLE - self.BASE : self.TABLE - self.BASE + 32] = b"".join(
+            struct.pack("<Q", label) for label in self.LABELS
+        )
+        config = SmdaConfig()
+        config.TIMEOUT = 30
+        config.WITH_STRINGS = False
+        config.CALCULATE_HASHING = False
+        report = Disassembler(config).disassembleBuffer(bytes(buffer), self.BASE, bitness=64)
+        self.assertEqual(report.status, "ok")
+        return next(f for f in report.getFunctions() if f.offset == self.FUNCTION)
+
+    def test_the_interpreter_is_one_function_holding_every_label(self):
+        function = self._function()
+
+        self.assertTrue(set(self.LABELS) <= {block.offset for block in function.getBlocks()})
+
+    def test_the_label_that_falls_through_keeps_its_successor(self):
+        """The first label runs into the second, so the block ended at the padding has to keep
+        that edge. This image is not enough on its own to pin the reference the cut used to
+        remove - the same assertion holds with it removed, because the second label is a
+        dispatch target too - but on the binary this code was taken from, where the analysis
+        reaches the labels in a different order, removing it left this block with no successor
+        at all."""
+        function = self._function()
+
+        self.assertEqual(function.blockrefs.get(self.LABELS[0]), [self.LABELS[1]])


### PR DESCRIPTION
Rebased continuation of #281 (@r0ny123) onto master — cherry-picked the branch's six documented commits (register-base jump tables, alignment-floor exemption, padded landing-pad cut, prologue entry seed, plus the two review fixes). See #281 for the full write-up and measurements: recall 93.869% → 95.098%, body splits −57% on the 50-binary labelled ground truth, no bundled fixture moves. Locally validated: full pytest green (1607 passed, 2 skipped).