### PR TITLE
perf(labels): demangle a Mach-O's Swift names in one call

### DIFF
--- a/src/smda/common/labelprovider/MachoDemangler.py
+++ b/src/smda/common/labelprovider/MachoDemangler.py
@@ -13,6 +13,66 @@ _CXX_PREFIXES = ("__Z", "_Z")
 _SWIFT_PREFIXES = ("_$s", "$s", "_$S", "$S")
 
 
+_SWIFT_CACHE = {}
+
+
+def primeSwiftSymbols(names):
+    """Resolve every Swift name in one call, before the per-symbol lookups begin.
+
+    The Swift demangler is a subprocess, and a Mach-O carrying Swift carries it by the
+    hundred: 104 distinct names in the jokerspy corpus sample, at 26 ms of process spawn
+    each. Fed the whole set through stdin it answers in 20 ms, and a host with no Swift
+    toolchain costs one failed lookup instead of one per symbol.
+
+    stdin rather than argv, because a symbol table can hold more names than a command
+    line can carry.
+    """
+    pending = sorted(
+        {
+            name
+            for name in names
+            if name and name.startswith(_SWIFT_PREFIXES) and name not in _SWIFT_CACHE and "\n" not in name
+        }
+    )
+    if not pending:
+        return
+    demangled = _demangleSwiftBatch(pending)
+    if demangled is None:
+        return
+    for name, result in zip(pending, demangled, strict=True):
+        _SWIFT_CACHE[name] = _finalize_demangled(name, result)
+
+
+def _demangleSwiftBatch(names):
+    if "swift" in _UNUSABLE_DEMANGLERS:
+        return None
+    executable = _find_demangler("swift")
+    if not executable:
+        return None
+    try:
+        completed = subprocess.run(
+            [executable, "demangle"],
+            input="\n".join(names),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        LOGGER.debug("Batched Swift demangling failed: %s", exc)
+        _UNUSABLE_DEMANGLERS.add("swift")
+        return None
+    if completed.returncode != 0:
+        return None
+    lines = (completed.stdout or "").splitlines()
+    if len(lines) != len(names):
+        # the answers are positional, so a short or padded reply cannot be realigned -
+        # taking it would label symbols with each other's names
+        LOGGER.debug("Swift demangler answered %d names with %d lines; discarding", len(names), len(lines))
+        return None
+    return lines
+
+
 @lru_cache(maxsize=4096)
 def demangle_macho_symbol(name):
     """Best-effort demangling for Mach-O symbol names (C++ Itanium, Swift).
@@ -27,6 +87,8 @@ def demangle_macho_symbol(name):
         if demangled:
             return demangled
     if name.startswith(_SWIFT_PREFIXES):
+        if name in _SWIFT_CACHE:
+            return _SWIFT_CACHE[name] or name
         demangled = _finalize_demangled(name, _demangle_with_tools(name, ("swift",), ["demangle"]))
         if demangled:
             return demangled

--- a/src/smda/common/labelprovider/MachoSymbolProvider.py
+++ b/src/smda/common/labelprovider/MachoSymbolProvider.py
@@ -12,7 +12,7 @@ from smda.utility.MachoBinary import (
 
 from .AbstractLabelProvider import AbstractLabelProvider
 from .import_parsers import parse_macho_bindings
-from .MachoDemangler import demangle_macho_symbol
+from .MachoDemangler import demangle_macho_symbol, primeSwiftSymbols
 
 lief.logging.disable()
 LOGGER = logging.getLogger(__name__)
@@ -69,6 +69,19 @@ class MachoSymbolProvider(AbstractLabelProvider):
             return demangled
         return demangle_macho_symbol(raw_name)
 
+    @classmethod
+    def _collectSymbolNames(cls, lief_binary):
+        names = []
+        for attribute in ("symbols", "exported_symbols"):
+            try:
+                for symbol in getattr(lief_binary, attribute, []) or []:
+                    name = cls._get_symbol_name(symbol)
+                    if name:
+                        names.append(name)
+            except Exception as exc:
+                LOGGER.debug("Failed collecting Mach-O %s for demangling: %s", attribute, exc)
+        return names
+
     def _filter_symbols_to_code(self, symbols, binary_info):
         if not binary_info:
             return symbols
@@ -83,6 +96,7 @@ class MachoSymbolProvider(AbstractLabelProvider):
         if not lief_binary or not isinstance(lief_binary, lief.MachO.Binary):
             return
 
+        primeSwiftSymbols(self._collectSymbolNames(lief_binary))
         adjustment = self._get_address_adjustment(lief_binary)
 
         if hasattr(lief_binary, "entrypoint"):

--- a/tests/testMachoSymbolProvider.py
+++ b/tests/testMachoSymbolProvider.py
@@ -357,12 +357,42 @@ class TestSwiftDemangleCorpusRegression(unittest.TestCase):
         self.assertEqual(typed_function.function_name, self._JOKERSPY_TYPE_DEMANGLED)
 
 
+class TestMachoSymbolNameCollection(unittest.TestCase):
+    class _Exploding:
+        @property
+        def symbols(self):
+            raise RuntimeError("lief refused the symbol table")
+
+        exported_symbols = [_MockMachoSymbol("_$s4mainAAyyF", 0x1000)]
+
+    def test_both_symbol_tables_feed_the_batch(self):
+        class _Binary:
+            symbols = [_MockMachoSymbol("_$s4mainAAyyF", 0x1000), _MockMachoSymbol(None, 0x2000)]
+            exported_symbols = [_MockMachoSymbol("__Z3uidv", 0x3000)]
+
+        self.assertEqual(
+            MachoSymbolProvider._collectSymbolNames(_Binary()),
+            ["_$s4mainAAyyF", "__Z3uidv"],
+        )
+
+    def test_an_unreadable_symbol_table_does_not_lose_the_other_one(self):
+        self.assertEqual(MachoSymbolProvider._collectSymbolNames(self._Exploding()), ["_$s4mainAAyyF"])
+
+
+class _CompletedProcess:
+    def __init__(self, stdout, returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
 class TestMachoDemanglerToolFanout(unittest.TestCase):
     def setUp(self):
         MachoDemangler._UNUSABLE_DEMANGLERS.clear()
+        MachoDemangler._SWIFT_CACHE.clear()
         MachoDemangler._find_demangler.cache_clear()
         MachoDemangler.demangle_macho_symbol.cache_clear()
         self.addCleanup(MachoDemangler._UNUSABLE_DEMANGLERS.clear)
+        self.addCleanup(MachoDemangler._SWIFT_CACHE.clear)
         self.addCleanup(MachoDemangler._find_demangler.cache_clear)
         self.addCleanup(MachoDemangler.demangle_macho_symbol.cache_clear)
 
@@ -381,6 +411,98 @@ class TestMachoDemanglerToolFanout(unittest.TestCase):
             self.assertEqual([MachoDemangler.demangle_macho_symbol(name) for name in names], names)
 
         self.assertEqual(len(calls), 1)
+
+    def test_priming_answers_every_swift_name_in_one_process(self):
+        names = [f"_$s4test{index}Vyyf" for index in range(25)]
+        calls = []
+
+        def _run(argv, **kwargs):
+            calls.append(kwargs.get("input"))
+            fed = kwargs["input"].splitlines()
+            return _CompletedProcess("\n".join(f"test.demangled{index}()" for index, _ in enumerate(fed)))
+
+        with (
+            mock.patch.object(MachoDemangler.shutil, "which", return_value="/usr/bin/swift"),
+            mock.patch.object(MachoDemangler.subprocess, "run", _run),
+        ):
+            MachoDemangler.primeSwiftSymbols(names)
+            # the batch already answered these, so resolving them must spawn nothing further
+            resolved = [MachoDemangler.demangle_macho_symbol(name) for name in names]
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls[0].splitlines()), 25)
+        self.assertTrue(all(name.startswith("test.demangled") for name in resolved))
+
+    def test_a_reply_with_the_wrong_line_count_is_discarded(self):
+        names = ["_$s4testAVyyf", "_$s4testBVyyf", "_$s4testCVyyf"]
+        with (
+            mock.patch.object(MachoDemangler.shutil, "which", return_value="/usr/bin/swift"),
+            mock.patch.object(MachoDemangler.subprocess, "run", return_value=_CompletedProcess("only.one.answer()")),
+        ):
+            MachoDemangler.primeSwiftSymbols(names)
+
+        # answers are positional; a short reply would label symbols with each other's names
+        self.assertEqual(MachoDemangler._SWIFT_CACHE, {})
+
+    def test_a_nonzero_exit_leaves_the_names_alone(self):
+        names = ["_$s4testAVyyf"]
+        with (
+            mock.patch.object(MachoDemangler.shutil, "which", return_value="/usr/bin/swift"),
+            mock.patch.object(
+                MachoDemangler.subprocess, "run", return_value=_CompletedProcess("nonsense", returncode=1)
+            ),
+        ):
+            MachoDemangler.primeSwiftSymbols(names)
+
+        self.assertEqual(MachoDemangler._SWIFT_CACHE, {})
+
+    def test_a_batch_that_cannot_run_is_not_retried_per_symbol(self):
+        names = [f"_$s4test{index}Vyyf" for index in range(25)]
+        calls = []
+
+        def _explode(argv, **kwargs):
+            calls.append(argv)
+            raise OSError("cannot execute")
+
+        with (
+            mock.patch.object(MachoDemangler.shutil, "which", return_value="/usr/bin/swift"),
+            mock.patch.object(MachoDemangler.subprocess, "run", _explode),
+        ):
+            MachoDemangler.primeSwiftSymbols(names)
+            self.assertEqual([MachoDemangler.demangle_macho_symbol(name) for name in names], names)
+
+        self.assertEqual(len(calls), 1)
+
+    def test_a_name_carrying_a_newline_is_kept_out_of_the_batch(self):
+        with (
+            mock.patch.object(MachoDemangler.shutil, "which", return_value="/usr/bin/swift"),
+            mock.patch.object(MachoDemangler.subprocess, "run", return_value=_CompletedProcess("one.answer()")) as run,
+        ):
+            MachoDemangler.primeSwiftSymbols(["_$s4testAVyyf", "_$s4test\nBVyyf"])
+
+        # the batch protocol is one name per line, so a name holding a newline would
+        # shift every answer after it
+        self.assertEqual(run.call_args.kwargs["input"], "_$s4testAVyyf")
+
+    def test_priming_is_skipped_once_the_demangler_is_known_unusable(self):
+        MachoDemangler._UNUSABLE_DEMANGLERS.add("swift")
+        with mock.patch.object(MachoDemangler.subprocess, "run") as run:
+            MachoDemangler.primeSwiftSymbols(["_$s4testAVyyf"])
+        run.assert_not_called()
+
+    def test_priming_without_a_swift_toolchain_runs_no_process(self):
+        with (
+            mock.patch.object(MachoDemangler.shutil, "which", return_value=None),
+            mock.patch.object(MachoDemangler.subprocess, "run") as run,
+        ):
+            MachoDemangler.primeSwiftSymbols(["_$s4testAVyyf"])
+        run.assert_not_called()
+        self.assertEqual(MachoDemangler._SWIFT_CACHE, {})
+
+    def test_priming_without_a_swift_name_runs_no_process(self):
+        with mock.patch.object(MachoDemangler.subprocess, "run") as run:
+            MachoDemangler.primeSwiftSymbols(["_plain", "__Z3uidv", ""])
+        run.assert_not_called()
 
     def test_the_executable_lookup_happens_once_per_command(self):
         lookups = []


### PR DESCRIPTION
Rebased continuation of #258 (@r0ny123) onto current master — single commit, cherry-picked cleanly. Batches Swift demangling through one toolchain subprocess per image (stdin protocol, positional reply) instead of one process spawn per symbol: 4.29s → 0.08s across the 12-sample corpus, recovered name map identical sample for sample. See #258 for details.