### PR TITLE
fix(labels): report confirmed-format parse failures at warning

### DIFF
--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -128,7 +128,7 @@ class BinaryInfo:
                 with open(self.file_path, "rb") as fin:
                     data = fin.read()
             except OSError as e:
-                LOGGER.debug("Failed to read binary from path %s: %s", self.file_path, e)
+                LOGGER.warning("Failed to read binary from path %s: %s", self.file_path, e)
                 return None
         return data
 

--- a/src/smda/common/labelprovider/CilSymbolProvider.py
+++ b/src/smda/common/labelprovider/CilSymbolProvider.py
@@ -42,7 +42,7 @@ class CilSymbolProvider(AbstractLabelProvider):
             pe = dnfile.dnPE(data=binary_info.raw_data) if parsed is None else parsed
         except Exception as exc:
             reraise_non_operational_exception(exc)
-            LOGGER.debug("Failed to parse CIL symbols: %s", exc)
+            LOGGER.warning("Failed to parse CIL symbols: %s", exc)
             return
         if not getattr(pe, "net", None) or not getattr(pe.net, "mdtables", None):
             return

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -252,7 +252,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
         # Determine code areas
         code_areas = binary_info.code_areas
         if not code_areas:
-            LOGGER.debug("No code areas found, skipping DelphiReSym parsing")
+            LOGGER.warning("No code areas found, skipping DelphiReSym parsing")
             return
 
         # Code areas are virtual addresses - convert to file offsets for scanning
@@ -266,7 +266,7 @@ class DelphiReSymProvider(AbstractLabelProvider):
 
         # Validate the offsets are within binary bounds
         if self._code_start < 0 or self._code_end > len(self._binary):
-            LOGGER.debug(
+            LOGGER.warning(
                 f"Code area offsets out of bounds: {self._code_start}-{self._code_end}, binary size: {len(self._binary)}"
             )
             return

--- a/src/smda/common/labelprovider/GoLabelProvider.py
+++ b/src/smda/common/labelprovider/GoLabelProvider.py
@@ -195,6 +195,7 @@ class GoSymbolProvider(AbstractLabelProvider):
                     self._func_symbols = result
             except Exception as exc:
                 reraise_non_operational_exception(exc)
+                LOGGER.warning("Failed to parse Go pclntab at offset 0x%x: %s", pclntab_offset, exc)
                 return
             binary_info._go_pclntab_symbols = dict(self._func_symbols)
 

--- a/src/smda/common/labelprovider/MachoSymbolProvider.py
+++ b/src/smda/common/labelprovider/MachoSymbolProvider.py
@@ -107,8 +107,8 @@ class MachoSymbolProvider(AbstractLabelProvider):
                     and adjusted_stub_addr not in self._func_symbols
                 ):
                     self._func_symbols[adjusted_stub_addr] = f"stub_{adjusted_stub_addr:x}"
-        except Exception:
-            pass
+        except Exception as e:
+            LOGGER.warning("Failed to collect Mach-O symbol stubs: %s", e)
 
         self._api_map = self.parseImports(lief_binary)
 
@@ -125,7 +125,7 @@ class MachoSymbolProvider(AbstractLabelProvider):
                     adjusted_val = symbol.value + adjustment
                     exported[adjusted_val] = demangle_macho_symbol(symbol_name)
         except Exception as e:
-            LOGGER.debug("Failed to parse Mach-O exports: %s", e)
+            LOGGER.warning("Failed to parse Mach-O exports: %s", e)
         return exported
 
     def parseSymbols(self, lief_binary):
@@ -141,7 +141,7 @@ class MachoSymbolProvider(AbstractLabelProvider):
                     adjusted_val = symbol.value + adjustment
                     symbols[adjusted_val] = symbol_name
         except Exception as e:
-            LOGGER.debug("Failed to parse Mach-O symbols: %s", e)
+            LOGGER.warning("Failed to parse Mach-O symbols: %s", e)
         return symbols
 
     def parseImports(self, lief_binary):

--- a/src/smda/common/labelprovider/RustSymbolProvider.py
+++ b/src/smda/common/labelprovider/RustSymbolProvider.py
@@ -44,7 +44,7 @@ class RustSymbolProvider(AbstractLabelProvider):
             lief_binary = binary_info.getLiefBinary()
         except Exception as exc:
             reraise_non_operational_exception(exc)
-            LOGGER.debug("Failed to parse binary with LIEF: %s", type(exc).__name__)
+            LOGGER.warning("Failed to parse binary with LIEF: %s", type(exc).__name__)
             return
 
         if not lief_binary or not self.is_rust_binary(binary_info):
@@ -121,7 +121,7 @@ class RustSymbolProvider(AbstractLabelProvider):
                 with open(binary_info.file_path, "rb") as fin:
                     data = fin.read()
             except OSError as e:
-                LOGGER.debug("Failed to read binary from path %s: %s", binary_info.file_path, e)
+                LOGGER.warning("Failed to read binary from path %s: %s", binary_info.file_path, e)
                 return None
         return data
 

--- a/src/smda/utility/ElfFileLoader.py
+++ b/src/smda/utility/ElfFileLoader.py
@@ -271,7 +271,7 @@ class ElfFileLoader:
         )
 
         if not max_virtual_address:
-            LOGGER.debug("ELF: no section or segment data")
+            LOGGER.warning("ELF: no section or segment data")
             return b""
 
         # create mapped region.

--- a/src/smda/utility/FileLoader.py
+++ b/src/smda/utility/FileLoader.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from smda.utility.DelphiKbFileLoader import DelphiKbFileLoader
@@ -5,6 +6,8 @@ from smda.utility.DexFileLoader import DexFileLoader
 from smda.utility.ElfFileLoader import ElfFileLoader
 from smda.utility.MachoFileLoader import MachoFileLoader
 from smda.utility.PeFileLoader import PeFileLoader
+
+LOGGER = logging.getLogger(__name__)
 
 
 class FileLoader:
@@ -63,6 +66,10 @@ class FileLoader:
                     # distinguishes "caller did not supply" from
                     # "caller already tried and got None".
                     kw = {"parsed": loader.parseBinary(self._raw_data)} if hasattr(loader, "parseBinary") else {}
+                    # isCompatible() has confirmed the format, so a failed shared parse means
+                    # every accessor below silently yields nothing for a real PE/ELF/Mach-O
+                    if "parsed" in kw and not kw["parsed"]:
+                        LOGGER.warning("%s: failed to parse the binary, no data will be mapped", loader.__name__)
                     self._data = loader.mapBinary(self._raw_data, **kw)
                     self._base_addr = loader.getBaseAddress(self._raw_data, **kw)
                     self._bitness = loader.getBitness(self._raw_data, **kw)

--- a/src/smda/utility/MachoFileLoader.py
+++ b/src/smda/utility/MachoFileLoader.py
@@ -221,7 +221,7 @@ class MachoFileLoader:
         max_virtual_address, min_virtual_address, min_raw_offset = _calculate_boundaries(macho_file)
 
         if not max_virtual_address:
-            LOGGER.debug("MachO: no section or segment data")
+            LOGGER.warning("MachO: no section or segment data")
             return b""
 
         # create mapped region.

--- a/src/smda/utility/PeFileLoader.py
+++ b/src/smda/utility/PeFileLoader.py
@@ -84,7 +84,7 @@ class PeFileLoader:
             # Mach-O loaders report the same condition, by returning no mapped data, instead
             # of raising a ValueError that claims the opposite of what happened.
             if not max_virt_section_offset:
-                LOGGER.debug("PE: no section data")
+                LOGGER.warning("PE: no section data")
                 return b""
             # support up to 100MB for now.
             if max_virt_section_offset > SmdaConfig.MAX_IMAGE_SIZE:

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -1,6 +1,7 @@
 import copy
 import hashlib
 import json
+import logging
 import struct
 import tempfile
 import unittest
@@ -561,6 +562,23 @@ class TestBinaryInfoCodeAreas(unittest.TestCase):
         self.assertTrue(binary_info.isInCodeAreas(0x400000))
         self.assertTrue(binary_info.isInCodeAreas(0x4000FF))
         self.assertFalse(binary_info.isInCodeAreas(0x400100))
+
+
+class TestBinaryInfoBinaryData(unittest.TestCase):
+    def test_an_unreadable_binary_path_is_reported_at_warning(self):
+        # getBinaryData feeds getLiefBinary and every lief-backed provider through it, so a
+        # read failure here silently unnames the whole run
+        binary_info = BinaryInfo(b"")
+        binary_info.file_path = str(Path(__file__).resolve().parent / "does_not_exist.bin")
+        # another test module's import-time logging.disable() would hide these records
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+        with self.assertLogs("smda.common.BinaryInfo", level="WARNING") as logged:
+            self.assertIsNone(binary_info.getBinaryData())
+
+        self.assertIn("Failed to read binary", logged.output[0])
 
 
 class TestSmdaFunctionRobustness(unittest.TestCase):

--- a/tests/testDelphiPythiaProvider.py
+++ b/tests/testDelphiPythiaProvider.py
@@ -1,3 +1,4 @@
+import logging
 import struct
 import unittest
 from types import SimpleNamespace
@@ -139,6 +140,43 @@ class TestDelphiPythiaProvider(unittest.TestCase):
 
         self.assertIn(DelphiPythiaProvider, provider_types)
         self.assertNotIn(DelphiPythiaProvider, {type(provider) for provider in engine.api_providers})
+
+
+class TestDelphiReSymDeadEndLogging(unittest.TestCase):
+    """Both paths run after the MZ + TObject signature match, so they are real dead ends."""
+
+    def setUp(self):
+        # another test module's import-time logging.disable() would hide these records
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+    @staticmethod
+    def _delphi_binary_info(code_areas):
+        binary = bytearray(0x2000)
+        binary[:2] = b"MZ"
+        binary[0x100:0x107] = b"TObject"
+        binary_info = BinaryInfo(bytes(binary))
+        binary_info.base_addr = 0x400000
+        binary_info.bitness = 32
+        binary_info.code_areas = code_areas
+        return binary_info
+
+    def test_a_binary_without_code_areas_is_reported_at_warning(self):
+        provider = DelphiReSymProvider(None)
+
+        with self.assertLogs("smda.common.labelprovider.DelphiReSymProvider", level="WARNING") as logged:
+            provider.update(self._delphi_binary_info([]))
+
+        self.assertIn("No code areas found", logged.output[0])
+
+    def test_out_of_bounds_code_area_offsets_are_reported_at_warning(self):
+        provider = DelphiReSymProvider(None)
+
+        with self.assertLogs("smda.common.labelprovider.DelphiReSymProvider", level="WARNING") as logged:
+            provider.update(self._delphi_binary_info([(0x400000, 0x409000)]))
+
+        self.assertIn("out of bounds", logged.output[0])
 
 
 class TestDelphiReSymNegativeOffsets(unittest.TestCase):

--- a/tests/testFileFormatParsers.py
+++ b/tests/testFileFormatParsers.py
@@ -46,6 +46,24 @@ class SmdaIntegrationTestSuite(unittest.TestCase):
             decrypted_binary.append(byte ^ (index % 256))
         return bytes(decrypted_binary)
 
+    def test_a_confirmed_format_that_fails_to_parse_is_reported_at_warning(self):
+        # isCompatible() matched the magic, but the shared parse came back empty - every
+        # accessor below it then yields nothing for what really is a PE/ELF
+        # another test module's import-time logging.disable() would hide these records
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+        for name, binary in (("ELF", b"\x7fELF"), ("PE", b"MZ" + b"\x00" * 64)):
+            with self.subTest(format=name):
+                loader = FileLoader("/", map_file=True)
+
+                with self.assertLogs("smda.utility.FileLoader", level="WARNING") as logged:
+                    loader._loadFile(binary)
+
+                self.assertEqual(b"", loader.getData())
+                self.assertIn("failed to parse the binary", logged.output[0])
+
     def _create_binary_info(self, binary):
         loader = FileLoader("/", map_file=True)
         loader._loadFile(binary)

--- a/tests/testGoSymbolProvider.py
+++ b/tests/testGoSymbolProvider.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import random
 import struct
@@ -503,6 +504,24 @@ class TestPcLntabParseIsSharedAcrossProviders(unittest.TestCase):
             GoSymbolProvider._parse_pclntab = original
 
         self.assertEqual(parses, [1])
+
+
+class TestPcLntabParseFailureLogging(unittest.TestCase):
+    def test_a_parse_failure_after_a_validated_header_warns(self):
+        # the offset is only accepted once the header structure checks out, so recovering no
+        # symbols from it is a real failure - it used to leave no record at any level
+        provider = GoSymbolProvider(None)
+        binary_info = BinaryInfo(b"\xfb\xff\xff\xff\x00\x00\x01\x08")
+        # another test module's import-time logging.disable() would hide these records
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+        with self.assertLogs("smda.common.labelprovider.GoLabelProvider", level="WARNING") as logged:
+            provider.update(binary_info)
+
+        self.assertEqual({}, provider.getFunctionSymbols())
+        self.assertIn("pclntab", logged.output[0])
 
 
 if __name__ == "__main__":

--- a/tests/testMachoSymbolProvider.py
+++ b/tests/testMachoSymbolProvider.py
@@ -40,6 +40,20 @@ class _MockMachoBinary:
         self.sections = []
 
 
+class _UnreadableValueSymbol:
+    name = "_main"
+
+    @property
+    def value(self):
+        raise RuntimeError("symbol table unreadable")
+
+
+class _UnreadableAddressStub:
+    @property
+    def address(self):
+        raise RuntimeError("stub table unreadable")
+
+
 def _xor_fixture(data):
     return bytes(byte ^ (index % 256) for index, byte in enumerate(data))
 
@@ -165,6 +179,56 @@ class TestMachoSymbolProviderBehavior(unittest.TestCase):
         binary_info = BinaryInfo(b"not a container")
 
         self.assertIsNone(GoSymbolProvider(None).getTextStart(binary_info))
+
+
+class TestMachoSymbolProviderFailureLogging(unittest.TestCase):
+    """Every path here runs only after the isinstance(lief.MachO.Binary) gate has matched."""
+
+    def setUp(self):
+        # this module's import-time logging.disable() would hide these records
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+    def test_a_failing_export_table_is_reported_at_warning(self):
+        macho = _MockMachoBinary([_UnreadableValueSymbol()])
+        provider = MachoSymbolProvider(None)
+
+        with (
+            mock.patch("lief.MachO.Binary", _MockMachoBinary),
+            self.assertLogs("smda.common.labelprovider.MachoSymbolProvider", level="WARNING") as logged,
+        ):
+            self.assertEqual({}, provider.parseExports(macho))
+
+        self.assertIn("exports", logged.output[0])
+
+    def test_a_failing_symbol_table_is_reported_at_warning(self):
+        macho = _MockMachoBinary([_UnreadableValueSymbol()])
+        provider = MachoSymbolProvider(None)
+
+        with (
+            mock.patch("lief.MachO.Binary", _MockMachoBinary),
+            self.assertLogs("smda.common.labelprovider.MachoSymbolProvider", level="WARNING") as logged,
+        ):
+            self.assertEqual({}, provider.parseSymbols(macho))
+
+        self.assertIn("symbols", logged.output[0])
+
+    def test_a_failing_stub_table_is_reported_at_warning(self):
+        macho = _MockMachoBinary([])
+        macho.symbol_stubs = [_UnreadableAddressStub()]
+        binary_info = BinaryInfo(b"not a container")
+        provider = MachoSymbolProvider(None)
+
+        with (
+            mock.patch("lief.MachO.Binary", _MockMachoBinary),
+            mock.patch.object(binary_info, "getLiefBinary", return_value=macho),
+            self.assertLogs("smda.common.labelprovider.MachoSymbolProvider", level="WARNING") as logged,
+        ):
+            provider.update(binary_info)
+
+        self.assertEqual({}, provider.getFunctionSymbols())
+        self.assertIn("stubs", logged.output[0])
 
 
 class TestMachoCorpusIntegration(unittest.TestCase):

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -1,5 +1,7 @@
+import logging
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -617,6 +619,36 @@ class TestRustV0ConstBackrefs(unittest.TestCase):
     def test_a_const_backref_reproduces_the_referenced_value(self):
         self.assertEqual(demangle("_RIC1aKh4_KB4_E"), demangle("_RIC1aKh4_Kh4_E"))
         self.assertEqual(demangle("_RIC1aKh4_KB4_E"), "a::<4, 4>")
+
+
+class TestRustProviderFailureLogging(unittest.TestCase):
+    def setUp(self):
+        # another test module's import-time logging.disable() would hide these records
+        previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+        self.addCleanup(logging.disable, previous_disable)
+
+    def test_a_lief_parse_failure_is_reported_at_warning(self):
+        provider = RustSymbolProvider(None)
+        binary_info = BinaryInfo(b"/rustc/")
+
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", side_effect=RuntimeError("boom")),
+            self.assertLogs("smda.common.labelprovider.RustSymbolProvider", level="WARNING") as logged,
+        ):
+            provider.update(binary_info)
+
+        self.assertEqual({}, provider.getFunctionSymbols())
+        self.assertIn("RuntimeError", logged.output[0])
+
+    def test_an_unreadable_binary_path_is_reported_at_warning(self):
+        provider = RustSymbolProvider(None)
+        missing = SimpleNamespace(raw_data=b"", file_path=str(Path(__file__).resolve().parent / "does_not_exist.bin"))
+
+        with self.assertLogs("smda.common.labelprovider.RustSymbolProvider", level="WARNING") as logged:
+            self.assertIsNone(provider._get_binary_data(missing))
+
+        self.assertIn("Failed to read binary", logged.output[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rebased continuation of #246 (@r0ny123) onto current master. Single commit; the only conflict (tests/testGoSymbolProvider.py) was resolved by keeping both #283's cache tests and this PR's new failure-logging test. Raises confirmed-format whole-parse failures from debug/silence to warning across CIL/Rust/Mach-O/Delphi/Go providers, BinaryInfo and all three file loaders — the class that made the PDB defect (#230) invisible. See #246 for the full write-up.