### PR TITLE
fix(labels): decode non-ASCII identifiers in Rust v0 symbols

### DIFF
--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -101,7 +101,7 @@ class Ident:
         self.out[i] = c
         return True
 
-    def punycode_decode(self) -> Optional[None]:
+    def punycode_decode(self) -> Optional[bool]:
         count = 0
         punycode_bytes = self.punycode
         try:
@@ -151,10 +151,9 @@ class Ident:
             n += i // lent
             i %= lent
 
-            try:
-                c = chr(n)
-            except (ValueError, OverflowError):
+            if not 0 <= n <= 0x10FFFF or 0xD800 <= n <= 0xDFFF:
                 return None
+            c = chr(n)
 
             if not self.insert(i, c):
                 return None
@@ -163,7 +162,7 @@ class Ident:
             try:
                 punycode_bytes[count]
             except IndexError:
-                return
+                return True
 
             delta = delta // damp
             damp = 2

--- a/tests/testRustSymbolProvider.py
+++ b/tests/testRustSymbolProvider.py
@@ -13,6 +13,7 @@ from smda.common.labelprovider.rust_demangler import demangle
 from smda.common.labelprovider.rust_demangler.rust import TypeNotFoundError
 from smda.common.labelprovider.rust_demangler.rust_legacy import LegacyDemangler, UnableToLegacyDemangle
 from smda.common.labelprovider.rust_demangler.rust_v0 import (
+    Ident,
     Parser,
     Printer,
     UnableTov0Demangle,
@@ -116,6 +117,28 @@ class TestRustDemangler(unittest.TestCase):
     def test_v0_unnamed_closure_has_no_stray_colon(self):
         # unnamed closures/shims must render as {closure#N}, not {closure:#N}
         self.assertEqual(demangle("_RNCNvC8rustc_v01fs_0"), "rustc_v0::f::{closure#1}")
+
+    def test_v0_non_ascii_identifier_is_decoded(self):
+        # the decode itself always worked; its success was reported as None,
+        # which is what every failure path returns, so the caller fell back
+        name = "_RNqCs4fqI2P2rA04_11utf8_identsu30____7hkackfecea1cbdathfdh9hlq6y"
+        self.assertEqual(demangle(name), "utf8_idents::საჭმელად_გემრიელი_სადილი")
+        self.assertNotIn("punycode{", demangle(name))
+
+    def test_v0_punycode_never_decodes_to_a_surrogate(self):
+        # chr() accepts 0xD800-0xDFFF where Rust's char::from_u32 refuses; a name carrying
+        # one cannot be encoded as UTF-8 by whoever consumes the report
+        name = "_RNvCu4_ib9b4main"
+
+        demangled = demangle(name)
+
+        self.assertNotIn("\ud800", demangled)
+        demangled.encode("utf-8")
+
+    def test_v0_undecodable_punycode_still_falls_back_to_the_raw_form(self):
+        ident = Ident("", "!not-punycode!")
+        ident.display()
+        self.assertEqual(ident.disp, "punycode{!not-punycode!}")
 
     def test_v0_empty_const_hex_nibbles_raise_demangler_error(self):
         # `Kh_` (u8 const with zero hex nibbles) previously escaped as a bare

--- a/tests/test_fuzz_rust_demangler.py
+++ b/tests/test_fuzz_rust_demangler.py
@@ -26,6 +26,9 @@ def test_rust_demangler_never_hangs(s):
     """
     try:
         result = demangle(s)
+        # a demangled name is handed to consumers as text; a lone surrogate would make it
+        # unencodable, so the demangler must never produce one
+        result.encode("utf-8")
     except (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDemangle):
         return
     except RecursionError:


### PR DESCRIPTION
Re-proposes #252, which was closed as already contained in master. It is not, and the check below shows it on current master. Rebased onto 802e627 and re-verified there.

## Why this is being reopened

The close reads: *"Already contained in master — `try_small_punycode_decode` returns `Optional[bool]` with surrogate rejection via `from_u32`, matching this PR exactly."*

`try_small_punycode_decode` and `punycode_decode` are two different methods in `rust_v0.py`. The first, at line 73, is the caller, and it has always returned `Optional[bool]` — it is not what this PR touches. The second, at line 104, is the one this PR fixes, and on current master it is still annotated `-> Optional[None]` and still returns bare `None` on its success path. `from_u32`, `0xD800` and `0x10FFFF` appear zero times in the file.

The result is observable without reading any of that:

```python
from smda.common.labelprovider.rust_demangler import demangle
demangle("_RNqCs4fqI2P2rA04_11utf8_identsu30____7hkackfecea1cbdathfdh9hlq6y")
# master:  'utf8_idents::punycode{__-7hkackfecea1cbdathfdh9hlq6y}'
# this PR: 'utf8_idents::საჭმელად_გემრიელი_სადილი'
```

Every non-ASCII Rust v0 identifier is currently reported with a placeholder in place of the identifier.

## Root cause

The decoder itself was always correct. Its success path fell out of the loop through a bare `return`, which yields `None` — the same value each of its seven failure paths returns — so `try_small_punycode_decode` could not tell a finished decode from a rejected one and always took the `punycode{...}` fallback. The `Optional[None]` annotation records the same defect: the function had no way to say it had succeeded.

That placeholder is worse than leaving the symbol mangled, because the reported name matches neither the mangled spelling nor the real one.

## Changed behavior

`punycode_decode` returns `True` on completion and is annotated `Optional[bool]`. A decode that genuinely fails still falls back to the placeholder, which has its own test.

Making the decoded text reachable also made a second defect reachable, unobservable while every decode was being discarded: the code point was built with `chr()`, which accepts the surrogate range where Rust's `char::from_u32` refuses it. `_RNvCu4_ib9b4main` decoded to a name holding U+D800, and a lone surrogate cannot be encoded as UTF-8 by whatever consumes the report. Non-scalar values are now rejected explicitly, and the fuzz target encodes every result so the class stays closed.

## Bug-class sweep

The root-cause signature is a success path returning the value the failure paths use as their sentinel. An AST scan of `src/smda/**` for functions mixing a bare `return` with value-returning paths found one other site, `basic_type()` at `rust_v0.py:197` — benign, because its bare `return` is on the failure path and all three callers test truthiness. No `Optional[None]` annotation remains in the tree.

## Validation

| command | result |
| --- | --- |
| `ruff check .` | clean |
| `ruff format --check .` | 246 files already formatted |
| `make typecheck` | exit 0 |
| `python -m pytest tests/ -q` | 1790 passed, 1 skipped, 2579 subtests |
| `diff-cover coverage.xml --compare-branch=upstream/master --fail-under=100` | 100%, 4/4 lines |

Cross-checked against the 18 mangled symbols in rustc-demangle 0.1.28's own test corpus: 9 now match exactly, 9 raise on the splat grammar this port does not implement and so keep the name the binary gave them, and none disagree.
