### PR TITLE
feat(intel): recover Delphi method-table entries nothing else names

### DIFF
--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -44,6 +44,7 @@ class FunctionCandidateManager:
         self._candidate_offsets = set()
         self.candidate_index = 0
         self._all_call_refs = {}
+        self._delphi_detected = False
         self.symbol_addresses = []
         self.identified_alignment = 0
         self.go_objects = None
@@ -444,6 +445,11 @@ class FunctionCandidateManager:
                 continue
             yield fde_start
 
+    def locateLateCandidates(self):
+        """Candidate sources that need a near-complete function set, not just the primary
+        pass: they run after gap analysis and its drain. No sources here."""
+        return ()
+
     def _machoActiveBinaryAndAdjustment(self):
         binary_info = self.disassembly.binary_info
         lief_binary = binary_info.getLiefBinary()
@@ -582,6 +588,7 @@ class FunctionCandidateManager:
             for add in self.delphi_kb_objects:
                 self.addLanguageSpecCandidate(add, "delphi_kb")
         elif self.lang_analyzer.checkDelphi():
+            self._delphi_detected = True
             LOGGER.debug("Programming language recognized as Delphi, adding function start addresses from VMTs")
             delphi_objects = self.lang_analyzer.getDelphiObjects()
             LOGGER.debug("delphi candidates based on legacy VMT analysis: %d", len(delphi_objects))

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -488,6 +488,10 @@ class RecursiveDisassembler:
         # candidates may have been discovered during gap analysis (e.g. tailcall targets triggered
         # by _analyzeUncondBranch); drain them before moving to the tailcall pass.
         self._drainCandidateQueue(cbAnalysisTimeout)
+        for late_addr in self.fc_manager.locateLateCandidates():
+            if self._analysisTimeoutTripped(cbAnalysisTimeout):
+                break
+            self.analyzeFunction(late_addr)
         # third pass, fix potential tailcall functions that were identified during analysis
         if self.config.RESOLVE_TAILCALLS:
             tailcalled_functions = self.tailcall_analyzer.resolveTailcalls(self)

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -492,6 +492,9 @@ class RecursiveDisassembler:
             if self._analysisTimeoutTripped(cbAnalysisTimeout):
                 break
             self.analyzeFunction(late_addr)
+        # a late function can resolve a register-indirect call and register its callee; the
+        # tailcall pass below is off by default, so nothing else would drain that candidate.
+        self._drainCandidateQueue(cbAnalysisTimeout)
         # third pass, fix potential tailcall functions that were identified during analysis
         if self.config.RESOLVE_TAILCALLS:
             tailcalled_functions = self.tailcall_analyzer.resolveTailcalls(self)

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -50,6 +50,15 @@ _ENTRY_PAD_SEQUENCES = {
 # MSVC aligns function entries to 16 bytes.
 _CODE_ALIGNMENT = 16
 
+# Delphi method tables are runs of 32-bit pointers into code. A run is only read as a table
+# when most of its entries are already recovered functions and code takes a data reference to
+# it; measured on a PE corpus, the self-validation test alone admits a thousand addresses that
+# point at data. The scan polls the analysis budget once per 64 KiB rather than per entry.
+_POINTER_TABLE_ENTRY_SIZE = 4
+_POINTER_TABLE_MIN_RUN = 4
+_POINTER_TABLE_MIN_KNOWN_RATIO = 0.8
+_POINTER_TABLE_POLL_BYTES = 0x10000
+
 # Written as `A(BA)+B` rather than the equivalent `(AB){2,}` so the pattern starts with a literal:
 # only then does the regex engine emit a prefix fast-search instead of entering the matcher at
 # every offset of the mapped image.
@@ -374,6 +383,88 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
     def locateDeferredCandidates(self):
         yield from self.locateEhFrameCandidates()
         yield from self.locateMachoFunctionStartCandidates()
+
+    def locateLateCandidates(self):
+        yield from self.locatePointerTableCandidates()
+
+    def locatePointerTableCandidates(self):
+        """Entries of a function-pointer table that the primary pass did not recover.
+
+        The entries a Delphi program only ever calls through its method table are reachable no
+        other way - no call names them, so nothing seeds them. A run of aligned dwords is read
+        as a table only when most of its entries are already recovered functions and code takes
+        a data reference to the run itself; both facts are products of the passes before this
+        one, which is why it runs after gap analysis rather than at the deferred hook.
+        """
+        if not self._delphi_detected or self.bitness != 32:
+            return
+        functions = self.disassembly.functions
+        if not functions:
+            return
+        buffer = memoryview(self.disassembly.binary_info.binary)
+        base_addr = self.disassembly.binary_info.base_addr
+        lowest, highest = min(functions), max(functions)
+        referenced = set()
+        for targets in self.disassembly.data_refs_from.values():
+            referenced.update(targets)
+        is_code = self.disassembly.isCode
+        # insertion-ordered set: a table can be laid out twice, and re-analyzing a start
+        # the previous run already accepted would be wasted work
+        accepted = {}
+        run_start = None
+        scan_end = len(buffer) - (len(buffer) % _POINTER_TABLE_ENTRY_SIZE)
+        offset = 0
+        while offset < scan_end:
+            if self._candidateTimeoutTripped():
+                return
+            chunk_end = min(offset + _POINTER_TABLE_POLL_BYTES, scan_end)
+            entry_offset = offset
+            for (value,) in struct.iter_unpack("<I", buffer[offset:chunk_end]):
+                if lowest <= value <= highest and not is_code(base_addr + entry_offset):
+                    if run_start is None:
+                        run_start = entry_offset
+                elif run_start is not None:
+                    self._admitPointerTableRun(buffer, run_start, entry_offset, referenced, accepted)
+                    run_start = None
+                entry_offset += _POINTER_TABLE_ENTRY_SIZE
+            offset = chunk_end
+        if run_start is not None:
+            self._admitPointerTableRun(buffer, run_start, scan_end, referenced, accepted)
+        # register every accepted start before analyzing any of them, so an earlier one cannot
+        # absorb a later one it branches into
+        self._candidate_offsets.update(accepted)
+        for start in accepted:
+            if self._candidateTimeoutTripped():
+                return
+            if is_code(start):
+                continue
+            yield start
+
+    def _admitPointerTableRun(self, buffer, run_start, run_end, referenced, accepted):
+        """Read one run of code-pointer-shaped dwords as a method table, or decline it.
+
+        The run is re-read from the image rather than carried along as a list of entries: a
+        crafted image can make one run as long as the image itself, and every test here either
+        streams over it or is decided from its length.
+        """
+        entries = (run_end - run_start) // _POINTER_TABLE_ENTRY_SIZE
+        if entries < _POINTER_TABLE_MIN_RUN:
+            return
+        functions = self.disassembly.functions
+        known = sum(1 for (value,) in struct.iter_unpack("<I", buffer[run_start:run_end]) if value in functions)
+        if known < _POINTER_TABLE_MIN_KNOWN_RATIO * entries:
+            return
+        base_addr = self.disassembly.binary_info.base_addr
+        if referenced.isdisjoint(range(base_addr + run_start, base_addr + run_end, _POINTER_TABLE_ENTRY_SIZE)):
+            return
+        for (value,) in struct.iter_unpack("<I", buffer[run_start:run_end]):
+            if value in functions or self.disassembly.isCode(value):
+                continue
+            if not self._passesCodeFilter(value):
+                continue
+            self.ensureCandidate(value)
+            if value in self.candidates:
+                accepted[value] = None
 
     def locateCandidates(self):
         # add guaranteed / high-value starts first so that, if the candidate cap is hit, the most reliable

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -413,21 +413,15 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         accepted = {}
         run_start = None
         scan_end = len(buffer) - (len(buffer) % _POINTER_TABLE_ENTRY_SIZE)
-        offset = 0
-        while offset < scan_end:
-            if self._candidateTimeoutTripped():
-                return
-            chunk_end = min(offset + _POINTER_TABLE_POLL_BYTES, scan_end)
-            entry_offset = offset
-            for (value,) in struct.iter_unpack("<I", buffer[offset:chunk_end]):
-                if lowest <= value <= highest and not is_code(base_addr + entry_offset):
-                    if run_start is None:
-                        run_start = entry_offset
-                elif run_start is not None:
-                    self._admitPointerTableRun(buffer, run_start, entry_offset, referenced, accepted)
-                    run_start = None
-                entry_offset += _POINTER_TABLE_ENTRY_SIZE
-            offset = chunk_end
+        for entry_addr, value in self._pointerTableEntries(buffer, 0, scan_end):
+            if lowest <= value <= highest and not is_code(entry_addr):
+                if run_start is None:
+                    run_start = entry_addr - base_addr
+            elif run_start is not None:
+                self._admitPointerTableRun(buffer, run_start, entry_addr - base_addr, referenced, accepted)
+                run_start = None
+        if self._candidateTimeoutTripped():
+            return
         if run_start is not None:
             self._admitPointerTableRun(buffer, run_start, scan_end, referenced, accepted)
         # register every accepted start before analyzing any of them, so an earlier one cannot
@@ -440,24 +434,47 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 continue
             yield start
 
+    def _pointerTableEntries(self, buffer, start, end):
+        """Walk aligned dwords of [start, end), polling the analysis budget between chunks.
+
+        Every traversal of the image and of a single run goes through here, so no one of them
+        can run for seconds without the budget being consulted: a crafted image can make one
+        run as long as the image itself, and a run is walked twice more after it is found.
+        """
+        base_addr = self.disassembly.binary_info.base_addr
+        offset = start
+        while offset < end:
+            if self._candidateTimeoutTripped():
+                return
+            chunk_end = min(offset + _POINTER_TABLE_POLL_BYTES, end)
+            entry_addr = base_addr + offset
+            for (value,) in struct.iter_unpack("<I", buffer[offset:chunk_end]):
+                yield entry_addr, value
+                entry_addr += _POINTER_TABLE_ENTRY_SIZE
+            offset = chunk_end
+
     def _admitPointerTableRun(self, buffer, run_start, run_end, referenced, accepted):
         """Read one run of code-pointer-shaped dwords as a method table, or decline it.
 
-        The run is re-read from the image rather than carried along as a list of entries: a
-        crafted image can make one run as long as the image itself, and every test here either
-        streams over it or is decided from its length.
+        The run is re-read from the image rather than carried along as a list of entries, so
+        what a single run costs is bounded time rather than memory proportional to the image.
         """
         entries = (run_end - run_start) // _POINTER_TABLE_ENTRY_SIZE
         if entries < _POINTER_TABLE_MIN_RUN:
             return
         functions = self.disassembly.functions
-        known = sum(1 for (value,) in struct.iter_unpack("<I", buffer[run_start:run_end]) if value in functions)
+        known = 0
+        is_referenced = False
+        for entry_addr, value in self._pointerTableEntries(buffer, run_start, run_end):
+            if value in functions:
+                known += 1
+            if not is_referenced and entry_addr in referenced:
+                is_referenced = True
+        if self._candidateTimeoutTripped() or not is_referenced:
+            return
         if known < _POINTER_TABLE_MIN_KNOWN_RATIO * entries:
             return
-        base_addr = self.disassembly.binary_info.base_addr
-        if referenced.isdisjoint(range(base_addr + run_start, base_addr + run_end, _POINTER_TABLE_ENTRY_SIZE)):
-            return
-        for (value,) in struct.iter_unpack("<I", buffer[run_start:run_end]):
+        for _, value in self._pointerTableEntries(buffer, run_start, run_end):
             if value in functions or self.disassembly.isCode(value):
                 continue
             if not self._passesCodeFilter(value):

--- a/tests/testPointerTableCandidates.py
+++ b/tests/testPointerTableCandidates.py
@@ -1,0 +1,295 @@
+#!/usr/bin/python
+"""The late candidate pass that reads Delphi method tables.
+
+A Delphi program's virtual methods are called only through the object's method table, so an
+entry no other code names is reachable by nothing the primary pass does: no call seeds it, and
+gap analysis only reaches it if it happens to sit between two recovered functions. The pass
+reads such a table, but only when two independent facts agree that the run of dwords is one -
+most of its entries are already recovered functions, and code takes a data reference to it.
+Each test below that expects an admission is paired with a control that removes exactly one of
+those facts and expects none.
+"""
+
+import struct
+import unittest
+from unittest import mock
+
+from smda.common.BinaryInfo import BinaryInfo
+from smda.common.FunctionCandidateManager import FunctionCandidateManager as CommonFunctionCandidateManager
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager as IntelFunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+IMAGE_SIZE = 0x20000
+CODE_RVA = 0x1000
+TABLE_RVA = 0x8000
+#: five method bodies, four of which the primary pass is assumed to have recovered. The
+#: unrecovered one sits in the middle: a run is only read against the address span of the
+#: functions already recovered, so an entry past the outermost of them is not one this pass
+#: can reason about.
+ENTRIES = [BASE + CODE_RVA + 0x10 * index for index in range(5)]
+UNRECOVERED = ENTRIES[2]
+RECOVERED = [entry for entry in ENTRIES if entry != UNRECOVERED]
+
+
+def _image(table_rva=TABLE_RVA, entries=None):
+    image = bytearray(IMAGE_SIZE)
+    for index, entry in enumerate(entries if entries is not None else ENTRIES):
+        struct.pack_into("<I", image, table_rva + 4 * index, entry)
+    return bytes(image)
+
+
+def _twoTableImage():
+    """Two tables in one image, each with one entry the primary pass did not recover."""
+    image = bytearray(_image())
+    second = [BASE + CODE_RVA + 0x100 + 0x10 * index for index in range(5)]
+    for index, entry in enumerate(second):
+        struct.pack_into("<I", image, TABLE_RVA + 0x100 + 4 * index, entry)
+    manager = _manager(
+        bytes(image),
+        functions=RECOVERED + [entry for entry in second if entry != second[2]],
+        data_refs={BASE + CODE_RVA: {BASE + TABLE_RVA, BASE + TABLE_RVA + 0x100}},
+    )
+    return second[2], manager
+
+
+def _manager(image, functions=RECOVERED, data_refs=None, code=(), bitness=32, delphi=True):
+    binary_info = BinaryInfo(image)
+    binary_info.base_addr = BASE
+    binary_info.bitness = bitness
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = binary_info
+    disassembly.functions = {addr: [] for addr in functions}
+    disassembly.data_refs_from = dict(data_refs if data_refs is not None else {BASE + CODE_RVA: {BASE + TABLE_RVA}})
+    for addr in code:
+        disassembly.code_map[addr] = 1
+    manager = IntelFunctionCandidateManager(SmdaConfig())
+    manager.disassembly = disassembly
+    manager.bitness = bitness
+    manager._delphi_detected = delphi
+    return manager
+
+
+class _DelphiVmtLanguageAnalyzer:
+    """A language analyzer reporting the legacy VMT Delphi path and nothing else.
+
+    No bundled fixture is a Delphi binary, and a real detection needs a valid VMT rather than
+    the string and timestamp hints, so what is checked here is the wiring: whether taking the
+    VMT branch is what the late pass later reads.
+    """
+
+    def __init__(self, delphi=True):
+        self.delphi = delphi
+
+    def checkGo(self):
+        return False
+
+    def checkDelphiKb(self):
+        return False
+
+    def checkDelphi(self):
+        return self.delphi
+
+    def getDelphiObjects(self):
+        return []
+
+    def getDelphiReSymObjects(self):
+        return []
+
+
+class PointerTableCandidateTestSuite(unittest.TestCase):
+    def test_the_delphi_vmt_pass_records_that_it_ran(self):
+        manager = _manager(_image(), delphi=False)
+        manager.lang_analyzer = _DelphiVmtLanguageAnalyzer()
+        manager.locateLangSpecCandidates()
+        self.assertTrue(manager._delphi_detected)
+
+    def test_a_binary_the_vmt_pass_declines_records_nothing(self):
+        manager = _manager(_image(), delphi=False)
+        manager.lang_analyzer = _DelphiVmtLanguageAnalyzer(delphi=False)
+        manager.locateLangSpecCandidates()
+        self.assertFalse(manager._delphi_detected)
+
+    def test_a_table_at_the_very_end_of_the_image_is_still_read(self):
+        table_rva = IMAGE_SIZE - 4 * len(ENTRIES)
+        manager = _manager(_image(table_rva=table_rva))
+        manager.disassembly.data_refs_from = {BASE + CODE_RVA: {BASE + table_rva}}
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [UNRECOVERED])
+
+    def test_a_referenced_run_of_known_functions_admits_its_unknown_entries(self):
+        manager = _manager(_image())
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [UNRECOVERED])
+        self.assertIn(UNRECOVERED, manager.candidates)
+
+    def test_an_unreferenced_run_admits_nothing(self):
+        manager = _manager(_image(), data_refs={})
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_a_run_the_recovered_functions_do_not_validate_admits_nothing(self):
+        # same table, still spanned by recovered functions, but only three of its five entries
+        # are ones - below the ratio a run has to clear to be read as a table
+        manager = _manager(_image(), functions=[ENTRIES[0], ENTRIES[1], ENTRIES[4]])
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_a_run_shorter_than_the_minimum_admits_nothing(self):
+        short = _image(entries=ENTRIES[:3] + [0, 0])
+        manager = _manager(short)
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_a_table_slot_already_claimed_as_code_ends_the_run(self):
+        # the third slot decodes as an instruction, so the table is two runs of two
+        manager = _manager(_image(), code=(BASE + TABLE_RVA + 8,))
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_an_entry_already_claimed_as_code_is_not_admitted_again(self):
+        manager = _manager(_image(), code=(UNRECOVERED,))
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_an_entry_outside_the_declared_code_areas_is_not_admitted(self):
+        manager = _manager(_image())
+        manager._code_areas = [(BASE + CODE_RVA, UNRECOVERED)]
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_an_entry_repeated_across_two_tables_is_admitted_once(self):
+        image = bytearray(_image())
+        for index, entry in enumerate(ENTRIES):
+            struct.pack_into("<I", image, TABLE_RVA + 0x100 + 4 * index, entry)
+        manager = _manager(
+            bytes(image),
+            data_refs={BASE + CODE_RVA: {BASE + TABLE_RVA, BASE + TABLE_RVA + 0x100}},
+        )
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [UNRECOVERED])
+
+    def test_two_tables_each_contribute_their_own_unrecovered_entry(self):
+        second_unrecovered, manager = _twoTableImage()
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [UNRECOVERED, second_unrecovered])
+
+    def test_no_candidates_without_delphi_evidence(self):
+        manager = _manager(_image(), delphi=False)
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_no_candidates_for_a_64_bit_image(self):
+        manager = _manager(_image(), bitness=64)
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_no_candidates_before_the_primary_pass_has_recovered_anything(self):
+        manager = _manager(_image(), functions=())
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_the_scan_stops_at_the_analysis_timeout(self):
+        manager = _manager(_image())
+        manager.disassembly.analysis_timeout = True
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+
+    def test_the_scan_polls_the_budget_once_per_chunk(self):
+        # the table sits in the second 64 KiB chunk of a two-chunk image, so a budget spent
+        # after the first chunk has to stop the scan before the table is reached - and the
+        # poll count says the budget is read per chunk rather than per entry
+        manager = _manager(_image(table_rva=0x18000))
+        manager.disassembly.data_refs_from = {BASE + CODE_RVA: {BASE + 0x18000}}
+        polls = []
+
+        def _tripAfterFirstChunk():
+            polls.append(len(polls))
+            return len(polls) > 1
+
+        manager._cb_analysis_timeout = _tripAfterFirstChunk
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+        self.assertEqual(len(polls), 2)
+
+    def test_a_start_claimed_as_code_before_it_is_reached_is_not_yielded(self):
+        # analyzing the first start can claim a later one as its own body, so each is
+        # re-checked at the moment it is handed over rather than only when it was accepted
+        second_unrecovered, manager = _twoTableImage()
+        candidates = manager.locatePointerTableCandidates()
+        self.assertEqual(next(candidates), UNRECOVERED)
+        manager.disassembly.code_map[second_unrecovered] = 1
+        self.assertEqual(list(candidates), [])
+
+    def test_every_accepted_start_is_registered_before_the_first_is_yielded(self):
+        second_unrecovered, manager = _twoTableImage()
+        candidates = manager.locatePointerTableCandidates()
+        self.assertEqual(next(candidates), UNRECOVERED)
+        self.assertLessEqual({UNRECOVERED, second_unrecovered}, manager._candidate_offsets)
+        self.assertEqual(list(candidates), [second_unrecovered])
+
+    def test_the_yield_loop_stops_at_the_analysis_timeout(self):
+        second_unrecovered, manager = _twoTableImage()
+        candidates = manager.locatePointerTableCandidates()
+        self.assertEqual(next(candidates), UNRECOVERED)
+        manager.disassembly.analysis_timeout = True
+        self.assertEqual(list(candidates), [])
+        self.assertIn(second_unrecovered, manager.candidates)
+
+    def test_the_architecture_neutral_base_declares_no_late_sources(self):
+        self.assertEqual(list(CommonFunctionCandidateManager(SmdaConfig()).locateLateCandidates()), [])
+
+
+LATE_BODY = b"\x31\xc0\xc3"  # xor eax, eax ; ret
+LATE_RVA = 0x2000
+LATE_ADDR = BASE + LATE_RVA
+SECOND_LATE_RVA = 0x2100
+SECOND_LATE_ADDR = BASE + SECOND_LATE_RVA
+
+
+def _lateImage():
+    image = bytearray(IMAGE_SIZE)
+    image[CODE_RVA : CODE_RVA + 6] = b"\x55\x89\xe5\x5d\xc3\x90"  # push ebp ; mov ebp, esp ; pop ebp ; ret
+    image[LATE_RVA : LATE_RVA + len(LATE_BODY)] = LATE_BODY
+    image[SECOND_LATE_RVA : SECOND_LATE_RVA + len(LATE_BODY)] = LATE_BODY
+    return bytes(image)
+
+
+def _config():
+    config = SmdaConfig()
+    config.CALCULATE_HASHING = False
+    config.CALCULATE_SCC = False
+    config.CALCULATE_NESTING = False
+    config.TIMEOUT = 0
+    return config
+
+
+def _offsets(image):
+    # the declared code area covers only the first body, so nothing the candidate manager or
+    # the gap scan does can reach the two later ones - they are recoverable solely by being
+    # handed to the orchestrator as late candidates
+    report = Disassembler(config=_config()).disassembleBuffer(
+        image,
+        BASE,
+        bitness=32,
+        code_areas=[(BASE + CODE_RVA, BASE + CODE_RVA + 0x10)],
+        architecture="intel",
+    )
+    return {function.offset for function in report.getFunctions()}
+
+
+class LateCandidateOrchestrationTestSuite(unittest.TestCase):
+    def test_the_orchestrator_analyzes_what_the_late_pass_yields(self):
+        image = _lateImage()
+        # control: nothing else in the pipeline reaches these two bodies
+        self.assertFalse({LATE_ADDR, SECOND_LATE_ADDR} & _offsets(image))
+        with mock.patch.object(
+            IntelFunctionCandidateManager,
+            "locateLateCandidates",
+            lambda self: iter([LATE_ADDR, SECOND_LATE_ADDR]),
+        ):
+            recovered = _offsets(image)
+        self.assertLessEqual({LATE_ADDR, SECOND_LATE_ADDR}, recovered)
+
+    def test_the_orchestrator_stops_the_late_pass_at_the_analysis_timeout(self):
+        def _spendAfterFirst(manager):
+            yield LATE_ADDR
+            manager.disassembly.analysis_timeout = True
+            yield SECOND_LATE_ADDR
+
+        image = _lateImage()
+        with mock.patch.object(IntelFunctionCandidateManager, "locateLateCandidates", _spendAfterFirst):
+            recovered = _offsets(image)
+        self.assertIn(LATE_ADDR, recovered)
+        self.assertNotIn(SECOND_LATE_ADDR, recovered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testPointerTableCandidates.py
+++ b/tests/testPointerTableCandidates.py
@@ -55,6 +55,19 @@ def _twoTableImage():
     return second[2], manager
 
 
+LONG_IMAGE_SIZE = 0x30000
+RUN_VALUE = BASE + CODE_RVA
+RUN_UNRECOVERED = BASE + CODE_RVA + 0x50
+RUN_HIGH = BASE + CODE_RVA + 0x100
+
+
+def _longRunImage():
+    """An image that is one uninterrupted run of code-pointer-shaped dwords."""
+    image = bytearray(struct.pack("<I", RUN_VALUE) * (LONG_IMAGE_SIZE // 4))
+    struct.pack_into("<I", image, 0x100, RUN_UNRECOVERED)
+    return bytes(image), BASE + 0x100
+
+
 def _manager(image, functions=RECOVERED, data_refs=None, code=(), bitness=32, delphi=True):
     binary_info = BinaryInfo(image)
     binary_info.base_addr = BASE
@@ -223,6 +236,31 @@ class PointerTableCandidateTestSuite(unittest.TestCase):
         self.assertEqual(list(candidates), [])
         self.assertIn(second_unrecovered, manager.candidates)
 
+    def test_the_budget_is_polled_while_a_long_run_is_admitted(self):
+        """A run can be as long as the image, and is walked twice more after it is found, so
+        the budget has to be consulted inside those walks and not only by the outer scan."""
+        long_image, referenced_addr = _longRunImage()
+        manager = _manager(long_image, functions=(RUN_VALUE, RUN_HIGH))
+        manager.disassembly.data_refs_from = {BASE + CODE_RVA: {referenced_addr}}
+        polls = []
+
+        def _tripAfterTheOuterScan():
+            polls.append(len(polls))
+            return len(polls) > 4
+
+        manager._cb_analysis_timeout = _tripAfterTheOuterScan
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [])
+        # the outer scan of a three-chunk image polls three times; a fourth means a poll
+        # happened inside the admission walk, which is what this test is about
+        self.assertGreater(len(polls), 3)
+
+    def test_a_long_run_is_admitted_when_the_budget_is_not_spent(self):
+        """Control for the rule above: without a spent budget the same run is read."""
+        long_image, referenced_addr = _longRunImage()
+        manager = _manager(long_image, functions=(RUN_VALUE, RUN_HIGH))
+        manager.disassembly.data_refs_from = {BASE + CODE_RVA: {referenced_addr}}
+        self.assertEqual(list(manager.locatePointerTableCandidates()), [RUN_UNRECOVERED])
+
     def test_the_architecture_neutral_base_declares_no_late_sources(self):
         self.assertEqual(list(CommonFunctionCandidateManager(SmdaConfig()).locateLateCandidates()), [])
 
@@ -232,6 +270,8 @@ LATE_RVA = 0x2000
 LATE_ADDR = BASE + LATE_RVA
 SECOND_LATE_RVA = 0x2100
 SECOND_LATE_ADDR = BASE + SECOND_LATE_RVA
+CALLEE_RVA = 0x2200
+CALLEE_ADDR = BASE + CALLEE_RVA
 
 
 def _lateImage():
@@ -251,15 +291,15 @@ def _config():
     return config
 
 
-def _offsets(image):
-    # the declared code area covers only the first body, so nothing the candidate manager or
-    # the gap scan does can reach the two later ones - they are recoverable solely by being
-    # handed to the orchestrator as late candidates
+def _offsets(image, code_areas=None):
+    # the declared code area covers only the first body by default, so nothing the candidate
+    # manager or the gap scan does can reach the later ones - they are recoverable solely by
+    # being handed to the orchestrator as late candidates
     report = Disassembler(config=_config()).disassembleBuffer(
         image,
         BASE,
         bitness=32,
-        code_areas=[(BASE + CODE_RVA, BASE + CODE_RVA + 0x10)],
+        code_areas=code_areas or [(BASE + CODE_RVA, BASE + CODE_RVA + 0x10)],
         architecture="intel",
     )
     return {function.offset for function in report.getFunctions()}
@@ -277,6 +317,25 @@ class LateCandidateOrchestrationTestSuite(unittest.TestCase):
         ):
             recovered = _offsets(image)
         self.assertLessEqual({LATE_ADDR, SECOND_LATE_ADDR}, recovered)
+
+    def test_a_callee_the_late_pass_discovers_is_analyzed(self):
+        """A late function can resolve a register-indirect call and register its callee. The
+        tailcall pass is off by default, so without a drain of its own that callee stays
+        registered and never analyzed."""
+        image = bytearray(IMAGE_SIZE)
+        image[CODE_RVA : CODE_RVA + 6] = b"\x55\x89\xe5\x5d\xc3\x90"
+        # mov eax, CALLEE_ADDR ; call eax ; ret - deliberately no prologue, so nothing but the
+        # late pass reaches it, and the callee is reachable only through the resolved call
+        image[LATE_RVA : LATE_RVA + 8] = b"\xb8" + struct.pack("<I", CALLEE_ADDR) + b"\xff\xd0\xc3"
+        image[CALLEE_RVA : CALLEE_RVA + 3] = b"\x31\xc0\xc3"  # xor eax, eax ; ret
+        areas = [(BASE + CODE_RVA, BASE + CODE_RVA + 0x10), (LATE_ADDR, CALLEE_ADDR + 4)]
+
+        # control: neither body is reachable without the late pass
+        self.assertEqual(_offsets(bytes(image), areas), {BASE + CODE_RVA})
+        with mock.patch.object(IntelFunctionCandidateManager, "locateLateCandidates", lambda self: iter([LATE_ADDR])):
+            recovered = _offsets(bytes(image), areas)
+
+        self.assertLessEqual({LATE_ADDR, CALLEE_ADDR}, recovered)
 
     def test_the_orchestrator_stops_the_late_pass_at_the_analysis_timeout(self):
         def _spendAfterFirst(manager):


### PR DESCRIPTION
Rebased continuation of #279 (@r0ny123) onto master — cherry-picked the branch's two commits (late-pass Delphi method-table candidate source, plus the post-pass drain). Depends on the data-reference signal from #284 (rebased #278), which is now merged. See #279 for the full write-up: +3 real functions on the corpus at exactly the three documented addresses, zero fixture moves. Locally validated: targeted suites green.