### PR TITLE
fix(labels): keep ELF import names as the binary spells them

### DIFF
--- a/src/smda/common/labelprovider/ElfSymbolProvider.py
+++ b/src/smda/common/labelprovider/ElfSymbolProvider.py
@@ -140,15 +140,15 @@ class ElfSymbolProvider(AbstractLabelProvider):
         return function_symbols
 
     def parseImports(self, lief_binary):
-        """Return relocation-backed imports with demangled, human-readable names.
+        """Return relocation-backed imports as the binary spells them.
 
-        Only this label view is demangled. ElfApiResolver consumes the undecorated
-        map so API references keep matching PE and Mach-O import names.
+        This is not a label view. It reaches xmetadata["imported_functions"], which
+        BinarySynthesizer writes back as the literal names of a reconstructed import table,
+        and which SmdaReport._mergeImportedFunctions fills from the undecorated API-resolver
+        view as well - so a demangled spelling here is both an unusable import name and a
+        second spelling of names already in the same dict.
         """
-        return {
-            address: (lib, demangle_itanium_symbol(name))
-            for address, (lib, name) in parse_elf_relocation_imports(lief_binary).items()
-        }
+        return parse_elf_relocation_imports(lief_binary)
 
     def collectSymbols(self, lief_binary):
         if not isinstance(lief_binary, lief.ELF.Binary):

--- a/src/smda/common/labelprovider/import_parsers.py
+++ b/src/smda/common/labelprovider/import_parsers.py
@@ -62,10 +62,10 @@ def parse_pe_delay_imports(lief_binary, base_addr=None):
 def parse_elf_relocation_imports(lief_binary):
     """Build import map keyed by relocation slot address: addr -> (lib, name).
 
-    Names stay exactly as the dynamic symbol table spells them. API resolution is
-    keyed by these names, so they must remain comparable with PE and Mach-O imports,
-    which are equally undecorated. Demangling happens one level up, where the result
-    is only used as a human-readable label.
+    Names stay exactly as the dynamic symbol table spells them, here and in every
+    caller: API resolution is keyed by them, so they must remain comparable with PE
+    and Mach-O imports, which are equally undecorated, and synthesis writes them back
+    into an import table.
     """
     if not isinstance(lief_binary, lief.ELF.Binary):
         return {}

--- a/tests/testElfSymbolProvider.py
+++ b/tests/testElfSymbolProvider.py
@@ -301,12 +301,12 @@ class TestElfApiSymbolSeparation(unittest.TestCase):
         binary_info = _binary_info(elf)
         with mock.patch("lief.ELF.Binary", _MockElfBinary):
             resolver.update(binary_info)
-            # The human-readable label view demangles ...
-            self.assertEqual(provider.parseImports(elf), {0x4000: (None, "operator new(unsigned long)")})
-        # ... while API references stay comparable with PE and Mach-O import names.
+            self.assertEqual(provider.parseImports(elf), {0x4000: (None, "_Znwm")})
+        # both views spell the import the way the binary does, so the merged
+        # xmetadata entry cannot hold two spellings of the same import
         self.assertEqual(resolver.getApi(0x4000), (None, "_Znwm"))
 
-    def test_elf_exports_and_imports_use_itanium_demangling(self):
+    def test_elf_exports_demangle_while_imports_keep_their_encoded_name(self):
         imported = _MockSymbol("_Z3barv", imported=True)
         elf = _MockElfBinary(
             exported_functions=[_MockExport("_Z3foov", 0x1000)],
@@ -324,7 +324,7 @@ class TestElfApiSymbolSeparation(unittest.TestCase):
             ),
         ):
             self.assertEqual(provider.parseExports(elf), {0x1000: "foo()"})
-            self.assertEqual(provider.parseImports(elf), {0x4000: (None, "bar()")})
+            self.assertEqual(provider.parseImports(elf), {0x4000: (None, "_Z3barv")})
 
     def test_binary_info_elf_imported_functions_use_relocation_slots(self):
         binary_info = BinaryInfo(b"")
@@ -335,6 +335,25 @@ class TestElfApiSymbolSeparation(unittest.TestCase):
         ):
             imported = binary_info.getImportedFunctions()
         self.assertEqual(imported, {0x4000: (None, "printf")})
+
+    def test_binary_info_elf_imported_functions_stay_encoded(self):
+        imported = _MockSymbol("_Z3barv", imported=True)
+        elf = _MockElfBinary(
+            exported_functions=[],
+            symtab_symbols=[],
+            dynamic_symbols=[imported],
+            relocations=[_MockReloc(0x4000, imported)],
+            entrypoint=0,
+        )
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=elf),
+            mock.patch("lief.ELF.Binary", _MockElfBinary),
+        ):
+            # BinarySynthesizer writes these back as the literal names of a reconstructed
+            # import table, so a signature here would be an unusable import name
+            self.assertEqual(binary_info.getImportedFunctions(), {0x4000: (None, "_Z3barv")})
 
     def test_binary_info_elf_symbols_merge_symtab_sources(self):
         binary_info = BinaryInfo(b"")

--- a/tests/testMachoSymbolProvider.py
+++ b/tests/testMachoSymbolProvider.py
@@ -137,6 +137,19 @@ class TestMachoSymbolProviderBehavior(unittest.TestCase):
         provider.update(binary_info)
         self.assertEqual(provider.getSymbol(0x100096320), "_runtime.etext")
 
+    def test_frostyferret_cxx_imports_stay_decorated_in_both_views(self):
+        _, raw, loader = _load_fixture("malpedia/osx.frostyferret")
+        binary_info = _binary_info(raw, loader)
+        provider = MachoSymbolProvider(None)
+        provider.update(binary_info)
+
+        imported = provider.parseImports(binary_info.getLiefBinary())
+
+        self.assertEqual(imported[0x1000101E0][1], "__Znwm")
+        self.assertEqual(imported[0x1000101D8][1], "__ZdlPv")
+        self.assertEqual(provider.getApi(0x1000101E0), imported[0x1000101E0])
+        self.assertEqual(binary_info.getImportedFunctions()[0x1000101E0][1], "__Znwm")
+
     def test_go_provider_parses_macho_pclntab(self):
         _, raw, loader = _load_fixture("objective-see/turtle")
         binary_info = _binary_info(raw, loader)

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -280,6 +280,24 @@ class TestPeSymbolProviderMetadata(unittest.TestCase):
             imported = binary_info.getImportedFunctions()
         self.assertEqual(imported, {0x402000: ("kernel32.dll", "ExitProcess")})
 
+    def test_imported_functions_keep_msvc_decorated_names(self):
+        decorated = "?compute@Solver@@QEAAHH@Z"
+        pe_binary = _MockPeBinary(
+            imports=[_MockImportLibrary("solver.dll", [_MockImportEntry(decorated, 0x2000)])],
+            imagebase=0x140000000,
+        )
+        provider = PeSymbolProvider(None)
+        self.assertEqual(provider.parseImports(pe_binary, base_addr=0x400000), {0x402000: ("solver.dll", decorated)})
+
+        binary_info = BinaryInfo(b"")
+        binary_info.base_addr = 0x400000
+        with (
+            mock.patch.object(binary_info, "getLiefBinary", return_value=pe_binary),
+            mock.patch("lief.PE.Binary", _MockPeBinary),
+        ):
+            imported = binary_info.getImportedFunctions()
+        self.assertEqual(imported, {0x402000: ("solver.dll", decorated)})
+
     def test_rebased_dump_xmetadata_and_api_parity(self):
         pe_binary = _MockPeBinary(
             imports=[_MockImportLibrary("KERNEL32.dll", [_MockImportEntry("CreateFileW", 0x3000)])],

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -287,6 +287,26 @@ class SmdaSynthesisTestSuite(unittest.TestCase):
         assert relocations[slot_a].symbol.name == "system"
         assert relocations[slot_b].symbol.name == "strdup"
 
+    def testDecoratedImportNamesReachTheImportTableVerbatim(self):
+        pe_report = SmdaReport.fromDict(self.pe_report.toDict())
+        pe_slot = min(int(key) for key in pe_report.xmetadata["imported_functions"])
+        pe_report.xmetadata["imported_functions"] = {pe_slot: ("solver.dll", "?compute@Solver@@QEAAHH@Z")}
+        parsed = lief.parse(pe_report.synthesizeBinary())
+        pe_names = {entry.name for imported in parsed.imports for entry in imported.entries if entry.name}
+        assert "?compute@Solver@@QEAAHH@Z" in pe_names
+
+        elf_report = SmdaReport.fromDict(self.elf_report.toDict())
+        data_va = next(start for name, start, _ in self.elf_report.code_sections if name == ".data")
+        elf_report.xmetadata["imported_functions"] = {data_va + 0x8: ("libstdc++.so.6", "_Znwm")}
+        parsed = lief.parse(elf_report.synthesizeBinary())
+        assert "_Znwm" in {symbol.name for symbol in parsed.dynamic_symbols}
+
+        macho_report = SmdaReport.fromDict(self.macho_report.toDict())
+        macho_slot = min(int(key) for key in macho_report.xmetadata["imported_functions"])
+        macho_report.xmetadata["imported_functions"] = {macho_slot: ("/usr/lib/libc++.1.dylib", "__Znwm")}
+        parsed = lief.parse(macho_report.synthesizeBinary())
+        assert "__Znwm" in {symbol.name for symbol in parsed.symbols}
+
     def testFunctionsOutsideEverySectionGetASyntheticSection(self):
         # keeps the header (so the full path runs, not the minimal one) but moves every
         # section clear of the functions, which is the branch that builds the synthetic


### PR DESCRIPTION
Rebased continuation of #256 (@r0ny123) onto current master — both commits cherry-picked cleanly. `ElfSymbolProvider.parseImports` stops demangling: the dict feeds import-table reconstruction in the synthesizers and the report's imported-functions merge, both of which need identifiers, not prose. Exports and symbol labels still demangle. See #256 for the full write-up.