### PR TITLE
test(labels): read a real MSVC PE through the symbol provider

### DIFF
--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -510,5 +510,46 @@ class TestPeCxxSymbolFixture(unittest.TestCase):
         self.assertIn("double) const", measure[0])
 
 
+class TestPeMsvcSymbolFixture(unittest.TestCase):
+    """The MSVC arm of the dispatch, on a PE that really carries decorated names.
+
+    tests/msvc_cxx_pe_xored is a small C++ translation unit built for
+    x86_64-pc-windows-msvc by clang-cl 22.1.7, exporting free functions, a namespace, a
+    class returned by value and one extern "C" name.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        fixture = os.path.join(os.path.dirname(os.path.abspath(__file__)), "msvc_cxx_pe_xored")
+        raw = Path(fixture).read_bytes()
+        binary = bytes(byte ^ (index % 256) for index, byte in enumerate(raw))
+        binary_info = BinaryInfo(binary)
+        binary_info.file_path = ""
+        binary_info.base_addr = 0x180000000
+        provider = PeSymbolProvider(None)
+        provider.update(binary_info)
+        cls.symbols = provider.getFunctionSymbols()
+
+    def test_no_exported_name_is_left_decorated(self):
+        self.assertEqual([name for name in self.symbols.values() if name.startswith("?")], [])
+
+    def test_a_namespaced_signature_is_expanded(self):
+        names = set(self.symbols.values())
+
+        self.assertIn("double __cdecl geometry::dot(struct Matrix const &, struct Matrix const &)", names)
+        self.assertIn("int __cdecl geometry::classify(struct Matrix const *, char, bool)", names)
+
+    def test_a_class_returned_by_value_keeps_its_return_type(self):
+        names = set(self.symbols.values())
+
+        self.assertIn(
+            "struct Matrix __cdecl geometry::combine(struct Matrix const &, double, unsigned int)",
+            names,
+        )
+
+    def test_an_undecorated_name_is_left_alone(self):
+        self.assertIn("c_linkage", set(self.symbols.values()))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tests only. `tests/msvc_cxx_pe_xored` is in the tree but nothing reads it — this gives it a reader.

## Motivation

The fixture arrived with the MSVC demangler in #288. The provider-level tests that gave it a purpose did not come across when `PeSymbolProvider` was re-integrated over #287's Itanium demangling and #265's `lief_name`, so the fixture has been shipping unused since then. `git grep msvc_cxx_pe_xored` currently returns nothing outside the file itself.

That leaves the MSVC arm of `PeSymbolProvider` exercised only by synthetic symbols, while its Itanium arm has a real binary behind it. A demangler that is correct on a string is not the same claim as a provider that reaches it: dispatch, export parsing, and the name the report finally carries all sit between the two, and every other MSVC test in the tree starts from a string already known to be a symbol.

## What the fixture is

A small translation unit built for `x86_64-pc-windows-msvc` by clang-cl 22.1.7, exporting free functions, a namespace, a class returned by value and one `extern "C"` name — the shapes an ordinary build emits.

## What the four tests pin

Each one covers a distinct step rather than restating the demangler's own unit tests:

- **no exported name is left decorated** — fails if dispatch stops reaching the MSVC demangler at all, which is the failure mode a unit test on the demangler cannot see;
- **a namespaced signature is expanded** — qualified names and parameter lists, end to end;
- **a class returned by value keeps its return type** — the construct that distinguishes a return type read from one dropped;
- **an undecorated name is left alone** — the `extern "C"` export is not rewritten by a demangler that should decline it.

## Validation

| command | result |
| --- | --- |
| `python -m pytest tests/testPeSymbolProvider.py -q` | 30 passed (26 existing + 4 new) |
| `python -m pytest tests/ -q` | 1791 passed, 1 skipped, 2579 subtests |
| `ruff check .` / `ruff format --check .` | clean |

No source change, so there is no diff-coverage surface. The four tests pass against current master unmodified, which is what makes them a regression net rather than a change in behavior.
