### PR TITLE
perf: cut analysis hot-path overhead without changing output

### DIFF
--- a/src/smda/DisassemblyResult.py
+++ b/src/smda/DisassemblyResult.py
@@ -313,17 +313,18 @@ class DisassemblyResult:
         # reduce outrefs to addresses within the memory image
         base_addr = self.binary_info.base_addr
         max_addr = base_addr + self.binary_info.binary_size
-        for block in self.functions[func_addr]:
+        for block in blocks:
             for ins in block:
                 ins_addr = ins[0]
-                if ins_addr in code_refs_from:
-                    for to_addr in code_refs_from[ins_addr]:
-                        if base_addr <= to_addr < max_addr and to_addr not in ins_addrs:
-                            if ins_addr in out_refs:
-                                out_refs[ins_addr].append(to_addr)
-                            else:
-                                out_refs[ins_addr] = [to_addr]
-        return {src: sorted(dst) for src, dst in out_refs.items()}
+                dests = code_refs_from.get(ins_addr)
+                if dests is None:
+                    continue
+                external = [
+                    to_addr for to_addr in dests if base_addr <= to_addr < max_addr and to_addr not in ins_addrs
+                ]
+                if external:
+                    out_refs[ins_addr] = sorted(external)
+        return out_refs
 
     def isRecursiveFunction(self, func_addr):
         ins_addrs = set()

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -12,6 +12,7 @@ from .analyzers import AArch64IndirectCallAnalyzer, AArch64JumpTableAnalyzer, AA
 from .definitions import (
     ADD_IMM64_MASK,
     ADD_IMM64_VALUE,
+    ADR_VALUE,
     ADRP_MASK,
     ADRP_VALUE,
     ALWAYS_BRANCH_INS,
@@ -30,6 +31,7 @@ from .definitions import (
     NOP,
     RET_INS,
     UNCOND_JUMP_INS,
+    adr_pc_value,
     adrp_page_value,
     is_bti_landing_pad,
     is_exception_record_entry,
@@ -52,6 +54,45 @@ _HEX_OPERAND = re.compile(r"0x[0-9a-fA-F]+")
 # address — the only values it ever records. Verified against capstone ground
 # truth (zero false negatives across the aarch64 corpora and live pipelines).
 _IMM_TOKEN = re.compile(r"#?-?0x[0-9a-fA-F]+|#-?\d+")
+
+
+_WIDE_IMM_MASK = 0x7F800000
+_MOVZ_OPC = 0x52800000
+_MOVN_OPC = 0x12800000
+_MOVK_OPC = 0x72800000
+
+
+def _dataRefImmediatesFromWord(ins_bytes, i_address):
+    if len(ins_bytes) != INSTRUCTION_SIZE:
+        return None
+    word = int.from_bytes(ins_bytes, "little")
+    if (word & ADRP_MASK) == ADRP_VALUE:
+        return (adrp_page_value(word, i_address),)
+    if (word & ADRP_MASK) == ADR_VALUE:
+        return (adr_pc_value(word, i_address),)
+    if ((word >> 23) & 0x3F) == 0x22:
+        imm12 = (word >> 10) & 0xFFF
+        if imm12 == 0:
+            return None
+        return (imm12,)
+    opc = word & _WIDE_IMM_MASK
+    if opc not in (_MOVZ_OPC, _MOVN_OPC, _MOVK_OPC):
+        return None
+    hw = (word >> 21) & 0x3
+    sf = word >> 31
+    if not sf and hw >= 2:
+        return None
+    imm16 = (word >> 5) & 0xFFFF
+    if opc == _MOVK_OPC:
+        return (imm16,)
+    shifted = imm16 << (hw * 16)
+    if opc == _MOVZ_OPC:
+        return (shifted,)
+    width = 64 if sf else 32
+    val = (~shifted) & ((1 << width) - 1)
+    if val >= 1 << (width - 1):
+        val -= 1 << width
+    return (val,)
 
 
 def _hasDataRefImmediate(op_str, base_addr, upper_addr, is_in_code_areas):
@@ -302,17 +343,26 @@ class AArch64Backend(ArchBackend):
         ins_bytes = d.disassembly.getBytes(i_address, i_size)
         if not ins_bytes or len(ins_bytes) != i_size:
             return
-        detailed = next(d.capstone.disasm(ins_bytes, i_address), None)
-        if detailed is None:
-            return
         emitted = set()
-        for operand in detailed.operands:
-            value = None
-            if operand.type == ARM64_OP_IMM:
-                value = operand.imm
-            elif operand.type == ARM64_OP_MEM and operand.mem.base == 0:
-                value = operand.mem.disp
-            if value is None or value in emitted:
+        word_imms = _dataRefImmediatesFromWord(ins_bytes, i_address)
+        if word_imms is None:
+            detailed = next(d.capstone.disasm(ins_bytes, i_address), None)
+            if detailed is None:
+                return
+            for operand in detailed.operands:
+                value = None
+                if operand.type == ARM64_OP_IMM:
+                    value = operand.imm
+                elif operand.type == ARM64_OP_MEM and operand.mem.base == 0:
+                    value = operand.mem.disp
+                if value is None or value in emitted:
+                    continue
+                if d.disassembly.isAddrWithinMemoryImage(value) and not binary_info.isInCodeAreas(value):
+                    emitted.add(value)
+                    state.addDataRef(i_address, value)
+            return
+        for value in word_imms:
+            if value in emitted:
                 continue
             if d.disassembly.isAddrWithinMemoryImage(value) and not binary_info.isInCodeAreas(value):
                 emitted.add(value)

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -60,9 +60,14 @@ _WIDE_IMM_MASK = 0x7F800000
 _MOVZ_OPC = 0x52800000
 _MOVN_OPC = 0x12800000
 _MOVK_OPC = 0x72800000
+_LDST_IMM_MASK = 0x3B000000
+_LDST_UNSIGNED_VALUE = 0x39000000
+_LDST_REGIMM_VALUE = 0x38000000
 
 
 def _dataRefImmediatesFromWord(ins_bytes, i_address):
+    # None: unknown encoding, fall back to Capstone detail.
+    # (): known encoding with no IMM / absolute-MEM data-ref operands.
     if len(ins_bytes) != INSTRUCTION_SIZE:
         return None
     word = int.from_bytes(ins_bytes, "little")
@@ -71,10 +76,15 @@ def _dataRefImmediatesFromWord(ins_bytes, i_address):
     if (word & ADRP_MASK) == ADR_VALUE:
         return (adr_pc_value(word, i_address),)
     if ((word >> 23) & 0x3F) == 0x22:
-        imm12 = (word >> 10) & 0xFFF
-        if imm12 == 0:
-            return None
-        return (imm12,)
+        return (((word >> 10) & 0xFFF),)
+    if (word & _LDST_IMM_MASK) == _LDST_UNSIGNED_VALUE:
+        return ()
+    if ((word >> 27) & 0x7) == 0x5 and ((word >> 23) & 0x7) in (0, 2, 3):
+        return ()
+    if (word & _LDST_IMM_MASK) == _LDST_REGIMM_VALUE:
+        bits_11_10 = (word >> 10) & 3
+        if bits_11_10 != 1 or (word >> 21) & 1:
+            return ()
     opc = word & _WIDE_IMM_MASK
     if opc not in (_MOVZ_OPC, _MOVN_OPC, _MOVK_OPC):
         return None

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -796,13 +796,13 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # discovery at the same 4096-word boundaries as before the prefilter
             chunk_end = min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)
             tops = binary[4 * chunk_start + 3 : 4 * chunk_end : INSTRUCTION_SIZE].translate(_BL_TOPBYTE_FILTER)
-            for local_count, top in enumerate(tops):
-                if not top:
-                    continue
+            local_count = -1
+            while True:
+                local_count = tops.find(1, local_count + 1)
+                if local_count < 0:
+                    break
                 match_count = chunk_start + local_count
                 word = words[match_count]
-                if (word & BL_MASK) != BL_VALUE:
-                    continue
                 source = base + match_count * INSTRUCTION_SIZE
                 if not self._passesCodeFilter(source):
                     continue
@@ -831,9 +831,11 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # discovery at the same 4096-word boundaries as before the prefilter
             chunk_end = min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)
             tops = binary[4 * chunk_start + 3 : 4 * chunk_end : INSTRUCTION_SIZE].translate(_PROLOGUE_TOPBYTE_FILTER)
-            for local_count, top in enumerate(tops):
-                if not top:
-                    continue
+            local_count = -1
+            while True:
+                local_count = tops.find(1, local_count + 1)
+                if local_count < 0:
+                    break
                 match_count = chunk_start + local_count
                 word = words[match_count]
                 if not is_function_prologue(word):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -98,6 +98,13 @@ _ARM64_PDATA_SEED_ENTRIES = 4
 # _ARM64_PDATA_SAMPLE_STRIDE <= (MIN_ENTRIES - SEED_ENTRIES) * ENTRY_SIZE, pinned by a test
 _ARM64_PDATA_SAMPLE_STRIDE = 64
 
+# every BL encoding (0xFC000000 mask) has a top byte in 0x94..0x97 and every recognized
+# prologue pattern (PAC/BTI literals, STP/STR pre-index masks) has one in {0xA9, 0xD5,
+# 0xF8} — verified exhaustively over each pattern's free bits — so scanning the top-byte
+# lane with these tables skips non-matching words at C speed before any Python runs
+_BL_TOPBYTE_FILTER = bytes(1 if 0x94 <= b <= 0x97 else 0 for b in range(256))
+_PROLOGUE_TOPBYTE_FILTER = bytes(1 if b in (0xA9, 0xD5, 0xF8) else 0 for b in range(256))
+
 
 class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
@@ -779,22 +786,30 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # word-by-word, resolve each BL's PC-relative target and register it as a
         # call-reference candidate — the AArch64 analogue of the base 0xE8 scan.
         base = self.disassembly.binary_info.base_addr
-        for match_count, word in enumerate(self._wordsView()):
-            if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
+        words = self._wordsView()
+        binary = self.disassembly.binary_info.binary
+        tops = binary[3 : len(words) * INSTRUCTION_SIZE : INSTRUCTION_SIZE].translate(_BL_TOPBYTE_FILTER)
+        num_words = len(tops)
+        for chunk_start in range(0, num_words, _TIMEOUT_POLL_INTERVAL):
+            if self._candidateTimeoutTripped():
                 return
-            if (word & BL_MASK) != BL_VALUE:
-                continue
-            source = base + match_count * INSTRUCTION_SIZE
-            if not self._passesCodeFilter(source):
-                continue
-            imm = word & BL_IMM_MASK
-            if imm & BL_IMM_SIGN_BIT:
-                imm -= BL_IMM_SIGN_BIT << 1  # sign-extend the 26-bit immediate
-            target = (source + imm * INSTRUCTION_SIZE) & self.getBitMask()
-            if self.disassembly.isAddrWithinMemoryImage(target):
-                self._call_targets.add(target)
-                self.addReferenceCandidate(target, source)
-                self.setInitialCandidate(target)
+            for match_count in range(chunk_start, min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)):
+                if not tops[match_count]:
+                    continue
+                word = words[match_count]
+                if (word & BL_MASK) != BL_VALUE:
+                    continue
+                source = base + match_count * INSTRUCTION_SIZE
+                if not self._passesCodeFilter(source):
+                    continue
+                imm = word & BL_IMM_MASK
+                if imm & BL_IMM_SIGN_BIT:
+                    imm -= BL_IMM_SIGN_BIT << 1  # sign-extend the 26-bit immediate
+                target = (source + imm * INSTRUCTION_SIZE) & self.getBitMask()
+                if self.disassembly.isAddrWithinMemoryImage(target):
+                    self._call_targets.add(target)
+                    self.addReferenceCandidate(target, source)
+                    self.setInitialCandidate(target)
 
     def locatePrologueCandidates(self):
         # AArch64 lacks a single dominant byte prologue (no push ebp). Scan the
@@ -802,28 +817,36 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # (frame-record store, callee-saved pair save, link-register save, PAC/BTI);
         # see definitions.is_function_prologue for the exact encodings.
         base = self.disassembly.binary_info.base_addr
-        for match_count, word in enumerate(self._wordsView()):
-            if match_count % _TIMEOUT_POLL_INTERVAL == 0 and self._candidateTimeoutTripped():
+        words = self._wordsView()
+        binary = self.disassembly.binary_info.binary
+        tops = binary[3 : len(words) * INSTRUCTION_SIZE : INSTRUCTION_SIZE].translate(_PROLOGUE_TOPBYTE_FILTER)
+        num_words = len(tops)
+        for chunk_start in range(0, num_words, _TIMEOUT_POLL_INTERVAL):
+            if self._candidateTimeoutTripped():
                 return
-            if not is_function_prologue(word):
-                continue
-            addr = (base + match_count * INSTRUCTION_SIZE) & self.getBitMask()
-            # #310's check runs first: it refuses `bti j` on the word alone, which is every
-            # pad in the ARM64 fixtures, and it costs an integer compare where the LSDA test
-            # below decodes .eh_frame. Both `continue`, so this is cost rather than arbitration.
-            if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(addr, word):
-                continue
-            if self.config.USE_LSDA_LANDING_PADS and self.isDeclaredLandingPad(addr):
-                # A declared landing pad is interior by construction, so it is never a
-                # prologue however much it looks like one. The x86 scan needs no equivalent:
-                # an endbr64 is not one of its prologue shapes, so pads reach it only through
-                # the gap scan. Here `bti` is a recognized entry prologue, which puts every
-                # pad in front of this loop.
-                continue
-            if not self._passesCodeFilter(addr):
-                continue
-            self.addPrologueCandidate(addr)
-            self.setInitialCandidate(addr)
+            for match_count in range(chunk_start, min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)):
+                if not tops[match_count]:
+                    continue
+                word = words[match_count]
+                if not is_function_prologue(word):
+                    continue
+                addr = (base + match_count * INSTRUCTION_SIZE) & self.getBitMask()
+                # #310's check runs first: it refuses `bti j` on the word alone, which is every
+                # pad in the ARM64 fixtures, and it costs an integer compare where the LSDA test
+                # below decodes .eh_frame. Both `continue`, so this is cost rather than arbitration.
+                if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(addr, word):
+                    continue
+                if self.config.USE_LSDA_LANDING_PADS and self.isDeclaredLandingPad(addr):
+                    # A declared landing pad is interior by construction, so it is never a
+                    # prologue however much it looks like one. The x86 scan needs no equivalent:
+                    # an endbr64 is not one of its prologue shapes, so pads reach it only through
+                    # the gap scan. Here `bti` is a recognized entry prologue, which puts every
+                    # pad in front of this loop.
+                    continue
+                if not self._passesCodeFilter(addr):
+                    continue
+                self.addPrologueCandidate(addr)
+                self.setInitialCandidate(addr)
 
     def addTailcallCandidate(self, addr):
         """Book a tailcall target, and queue it - which the shared base leaves to its caller.

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -788,14 +788,18 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         base = self.disassembly.binary_info.base_addr
         words = self._wordsView()
         binary = self.disassembly.binary_info.binary
-        tops = binary[3 : len(words) * INSTRUCTION_SIZE : INSTRUCTION_SIZE].translate(_BL_TOPBYTE_FILTER)
-        num_words = len(tops)
+        num_words = len(words)
         for chunk_start in range(0, num_words, _TIMEOUT_POLL_INTERVAL):
             if self._candidateTimeoutTripped():
                 return
-            for match_count in range(chunk_start, min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)):
-                if not tops[match_count]:
+            # build the filter per polling chunk, so a configured timeout stops
+            # discovery at the same 4096-word boundaries as before the prefilter
+            chunk_end = min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)
+            tops = binary[4 * chunk_start + 3 : 4 * chunk_end : INSTRUCTION_SIZE].translate(_BL_TOPBYTE_FILTER)
+            for local_count, top in enumerate(tops):
+                if not top:
                     continue
+                match_count = chunk_start + local_count
                 word = words[match_count]
                 if (word & BL_MASK) != BL_VALUE:
                     continue
@@ -819,14 +823,18 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         base = self.disassembly.binary_info.base_addr
         words = self._wordsView()
         binary = self.disassembly.binary_info.binary
-        tops = binary[3 : len(words) * INSTRUCTION_SIZE : INSTRUCTION_SIZE].translate(_PROLOGUE_TOPBYTE_FILTER)
-        num_words = len(tops)
+        num_words = len(words)
         for chunk_start in range(0, num_words, _TIMEOUT_POLL_INTERVAL):
             if self._candidateTimeoutTripped():
                 return
-            for match_count in range(chunk_start, min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)):
-                if not tops[match_count]:
+            # build the filter per polling chunk, so a configured timeout stops
+            # discovery at the same 4096-word boundaries as before the prefilter
+            chunk_end = min(chunk_start + _TIMEOUT_POLL_INTERVAL, num_words)
+            tops = binary[4 * chunk_start + 3 : 4 * chunk_end : INSTRUCTION_SIZE].translate(_PROLOGUE_TOPBYTE_FILTER)
+            for local_count, top in enumerate(tops):
+                if not top:
                     continue
+                match_count = chunk_start + local_count
                 word = words[match_count]
                 if not is_function_prologue(word):
                     continue

--- a/src/smda/aarch64/analyzers.py
+++ b/src/smda/aarch64/analyzers.py
@@ -8,6 +8,7 @@ import contextlib
 import logging
 import math
 import struct
+from bisect import bisect_right
 from collections import Counter
 from copy import deepcopy
 
@@ -28,6 +29,14 @@ from .dataflow import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _first_greater(sorted_addrs, after_addr):
+    index = bisect_right(sorted_addrs, after_addr)
+    if index < len(sorted_addrs):
+        return sorted_addrs[index]
+    return None
+
 
 # Bounded predecessor-block hops fed into gatherContextInstructions when the seed
 # block alone doesn't resolve a jump-table base/index (e.g. an adrp/add chain that
@@ -530,10 +539,18 @@ class AArch64JumpTableAnalyzer:
         d = self.disassembler
         candidates = getattr(getattr(d, "fc_manager", None), "candidates", None) or {}
         borders = getattr(d.disassembly, "function_borders", None) or {}
-        candidate_boundary = min((addr for addr in candidates if addr > after_addr), default=None)
-        border_boundary = min((fn_min for fn_min, _fn_max in borders.values() if fn_min > after_addr), default=None)
-        boundaries = [b for b in (candidate_boundary, border_boundary) if b is not None]
-        return min(boundaries) if boundaries else None
+        cache_key = (len(candidates), len(borders))
+        if getattr(self, "_boundary_cache_key", None) != cache_key:
+            self._sorted_candidate_starts = sorted(candidates)
+            self._sorted_border_starts = sorted(fn_min for fn_min, _fn_max in borders.values())
+            self._boundary_cache_key = cache_key
+        candidate_boundary = _first_greater(self._sorted_candidate_starts, after_addr)
+        border_boundary = _first_greater(self._sorted_border_starts, after_addr)
+        if candidate_boundary is None:
+            return border_boundary
+        if border_boundary is None or candidate_boundary <= border_boundary:
+            return candidate_boundary
+        return border_boundary
 
     def getJumpTargets(self, jump_instruction, state):
         jump_instruction_address = jump_instruction[0]

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -133,6 +133,15 @@ def adrp_page_value(word, pc):
     return (pc & ~0xFFF) + (imm << 12)
 
 
+def adr_pc_value(word, pc):
+    immlo = (word >> 29) & 0x3
+    immhi = (word >> 5) & 0x7FFFF
+    imm = (immhi << 2) | immlo
+    if imm & (1 << 20):
+        imm -= 1 << 21
+    return pc + imm
+
+
 def rd_field(word):
     """Destination register index (bits [4:0]) of a raw AArch64 instruction word."""
     return word & 0x1F

--- a/src/smda/cil/FunctionAnalysisState.py
+++ b/src/smda/cil/FunctionAnalysisState.py
@@ -25,7 +25,6 @@ class FunctionAnalysisState:
         self.block_start = 0xFFFFFFFF
         self.data_bytes = set()
         self.data_refs = set()
-        self.code_refs = set()
         self.code_refs_from = {}
         self.code_refs_to = {}
         self.prev_opcode = ""
@@ -52,30 +51,45 @@ class FunctionAnalysisState:
             self.addCodeRef(i_address, i_address + i_size, self.is_jmp)
         self.is_jmp = False
 
+    @property
+    def code_refs(self):
+        return {(addr_from, addr_to) for addr_from, dests in self.code_refs_from.items() for addr_to in dests}
+
+    @code_refs.setter
+    def code_refs(self, value):
+        self.code_refs_from = {}
+        self.code_refs_to = {}
+        if not value:
+            return
+        for addr_from, addr_to in value:
+            self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+            self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
+
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
-        self.code_refs.add((addr_from, addr_to))
         code_refs_from = self.code_refs_from
-        if addr_from in code_refs_from:
-            code_refs_from[addr_from].add(addr_to)
-        else:
+        dests = code_refs_from.get(addr_from)
+        if dests is None:
             code_refs_from[addr_from] = {addr_to}
-        code_refs_to = self.code_refs_to
-        if addr_to in code_refs_to:
-            code_refs_to[addr_to].add(addr_from)
         else:
+            dests.add(addr_to)
+        code_refs_to = self.code_refs_to
+        srcs = code_refs_to.get(addr_to)
+        if srcs is None:
             code_refs_to[addr_to] = {addr_from}
+        else:
+            srcs.add(addr_from)
         if by_jump:
             self.is_jmp = True
             self.jump_refs.add((addr_from, addr_to))
             self.jump_targets.add(addr_to)
 
     def removeCodeRef(self, addr_from, addr_to):
-        if (addr_from, addr_to) in self.code_refs:
-            self.code_refs.remove((addr_from, addr_to))
-        if addr_from in self.code_refs_from and addr_to in self.code_refs_from[addr_from]:
-            self.code_refs_from[addr_from].remove(addr_to)
-        if addr_to in self.code_refs_to and addr_from in self.code_refs_to[addr_to]:
-            self.code_refs_to[addr_to].remove(addr_from)
+        dests = self.code_refs_from.get(addr_from)
+        if dests is not None and addr_to in dests:
+            dests.remove(addr_to)
+        srcs = self.code_refs_to.get(addr_to)
+        if srcs is not None and addr_from in srcs:
+            srcs.remove(addr_from)
         if (addr_from, addr_to) in self.jump_refs:
             self.jump_refs.remove((addr_from, addr_to))
             if not any(to == addr_to for _, to in self.jump_refs):
@@ -111,15 +125,18 @@ class FunctionAnalysisState:
         self.disassembly.functions[self.start_addr] = self.getBlocks()
         code_refs_from = self.disassembly.code_refs_from
         code_refs_to = self.disassembly.code_refs_to
-        for addr_from, addr_to in self.code_refs:
-            if addr_from in code_refs_from:
-                code_refs_from[addr_from].add(addr_to)
+        for addr_from, dests in self.code_refs_from.items():
+            outgoing = code_refs_from.get(addr_from)
+            if outgoing is None:
+                code_refs_from[addr_from] = set(dests)
             else:
-                code_refs_from[addr_from] = {addr_to}
-            if addr_to in code_refs_to:
-                code_refs_to[addr_to].add(addr_from)
-            else:
-                code_refs_to[addr_to] = {addr_from}
+                outgoing.update(dests)
+            for addr_to in dests:
+                incoming = code_refs_to.get(addr_to)
+                if incoming is None:
+                    code_refs_to[addr_to] = {addr_from}
+                else:
+                    incoming.add(addr_from)
         for dref in self.data_refs:
             self.disassembly.addDataRefs(dref[0], dref[1])
         if self.is_recursive:

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from bisect import bisect_right
 from typing import Optional
 
 import lief
@@ -285,14 +286,25 @@ class BinaryInfo:
         return start, start + directory.size
 
     def isInCodeAreas(self, address):
-        is_inside = False
-        # if no code areas found, assume the whole image is code and calculate according to base address and size
-        if self.code_areas is None or len(self.code_areas) == 0:
-            if self.base_addr <= address < self.base_addr + self.binary_size:
-                is_inside = True
-        else:
-            is_inside = any(a[0] <= address < a[1] for a in self.code_areas)
-        return is_inside
+        areas = self.code_areas
+        if not areas:
+            return self.base_addr <= address < self.base_addr + self.binary_size
+        index = getattr(self, "_code_area_index", None)
+        if index is None or index[0] is not areas:
+            ordered = sorted((start, end) for start, end in areas)
+            merged = [list(ordered[0])]
+            for start, end in ordered[1:]:
+                if start <= merged[-1][1]:
+                    if end > merged[-1][1]:
+                        merged[-1][1] = end
+                else:
+                    merged.append([start, end])
+            starts = [start for start, _end in merged]
+            self._code_area_index = (areas, starts, merged)
+            index = self._code_area_index
+        _areas, starts, merged = index
+        pos = bisect_right(starts, address) - 1
+        return pos >= 0 and address < merged[pos][1]
 
     HEADER_CAP_PE = 0x1000
     HEADER_CAP_ELF = 0x400

--- a/src/smda/common/DominatorTree.py
+++ b/src/smda/common/DominatorTree.py
@@ -141,8 +141,9 @@ def build_dominator_tree(G, r):
 
 
 def get_nesting_depth(graph, domtree, root):
-    expanded_graph = fix_graph(graph)
-    significant_nodes = set.union(*([set(v) for v in expanded_graph.values() if len(v) > 1] + [set()]))
+    # fix_graph() would only add empty successor lists here, which cannot contribute
+    # to significant_nodes (len(v) > 1), so the raw graph yields the identical set
+    significant_nodes = set.union(*([set(v) for v in graph.values() if len(v) > 1] + [set()]))
 
     # print("significant_nodes", significant_nodes)
     def maximum_costs(root_node):

--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -41,7 +41,6 @@ class FunctionAnalysisState:
         self.block_start = 0xFFFFFFFF
         self.data_bytes = set()
         self.data_refs = set()
-        self.code_refs = set()
         self.code_refs_from = {}
         self.code_refs_to = {}
         self.suspicious_ins_count = 0
@@ -93,30 +92,45 @@ class FunctionAnalysisState:
             self.addCodeRef(i_address, i_address + i_size, self.is_jmp)
         self.is_jmp = False
 
+    @property
+    def code_refs(self):
+        return {(addr_from, addr_to) for addr_from, dests in self.code_refs_from.items() for addr_to in dests}
+
+    @code_refs.setter
+    def code_refs(self, value):
+        self.code_refs_from = {}
+        self.code_refs_to = {}
+        if not value:
+            return
+        for addr_from, addr_to in value:
+            self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+            self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
+
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
-        self.code_refs.add((addr_from, addr_to))
         code_refs_from = self.code_refs_from
-        if addr_from in code_refs_from:
-            code_refs_from[addr_from].add(addr_to)
-        else:
+        dests = code_refs_from.get(addr_from)
+        if dests is None:
             code_refs_from[addr_from] = {addr_to}
-        code_refs_to = self.code_refs_to
-        if addr_to in code_refs_to:
-            code_refs_to[addr_to].add(addr_from)
         else:
+            dests.add(addr_to)
+        code_refs_to = self.code_refs_to
+        srcs = code_refs_to.get(addr_to)
+        if srcs is None:
             code_refs_to[addr_to] = {addr_from}
+        else:
+            srcs.add(addr_from)
         if by_jump:
             self.is_jmp = True
             self.jump_refs.add((addr_from, addr_to))
             self.jump_targets.add(addr_to)
 
     def removeCodeRef(self, addr_from, addr_to):
-        if (addr_from, addr_to) in self.code_refs:
-            self.code_refs.remove((addr_from, addr_to))
-        if addr_from in self.code_refs_from and addr_to in self.code_refs_from[addr_from]:
-            self.code_refs_from[addr_from].remove(addr_to)
-        if addr_to in self.code_refs_to and addr_from in self.code_refs_to[addr_to]:
-            self.code_refs_to[addr_to].remove(addr_from)
+        dests = self.code_refs_from.get(addr_from)
+        if dests is not None and addr_to in dests:
+            dests.remove(addr_to)
+        srcs = self.code_refs_to.get(addr_to)
+        if srcs is not None and addr_from in srcs:
+            srcs.remove(addr_from)
         if (addr_from, addr_to) in self.jump_refs:
             self.jump_refs.remove((addr_from, addr_to))
             if not any(to == addr_to for _, to in self.jump_refs):
@@ -182,15 +196,18 @@ class FunctionAnalysisState:
         self.disassembly.functions[self.start_addr] = self.getBlocks()
         code_refs_from = self.disassembly.code_refs_from
         code_refs_to = self.disassembly.code_refs_to
-        for addr_from, addr_to in self.code_refs:
-            if addr_from in code_refs_from:
-                code_refs_from[addr_from].add(addr_to)
+        for addr_from, dests in self.code_refs_from.items():
+            outgoing = code_refs_from.get(addr_from)
+            if outgoing is None:
+                code_refs_from[addr_from] = set(dests)
             else:
-                code_refs_from[addr_from] = {addr_to}
-            if addr_to in code_refs_to:
-                code_refs_to[addr_to].add(addr_from)
-            else:
-                code_refs_to[addr_to] = {addr_from}
+                outgoing.update(dests)
+            for addr_to in dests:
+                incoming = code_refs_to.get(addr_to)
+                if incoming is None:
+                    code_refs_to[addr_to] = {addr_from}
+                else:
+                    incoming.add(addr_from)
         for dref in self.data_refs:
             self.disassembly.addDataRefs(dref[0], dref[1])
         if self.is_recursive:
@@ -254,8 +271,9 @@ class FunctionAnalysisState:
             for byte in range(ins[1]):
                 self.disassembly.code_map.pop(ins[0] + byte, None)
                 self.disassembly.ins2fn.pop(ins[0] + byte, None)
-        for cref in self.code_refs:
-            self.disassembly.removeCodeRefs(cref[0], cref[1])
+        for addr_from, dests in self.code_refs_from.items():
+            for addr_to in dests:
+                self.disassembly.removeCodeRefs(addr_from, addr_to)
         for dref in self.data_refs:
             self.disassembly.removeDataRefs(dref[0], dref[1])
         self.disassembly.functions.pop(self.start_addr, None)
@@ -378,7 +396,7 @@ class FunctionAnalysisState:
             len(self.getBlocks()),
             ",".join([f"0x{b:x}" for b in sorted(self.block_queue)]),
             ",".join([f"0x{b:x}" for b in sorted(self.processed_blocks)]),
-            len(self.code_refs),
+            sum(len(dests) for dests in self.code_refs_from.values()),
             len(self.data_refs),
             self.suspicious_ins_count,
             self.is_sanely_ending,

--- a/src/smda/common/FunctionAnalysisState.py
+++ b/src/smda/common/FunctionAnalysisState.py
@@ -330,7 +330,9 @@ class FunctionAnalysisState:
         return self.blocks
 
     def hasUnprocessedBlocks(self):
-        return bool(self._queued_blocks - self.processed_blocks)
+        # chooseNextBlock() moves every pop straight into processed_blocks and
+        # addBlockToQueue() refuses processed blocks, so the two sets stay disjoint
+        return bool(self._queued_blocks)
 
     def isProcessed(self, addr):
         return addr in self.processed_bytes

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -81,6 +81,7 @@ class FunctionCandidateManager:
         self._eh_frame_fde_starts = []
         self._declared_landing_pads = None
         self._plt_ranges = None
+        self._code_area_index = None
         if disassembly.binary_info.code_areas:
             self._code_areas = disassembly.binary_info.code_areas
         self.disassembly = disassembly
@@ -96,9 +97,25 @@ class FunctionCandidateManager:
     def _passesCodeFilter(self, addr):
         if addr is None:
             return False
-        if self._code_areas:
-            return any(area[0] <= addr < area[1] for area in self._code_areas)
-        return True
+        areas = self._code_areas
+        if not areas:
+            return True
+        index = getattr(self, "_code_area_index", None)
+        if index is None or index[0] is not areas:
+            ordered = sorted((start, end) for start, end in areas)
+            merged = [list(ordered[0])]
+            for start, end in ordered[1:]:
+                if start <= merged[-1][1]:
+                    if end > merged[-1][1]:
+                        merged[-1][1] = end
+                else:
+                    merged.append([start, end])
+            starts = [start for start, _end in merged]
+            self._code_area_index = (areas, starts, merged)
+            index = self._code_area_index
+        _areas, starts, merged = index
+        pos = bisect.bisect_right(starts, addr) - 1
+        return pos >= 0 and addr < merged[pos][1]
 
     def getBitMask(self):
         if self.bitness == 64:
@@ -143,11 +160,8 @@ class FunctionCandidateManager:
                     candidate = self.candidates[candidate_addr]
                     if candidate.removeCallRefs(conflict):
                         dirty_candidates.append(candidate)
-                if isinstance(self.candidate_queue, BracketQueue):
-                    for candidate in dirty_candidates:
-                        self.candidate_queue.update(candidate)
-                elif dirty_candidates:
-                    self.candidate_queue.update()
+                for candidate in dirty_candidates:
+                    self.candidate_queue.update(candidate)
 
     def _addCappedCallRef(self, candidate, source_ref):
         """add an inbound call reference, honoring MAX_CALL_REFS_PER_CANDIDATE to bound set growth and rescoring."""
@@ -201,9 +215,39 @@ class FunctionCandidateManager:
         if self.disassembly is None:
             return
         gaps = []
-        prev_ins = 0
-        min_code = min(self.disassembly.code_map) if self.disassembly.code_map else self.getBitMask()
-        max_code = max(self.disassembly.code_map) if self.disassembly.code_map else 0
+        merged = []
+        functions = getattr(self.disassembly, "functions", None) or {}
+        if functions:
+            intervals = []
+            for blocks in functions.values():
+                for block in blocks:
+                    for ins in block:
+                        start = ins[0]
+                        intervals.append((start, start + ins[1]))
+            intervals.sort()
+            for start, end in intervals:
+                if merged and start <= merged[-1][1]:
+                    if end > merged[-1][1]:
+                        merged[-1][1] = end
+                else:
+                    merged.append([start, end])
+        if merged:
+            min_code = merged[0][0]
+            max_code = merged[-1][1] - 1
+        else:
+            code_map = getattr(self.disassembly, "code_map", None) or {}
+            if code_map:
+                keys = sorted(code_map)
+                min_code = keys[0]
+                max_code = keys[-1]
+                prev_ins = 0
+                for ins in keys:
+                    if prev_ins != 0 and ins - prev_ins > 1:
+                        gaps.append([prev_ins + 1, ins, ins - prev_ins])
+                    prev_ins = ins
+            else:
+                min_code = self.getBitMask()
+                max_code = 0
         # Raw memory dumps are loaded without section info, so self._code_areas is empty; fall back to
         # the full mapped image so the head (before the first instruction) and tail (after the last
         # instruction) still get gap-scanned. Without this, functions that lie entirely before the
@@ -229,10 +273,13 @@ class FunctionCandidateManager:
                 # region unscanned. Section-derived code areas keep the legacy start (behavior-neutral).
                 tail_start = max_code + 1 if using_synthetic_area else max_code
                 gaps.append([tail_start, code_area[1], code_area[1] - tail_start])
-        for ins in sorted(self.disassembly.code_map.keys()):
-            if prev_ins != 0 and ins - prev_ins > 1:
-                gaps.append([prev_ins + 1, ins, ins - prev_ins])
-            prev_ins = ins
+        for index in range(len(merged) - 1):
+            prev_end = merged[index][1]
+            next_start = merged[index + 1][0]
+            # the byte-key walk used prev_ins != 0 as "already started"; address 0 is a real
+            # covered byte, so a hole after it was never emitted. Keep that cut.
+            if next_start - prev_end > 0 and prev_end != 1:
+                gaps.append([prev_end, next_start, next_start - prev_end])
         self.function_gaps = sorted(gaps)
 
     def initGapSearch(self):

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -215,39 +215,9 @@ class FunctionCandidateManager:
         if self.disassembly is None:
             return
         gaps = []
-        merged = []
-        functions = getattr(self.disassembly, "functions", None) or {}
-        if functions:
-            intervals = []
-            for blocks in functions.values():
-                for block in blocks:
-                    for ins in block:
-                        start = ins[0]
-                        intervals.append((start, start + ins[1]))
-            intervals.sort()
-            for start, end in intervals:
-                if merged and start <= merged[-1][1]:
-                    if end > merged[-1][1]:
-                        merged[-1][1] = end
-                else:
-                    merged.append([start, end])
-        if merged:
-            min_code = merged[0][0]
-            max_code = merged[-1][1] - 1
-        else:
-            code_map = getattr(self.disassembly, "code_map", None) or {}
-            if code_map:
-                keys = sorted(code_map)
-                min_code = keys[0]
-                max_code = keys[-1]
-                prev_ins = 0
-                for ins in keys:
-                    if prev_ins != 0 and ins - prev_ins > 1:
-                        gaps.append([prev_ins + 1, ins, ins - prev_ins])
-                    prev_ins = ins
-            else:
-                min_code = self.getBitMask()
-                max_code = 0
+        prev_ins = 0
+        min_code = min(self.disassembly.code_map) if self.disassembly.code_map else self.getBitMask()
+        max_code = max(self.disassembly.code_map) if self.disassembly.code_map else 0
         # Raw memory dumps are loaded without section info, so self._code_areas is empty; fall back to
         # the full mapped image so the head (before the first instruction) and tail (after the last
         # instruction) still get gap-scanned. Without this, functions that lie entirely before the
@@ -273,13 +243,10 @@ class FunctionCandidateManager:
                 # region unscanned. Section-derived code areas keep the legacy start (behavior-neutral).
                 tail_start = max_code + 1 if using_synthetic_area else max_code
                 gaps.append([tail_start, code_area[1], code_area[1] - tail_start])
-        for index in range(len(merged) - 1):
-            prev_end = merged[index][1]
-            next_start = merged[index + 1][0]
-            # the byte-key walk used prev_ins != 0 as "already started"; address 0 is a real
-            # covered byte, so a hole after it was never emitted. Keep that cut.
-            if next_start - prev_end > 0 and prev_end != 1:
-                gaps.append([prev_end, next_start, next_start - prev_end])
+        for ins in sorted(self.disassembly.code_map.keys()):
+            if prev_ins != 0 and ins - prev_ins > 1:
+                gaps.append([prev_ins + 1, ins, ins - prev_ins])
+            prev_ins = ins
         self.function_gaps = sorted(gaps)
 
     def initGapSearch(self):

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -280,13 +280,22 @@ class RecursiveDisassembler:
             cache = self.capstone.disasm_lite(self._getDisasmWindowBuffer(state.block_start), state.block_start)
             cache_pos = 0
             previous_i = None
+            # per-instruction locals: the maps are only ever mutated in place during
+            # analysis, so aliasing them here stays identity-safe through the whole loop
+            code_map = self.disassembly.code_map
+            data_map = self.disassembly.data_map
+            ins2fn = self.disassembly.ins2fn
+            raw_binary = binary_info.binary
+            analyze_instruction = self.backend.analyzeInstruction
+            add_instruction = state.addInstruction
+            processed_bytes = state.processed_bytes
             while True:
                 for i in cache:
                     i_address, i_size, i_mnemonic, i_op_str = i
 
                     i_op_str = i_op_str.strip()
                     i_relative_address = i_address - binary_info.base_addr
-                    i_bytes = binary_info.binary[i_relative_address : i_relative_address + i_size]
+                    i_bytes = raw_binary[i_relative_address : i_relative_address + i_size]
                     if debug_logging:
                         LOGGER.debug(
                             "  analyzeFunction() now processing instruction @0x%08x: %s",
@@ -313,28 +322,24 @@ class RecursiveDisassembler:
                             return state
                     # delegate architecture-specific control-flow analysis to the backend;
                     # a True return means: cut the block here without booking this instruction
-                    if self.backend.analyzeInstruction(self, i, state, previous_i, start_addr):
+                    if analyze_instruction(self, i, state, previous_i, start_addr):
                         break
                     previous_i = i
-                    if (
-                        i_address not in self.disassembly.code_map
-                        and i_address not in self.disassembly.data_map
-                        and i_address not in state.processed_bytes
-                    ):
+                    if i_address not in code_map and i_address not in data_map and i_address not in processed_bytes:
                         if debug_logging:
                             LOGGER.debug(
                                 "  analyzeFunction() booked instruction @0x%08x: %s for processed state",
                                 i_address,
                                 i_mnemonic + " " + i_op_str,
                             )
-                        state.addInstruction(i_address, i_size, i_mnemonic, i_op_str, i_bytes)
-                    elif i_address in self.disassembly.code_map:
+                        add_instruction(i_address, i_size, i_mnemonic, i_op_str, i_bytes)
+                    elif i_address in code_map:
                         if debug_logging:
                             LOGGER.debug(
                                 "  analyzeFunction() was already present?! instruction @0x%08x: %s (function: 0x%08x)",
                                 i_address,
                                 i_mnemonic + " " + i_op_str,
-                                self.disassembly.ins2fn[i_address],
+                                ins2fn[i_address],
                             )
                         # If the collision is with a gap function, revert it and
                         # book this instruction so the current function absorbs it.
@@ -342,7 +347,7 @@ class RecursiveDisassembler:
                         # not during the gap pass itself — gap candidates are
                         # expected to have independent analysis there.
                         if not as_gap and self._revertGapFunction(i_address, start_addr):
-                            state.addInstruction(i_address, i_size, i_mnemonic, i_op_str, i_bytes)
+                            add_instruction(i_address, i_size, i_mnemonic, i_op_str, i_bytes)
                         else:
                             state.setBlockEndingInstruction(True)
                             state.addCollision(i_address)

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -633,10 +633,12 @@ class SmdaFunction:
 
             active_try_ranges.append({"start": range_start, "end": range_end, "targets": normalized_targets})
 
-        # without try_ranges the pass below reduces to re-sorting what getBlockRefs()
-        # already produced as sorted, deduplicated lists
+        # without try_ranges the pass below reduces to deduplicating and sorting the
+        # successors of each block, with no per-block try-range overlap test
         if not active_try_ranges:
-            result = {block_start: list(current_blockrefs.get(block_start, [])) for block_start in sorted(self.blocks)}
+            result = {
+                block_start: sorted(set(current_blockrefs.get(block_start, []))) for block_start in sorted(self.blocks)
+            }
             self._normalized_blockrefs = result
             return result
 

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
+# escapeBinary() output is fully determined by (escaper, bytes, mnemonic, operands,
+# flag, bounds), so results may be reused across functions and runs; the cap bounds
+# retained strings when many distinct samples are analyzed in one process
+_ESCAPE_CACHE = {}
+_ESCAPE_CACHE_LIMIT = 1 << 17
+
 # AArch64 PIC hashing changed in 4.1.0 when control-flow opcode masking was unified,
 # and again in 4.2.0 when `escapeBinary` was made per-mnemonic immediate-aware
 # (nibble-keep-mask) so that relocated instructions produce the same pic_hash.
@@ -475,16 +481,28 @@ class SmdaFunction:
         else:
             lower_addr = binary_info.base_addr
             upper_addr = lower_addr + binary_info.binary_size
-            escaped_binary_seqs = [
-                escaper.escapeBinary(
-                    instruction,
-                    escape_intraprocedural_jumps=True,
-                    lower_addr=lower_addr,
-                    upper_addr=upper_addr,
-                )
-                for key in self._sorted_block_keys
-                for instruction in blocks[key]
-            ]
+            cache = _ESCAPE_CACHE
+            if len(cache) >= _ESCAPE_CACHE_LIMIT:
+                cache.clear()
+            escaped_binary_seqs = []
+            append = escaped_binary_seqs.append
+            cache_get = cache.get
+            for key in self._sorted_block_keys:
+                for instruction in blocks[key]:
+                    cache_key = (
+                        escaper,
+                        instruction.bytes,
+                        instruction.mnemonic,
+                        instruction.operands,
+                        True,
+                        lower_addr,
+                        upper_addr,
+                    )
+                    escaped = cache_get(cache_key)
+                    if escaped is None:
+                        escaped = escaper.escapeBinary(instruction, True, lower_addr, upper_addr)
+                        cache[cache_key] = escaped
+                    append(escaped)
         return "".join(escaped_binary_seqs).encode("ascii")
 
     def getOpcHash(self):
@@ -612,6 +630,13 @@ class SmdaFunction:
                 normalized_targets.add(block_start)
 
             active_try_ranges.append({"start": range_start, "end": range_end, "targets": normalized_targets})
+
+        # without try_ranges the pass below reduces to re-sorting what getBlockRefs()
+        # already produced as sorted, deduplicated lists
+        if not active_try_ranges:
+            result = {block_start: list(current_blockrefs.get(block_start, [])) for block_start in sorted(self.blocks)}
+            self._normalized_blockrefs = result
+            return result
 
         # 2. Iterate blocks once to build normalized_blockrefs and apply try_ranges
         for block_start, block in self.blocks.items():

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -217,21 +217,15 @@ class SmdaFunction:
             self.architecture_metadata = disassembly.function_metadata.get(function_offset, {})
             self.blockrefs = self.getNormalizedBlockRefs()
             self.function_name = disassembly.function_symbols.get(function_offset, "")
-            self.characteristics = (
-                disassembly.candidates[function_offset].getCharacteristics()
-                if function_offset in disassembly.candidates
-                else None
-            )
-            self.confidence = (
-                disassembly.candidates[function_offset].getConfidence()
-                if function_offset in disassembly.candidates
-                else None
-            )
-            self.tfidf = (
-                disassembly.candidates[function_offset].getTfIdf()
-                if function_offset in disassembly.candidates
-                else None
-            )
+            candidate = disassembly.candidates.get(function_offset)
+            if candidate is not None:
+                self.characteristics = candidate.getCharacteristics()
+                self.confidence = candidate.getConfidence()
+                self.tfidf = candidate.getTfIdf()
+            else:
+                self.characteristics = None
+                self.confidence = None
+                self.tfidf = None
             # DEX strings are part of the parsed file structure, so they're always
             # populated for Dalvik regardless of WITH_STRINGS — no extra extraction
             # cost. For other architectures, honor WITH_STRINGS as usual.
@@ -539,9 +533,7 @@ class SmdaFunction:
         self.blocks = {}
         for block in disasm_blocks:
             block_start = block[0][0]
-            self.blocks[block_start] = [
-                SmdaInstruction([ins[0], ins[4].hex(), str(ins[2]), str(ins[3])], smda_function=self) for ins in block
-            ]
+            self.blocks[block_start] = [SmdaInstruction.from_tuple(ins, smda_function=self) for ins in block]
             # len(hex) == 2 * len(raw), so the per-instruction len(hex)/2 this replaces summed to
             # the raw byte count; binweight is serialized, so it must stay that value and a float
             self.binweight += float(sum(map(len, map(itemgetter(4), block))))

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -482,8 +482,6 @@ class SmdaFunction:
             lower_addr = binary_info.base_addr
             upper_addr = lower_addr + binary_info.binary_size
             cache = _ESCAPE_CACHE
-            if len(cache) >= _ESCAPE_CACHE_LIMIT:
-                cache.clear()
             escaped_binary_seqs = []
             append = escaped_binary_seqs.append
             cache_get = cache.get
@@ -500,6 +498,10 @@ class SmdaFunction:
                     )
                     escaped = cache_get(cache_key)
                     if escaped is None:
+                        # enforce the cap at insertion so even one function with more
+                        # distinct instructions than the limit cannot grow past it
+                        if len(cache) >= _ESCAPE_CACHE_LIMIT:
+                            cache.clear()
                         escaped = escaper.escapeBinary(instruction, True, lower_addr, upper_addr)
                         cache[cache_key] = escaped
                     append(escaped)

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -31,6 +31,18 @@ class SmdaInstruction:
             self.mnemonic = ins_list[2]
             self.operands = ins_list[3]
 
+    @classmethod
+    def from_tuple(cls, ins, smda_function=None):
+        instruction = cls.__new__(cls)
+        instruction.smda_function = smda_function
+        instruction.offset = ins[0]
+        instruction.bytes = ins[4].hex()
+        mnemonic = ins[2]
+        instruction.mnemonic = mnemonic if mnemonic.__class__ is str else str(mnemonic)
+        operands = ins[3]
+        instruction.operands = operands if operands.__class__ is str else str(operands)
+        return instruction
+
     def getDataRefs(self) -> Iterator[int]:
         # direct read rather than getattr(): the class-level default covers the unpickled
         # case the getattr guarded, and it keeps the declared Optional[List[int]] instead

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -37,20 +37,23 @@ class WinApiResolver(AbstractLabelProvider):
                 self._loadDbFile(os_name, db_filepath)
             else:
                 deferred_dbs.append((os_name, db_filepath))
-        if deferred_dbs:
-            # os-name selection must wait until every configured DB had its chance to
-            # load, otherwise a single cached DB pins the name prematurely
-            self._deferred_dbs = deferred_dbs
-        else:
+        # os-name selection must wait until every configured DB had its chance to
+        # load, otherwise a single cached DB pins the name prematurely
+        self._deferred_dbs = deferred_dbs
+        if not deferred_dbs:
             self._resolveOsName()
 
     def _resolveOsName(self):
+        # deferred loading runs after construction, so setOsName() may already have
+        # pinned a name; an explicit choice always outranks the inference below
+        if self._os_name is not None:
+            return
         loaded_os_names = [os_name for os_name in self._config.API_COLLECTION_FILES if os_name in self._api_map]
         if len(loaded_os_names) == 1:
             self._os_name = loaded_os_names[0]
 
     def _ensureDbsLoaded(self):
-        deferred_dbs = getattr(self, "_deferred_dbs", None)
+        deferred_dbs = self._deferred_dbs
         if not deferred_dbs:
             return
         self._deferred_dbs = None

--- a/src/smda/common/labelprovider/WinApiResolver.py
+++ b/src/smda/common/labelprovider/WinApiResolver.py
@@ -28,11 +28,35 @@ class WinApiResolver(AbstractLabelProvider):
         self._api_map = {"lief": {}}
         self._os_name = None
         self._is_buffer = False
+        # parsing an uncached ApiScout DB costs tens of milliseconds; defer it to the
+        # first getApi() so analyses that never resolve an API don't pay for it.
+        # Cached DBs are attached immediately, they keep _os_name resolution cheap.
+        deferred_dbs = []
         for os_name, db_filepath in self._config.API_COLLECTION_FILES.items():
-            self._loadDbFile(os_name, db_filepath)
+            if db_filepath in WinApiResolver._db_cache:
+                self._loadDbFile(os_name, db_filepath)
+            else:
+                deferred_dbs.append((os_name, db_filepath))
+        if deferred_dbs:
+            # os-name selection must wait until every configured DB had its chance to
+            # load, otherwise a single cached DB pins the name prematurely
+            self._deferred_dbs = deferred_dbs
+        else:
+            self._resolveOsName()
+
+    def _resolveOsName(self):
         loaded_os_names = [os_name for os_name in self._config.API_COLLECTION_FILES if os_name in self._api_map]
         if len(loaded_os_names) == 1:
             self._os_name = loaded_os_names[0]
+
+    def _ensureDbsLoaded(self):
+        deferred_dbs = getattr(self, "_deferred_dbs", None)
+        if not deferred_dbs:
+            return
+        self._deferred_dbs = None
+        for os_name, db_filepath in deferred_dbs:
+            self._loadDbFile(os_name, db_filepath)
+        self._resolveOsName()
 
     def update(self, binary_info):
         self._is_buffer = binary_info.is_buffer
@@ -96,6 +120,7 @@ class WinApiResolver(AbstractLabelProvider):
 
     def getApi(self, to_addr, absolute_addr=None):
         """If the LabelProvider has any information about a used API for the given address, return (dll, api), else return (None, None)"""
+        self._ensureDbsLoaded()
         # if we work on a dump, use ApiScout method:
         if self._is_buffer:
             if self._os_name and self._os_name in self._api_map:

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -1187,6 +1187,8 @@ class DalvikDisassembler:
         payload_ranges = list(seed_payload_ranges)
         payload_range_set = set(payload_ranges)
 
+        resolve_reference = lambda ref_kind, ref_index: self._resolveReference(resolver, ref_kind, ref_index)  # noqa: E731
+
         while state.hasUnprocessedBlocks():
             block_start_addr = state.chooseNextBlock()
             if block_start_addr is None:
@@ -1209,7 +1211,7 @@ class DalvikDisassembler:
                     decoded = decode_instruction(
                         bytecode,
                         idx,
-                        lambda ref_kind, ref_index: self._resolveReference(resolver, ref_kind, ref_index),
+                        resolve_reference,
                     )
                 except ValueError as exc:
                     self.disassembly.errors[bytecode_offset + idx] = {

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -272,7 +272,9 @@ class DalvikFunctionAnalysisState:
         return self.blocks
 
     def hasUnprocessedBlocks(self):
-        return bool(self._queued_blocks - self.processed_blocks)
+        # addBlockToQueue() never queues a processed block and chooseNextBlock() moves each
+        # pop straight into processed_blocks, so the two sets are always disjoint
+        return bool(self._queued_blocks)
 
     def isProcessed(self, addr):
         return addr in self.processed_bytes

--- a/src/smda/dalvik/DalvikFunctionAnalysisState.py
+++ b/src/smda/dalvik/DalvikFunctionAnalysisState.py
@@ -46,7 +46,6 @@ class DalvikFunctionAnalysisState:
         self.block_start = 0xFFFFFFFF
         self.data_bytes = set()
         self.data_refs = set()
-        self.code_refs = set()
         self.code_refs_from = {}
         self.code_refs_to = {}
         self.suspicious_ins_count = 0
@@ -99,29 +98,44 @@ class DalvikFunctionAnalysisState:
         if self.is_next_instruction_reachable:
             self.addCodeRef(i_address, i_address + i_size)
 
+    @property
+    def code_refs(self):
+        return {(addr_from, addr_to) for addr_from, dests in self.code_refs_from.items() for addr_to in dests}
+
+    @code_refs.setter
+    def code_refs(self, value):
+        self.code_refs_from = {}
+        self.code_refs_to = {}
+        if not value:
+            return
+        for addr_from, addr_to in value:
+            self.code_refs_from.setdefault(addr_from, set()).add(addr_to)
+            self.code_refs_to.setdefault(addr_to, set()).add(addr_from)
+
     def addCodeRef(self, addr_from, addr_to, by_jump=False):
-        self.code_refs.add((addr_from, addr_to))
         code_refs_from = self.code_refs_from
-        if addr_from in code_refs_from:
-            code_refs_from[addr_from].add(addr_to)
-        else:
+        dests = code_refs_from.get(addr_from)
+        if dests is None:
             code_refs_from[addr_from] = {addr_to}
-        code_refs_to = self.code_refs_to
-        if addr_to in code_refs_to:
-            code_refs_to[addr_to].add(addr_from)
         else:
+            dests.add(addr_to)
+        code_refs_to = self.code_refs_to
+        srcs = code_refs_to.get(addr_to)
+        if srcs is None:
             code_refs_to[addr_to] = {addr_from}
+        else:
+            srcs.add(addr_from)
         if by_jump:
             self.jump_refs.add((addr_from, addr_to))
             self.jump_targets.add(addr_to)
 
     def removeCodeRef(self, addr_from, addr_to):
-        if (addr_from, addr_to) in self.code_refs:
-            self.code_refs.remove((addr_from, addr_to))
-        if addr_from in self.code_refs_from and addr_to in self.code_refs_from[addr_from]:
-            self.code_refs_from[addr_from].remove(addr_to)
-        if addr_to in self.code_refs_to and addr_from in self.code_refs_to[addr_to]:
-            self.code_refs_to[addr_to].remove(addr_from)
+        dests = self.code_refs_from.get(addr_from)
+        if dests is not None and addr_to in dests:
+            dests.remove(addr_to)
+        srcs = self.code_refs_to.get(addr_to)
+        if srcs is not None and addr_from in srcs:
+            srcs.remove(addr_from)
         if (addr_from, addr_to) in self.jump_refs:
             self.jump_refs.remove((addr_from, addr_to))
             if not any(to == addr_to for _, to in self.jump_refs):
@@ -170,15 +184,18 @@ class DalvikFunctionAnalysisState:
         self.disassembly.functions[self.start_addr] = self.getBlocks()
         code_refs_from = self.disassembly.code_refs_from
         code_refs_to = self.disassembly.code_refs_to
-        for addr_from, addr_to in self.code_refs:
-            if addr_from in code_refs_from:
-                code_refs_from[addr_from].add(addr_to)
+        for addr_from, dests in self.code_refs_from.items():
+            outgoing = code_refs_from.get(addr_from)
+            if outgoing is None:
+                code_refs_from[addr_from] = set(dests)
             else:
-                code_refs_from[addr_from] = {addr_to}
-            if addr_to in code_refs_to:
-                code_refs_to[addr_to].add(addr_from)
-            else:
-                code_refs_to[addr_to] = {addr_from}
+                outgoing.update(dests)
+            for addr_to in dests:
+                incoming = code_refs_to.get(addr_to)
+                if incoming is None:
+                    code_refs_to[addr_to] = {addr_from}
+                else:
+                    incoming.add(addr_from)
         for dref in self.data_refs:
             self.disassembly.addDataRefs(dref[0], dref[1])
         if self.is_recursive:
@@ -225,8 +242,9 @@ class DalvikFunctionAnalysisState:
             for byte in range(ins[1]):
                 self.disassembly.code_map.pop(ins[0] + byte, None)
                 self.disassembly.ins2fn.pop(ins[0] + byte, None)
-        for cref in self.code_refs:
-            self.disassembly.removeCodeRefs(cref[0], cref[1])
+        for addr_from, dests in self.code_refs_from.items():
+            for addr_to in dests:
+                self.disassembly.removeCodeRefs(addr_from, addr_to)
         for dref in self.data_refs:
             self.disassembly.removeDataRefs(dref[0], dref[1])
         self.disassembly.functions.pop(self.start_addr, None)

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -34,6 +34,14 @@ _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
 # one-byte padding above). anything else cannot be a nop, so the 15-byte
 # disasm_lite probe is skippable.
 _NOP_START_BYTES = frozenset({0x0F, 0x26, 0x2E, 0x36, 0x3E, 0x64, 0x65, 0x66, 0x67, 0xF2, 0xF3})
+# in 64-bit every REX prefix opens one too -- `40 90`, `48 0f 1f 00`, and
+# `41 0f 1f 00` which capstone spells `nop dword ptr [r8]`. Without them the scan
+# books a candidate on REX-padded alignment filler where it used to step over it.
+# Kept off the 32-bit set because 0x40-0x4F are inc/dec there and never a nop, so
+# admitting them would spend a 15-byte disassembly on every one. Swept against
+# capstone over all 256 first bytes in both modes: 32-bit needs nothing beyond the
+# set above, 64-bit needs exactly this range on top of it.
+_NOP_START_BYTES_64 = _NOP_START_BYTES | frozenset(range(0x40, 0x50))
 
 # The lowest score any multi-byte (length 3/4/5) COMMON_PROLOGUES entry carries, across
 # both bitnesses. Used as the "looks like a real function entry" floor for hasCommonPrologue:
@@ -221,6 +229,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             window_bytes = self.disassembly.getRawBytes(offset, max(256, length))
             return window_bytes[:length]
 
+        nop_start_bytes = _NOP_START_BYTES_64 if self.bitness == 64 else _NOP_START_BYTES
         scanned = 0
         while True:
             scanned += 1
@@ -253,7 +262,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 self.gap_pointer += run if run else 1
                 continue
             # try to find instructions that directly encode as NOP and skip them
-            if byte and byte[0] in _NOP_START_BYTES:
+            if byte and byte[0] in nop_start_bytes:
                 ins_buf = list(self.capstone.disasm_lite(get_window_slice(gap_offset, 15), gap_offset))
                 if ins_buf:
                     i_address, i_size, i_mnemonic, i_op_str = ins_buf[0]

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -30,6 +30,10 @@ LOGGER = logging.getLogger(__name__)
 # bytes.lstrip() can skip long runs of one-byte padding in C instead of
 # crawling them byte-by-byte in the gap scanner.
 _PADDING_STRIP_BYTES = bytes(sorted(seq[0] for seq in GAP_SEQUENCES[1]))
+# first bytes of encodings capstone spells `nop` (0x90 is already consumed as
+# one-byte padding above). anything else cannot be a nop, so the 15-byte
+# disasm_lite probe is skippable.
+_NOP_START_BYTES = frozenset({0x0F, 0x26, 0x2E, 0x36, 0x3E, 0x64, 0x65, 0x66, 0x67, 0xF2, 0xF3})
 
 # The lowest score any multi-byte (length 3/4/5) COMMON_PROLOGUES entry carries, across
 # both bitnesses. Used as the "looks like a real function entry" floor for hasCommonPrologue:
@@ -62,14 +66,15 @@ _POINTER_TABLE_POLL_BYTES = 0x10000
 # Written as `A(BA)+B` rather than the equivalent `(AB){2,}` so the pattern starts with a literal:
 # only then does the regex engine emit a prefix fast-search instead of entering the matcher at
 # every offset of the mapped image.
-_RE_STUB_BLOCK = re.compile(b"\xff\x25(?:.{4}\xff\x25)+.{4}", re.DOTALL)
-_RE_STUB_ENTRY = re.compile(b"\xff\x25(?P<function>.{4})", re.DOTALL)
-_RE_PLT_BLOCK = re.compile(b"\xff\x25(?:.{4}\x68.{4}\xe9.{4}\xff\x25)+.{4}\x68.{4}\xe9.{4}", re.DOTALL)
-_RE_PLTSEC_BLOCK = re.compile(
-    b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?:.{4}\x0f\x1f\x44\x00\x00\xf3\x0f\x1e\xfa\xf2\xff\x25)+.{4}\x0f\x1f\x44\x00\x00",
-    re.DOTALL,
+_RE_STUB_BLOCK = re.compile(b"\xff\x25(?:[\x00-\xff]{4}\xff\x25)+[\x00-\xff]{4}")
+_RE_STUB_ENTRY = re.compile(b"\xff\x25(?P<function>[\x00-\xff]{4})")
+_RE_PLT_BLOCK = re.compile(
+    b"\xff\x25(?:[\x00-\xff]{4}\x68[\x00-\xff]{4}\xe9[\x00-\xff]{4}\xff\x25)+[\x00-\xff]{4}\x68[\x00-\xff]{4}\xe9[\x00-\xff]{4}"
 )
-_RE_PLTSEC_ENTRY = re.compile(b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?P<function>.{4})", re.DOTALL)
+_RE_PLTSEC_BLOCK = re.compile(
+    b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?:[\x00-\xff]{4}\x0f\x1f\x44\x00\x00\xf3\x0f\x1e\xfa\xf2\xff\x25)+[\x00-\xff]{4}\x0f\x1f\x44\x00\x00"
+)
+_RE_PLTSEC_ENTRY = re.compile(b"\xf3\x0f\x1e\xfa\xf2\xff\x25(?P<function>[\x00-\xff]{4})")
 
 _PDATA_ENTRY_SIZE = 12
 # items (candidates, matches or exception records) a scan steps over between budget polls, mirroring
@@ -248,20 +253,21 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 self.gap_pointer += run if run else 1
                 continue
             # try to find instructions that directly encode as NOP and skip them
-            ins_buf = list(self.capstone.disasm_lite(get_window_slice(gap_offset, 15), gap_offset))
-            if ins_buf:
-                i_address, i_size, i_mnemonic, i_op_str = ins_buf[0]
-                if i_mnemonic == "nop":
-                    nop_instruction = i_mnemonic + " " + i_op_str
-                    nop_length = i_size
-                    LOGGER.debug(
-                        "nextGapCandidate() found nop instruction (%s) - gap_ptr += %d: 0x%08x",
-                        nop_instruction,
-                        nop_length,
-                        self.gap_pointer,
-                    )
-                    self.gap_pointer += nop_length
-                    continue
+            if byte and byte[0] in _NOP_START_BYTES:
+                ins_buf = list(self.capstone.disasm_lite(get_window_slice(gap_offset, 15), gap_offset))
+                if ins_buf:
+                    i_address, i_size, i_mnemonic, i_op_str = ins_buf[0]
+                    if i_mnemonic == "nop":
+                        nop_instruction = i_mnemonic + " " + i_op_str
+                        nop_length = i_size
+                        LOGGER.debug(
+                            "nextGapCandidate() found nop instruction (%s) - gap_ptr += %d: 0x%08x",
+                            nop_instruction,
+                            nop_length,
+                            self.gap_pointer,
+                        )
+                        self.gap_pointer += nop_length
+                        continue
             # try to find effective NOPs and skip them.
             found_multi_byte_nop = False
             for gap_length in range(max(GAP_SEQUENCES.keys()), 1, -1):

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -140,9 +140,8 @@ class JumpTableAnalyzer:
     def _findJumpTables(self):
         jumptables = set()
         for match_offset in re.finditer(
-            b"(\x48|\x4c)\x8d.{5}(.\x63|\x77|.\x89..\x63)",
+            b"(\x48|\x4c)\x8d[\x00-\xff]{5}([\x00-\xff]\x63|\x77|[\x00-\xff]\x89[\x00-\xff]{2}\x63)",
             self.disassembly.binary_info.binary,
-            re.DOTALL,
         ):
             raw_offset_bytes = self.disassembly.getRawBytes(match_offset.start() + 3, 4)
             if len(raw_offset_bytes) < 4:

--- a/src/smda/synthesis/BinarySynthesizer.py
+++ b/src/smda/synthesis/BinarySynthesizer.py
@@ -163,12 +163,18 @@ class BinarySynthesizer:
         return (pattern * (size // len(pattern) + 1))[:size]
 
     def _getImportMap(self):
-        imports = (self.report.xmetadata or {}).get("imported_functions") or {}
+        metadata = self.report.xmetadata
+        imports = metadata.get("imported_functions") if isinstance(metadata, dict) else None
+        if not isinstance(imports, dict):
+            return {}
         import_map = {}
         for key, value in imports.items():
-            if not value or len(value) < 2 or not value[1]:
+            if not isinstance(value, (list, tuple)) or len(value) < 2 or not value[1]:
                 continue
-            import_map[int(str(key))] = (value[0] or "", value[1])
+            try:
+                import_map[int(str(key))] = (value[0] or "", value[1])
+            except (TypeError, ValueError):
+                continue
         return import_map
 
     def _iterStringRefs(self):

--- a/src/smda/utility/PeFileLoader.py
+++ b/src/smda/utility/PeFileLoader.py
@@ -95,7 +95,7 @@ class PeFileLoader:
             # support up to 100MB for now.
             if max_virt_section_offset > SmdaConfig.MAX_IMAGE_SIZE:
                 raise ValueError("PE file larger than MAX_IMAGE_SIZE")
-            mapped_binary = bytearray([0] * max_virt_section_offset)
+            mapped_binary = bytearray(max_virt_section_offset)
             # clamp to both the raw file's actual length and mapped_binary's capacity so this
             # header-copy slice assignment can never resize mapped_binary (same length on
             # both sides of the assignment, mirroring the per-section copy clamp below)

--- a/src/smda/utility/PriorityQueue.py
+++ b/src/smda/utility/PriorityQueue.py
@@ -1,21 +1,25 @@
 import heapq
 
 
-class _MaxHeapItem:
+class _HeapItem:
+    __slots__ = ("neg_score", "addr", "element")
+
     def __init__(self, element):
         self.element = element
+        self.addr = element.addr
+        self.neg_score = -element.getScore()
 
     def __lt__(self, other):
-        return other.element < self.element
+        return (self.neg_score, self.addr) < (other.neg_score, other.addr)
 
 
 class PriorityQueue:
     def __init__(self, content=None):
-        if content is None:
-            content = []
-        self.heap = [_MaxHeapItem(element) for element in content]
+        content = list(content) if content else []
+        self._in_heap = set(content)
+        self.heap = [_HeapItem(element) for element in content]
         if self.heap:
-            self.update()
+            heapq.heapify(self.heap)
 
     def __iter__(self):
         return self
@@ -24,14 +28,30 @@ class PriorityQueue:
         return self.next()
 
     def next(self):
-        if not self.heap:
-            raise StopIteration
-        return heapq.heappop(self.heap).element
+        while self.heap:
+            item = heapq.heappop(self.heap)
+            element = item.element
+            if element not in self._in_heap:
+                continue
+            if item.neg_score != -element.getScore():
+                heapq.heappush(self.heap, _HeapItem(element))
+                continue
+            self._in_heap.discard(element)
+            return element
+        raise StopIteration
 
     def add(self, element):
-        heapq.heappush(self.heap, _MaxHeapItem(element))
+        if element in self._in_heap:
+            return
+        heapq.heappush(self.heap, _HeapItem(element))
+        self._in_heap.add(element)
 
     def update(self, target_candidate=None):
+        if target_candidate is not None:
+            if target_candidate in self._in_heap:
+                heapq.heappush(self.heap, _HeapItem(target_candidate))
+            return
+        self.heap = [_HeapItem(element) for element in self._in_heap]
         heapq.heapify(self.heap)
 
     def __str__(self):

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -24,12 +24,14 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import lief
+from capstone.arm64 import ARM64_OP_IMM, ARM64_OP_MEM
 
-from smda.aarch64.AArch64Backend import AArch64Backend
+from smda.aarch64.AArch64Backend import AArch64Backend, _dataRefImmediatesFromWord
 from smda.aarch64.AArch64CapstoneVerification import is_control_flow_mnemonic
 from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper
 from smda.aarch64.definitions import (
     EXCEPTION_RETURN_INS,
+    adr_pc_value,
     adrp_page_value,
     is_conditional_branch,
     is_trap,
@@ -1006,6 +1008,22 @@ class TestAArch64PrologueDiscovery(unittest.TestCase):
     def test_the_flag_is_on_by_default(self):
         self.assertTrue(SmdaConfig().USE_AARCH64_BTI_TARGET_TYPE)
 
+    def test_prologue_scan_skips_addresses_outside_code_areas(self):
+        prologue = 0xA9BF7BFD.to_bytes(4, "little")
+        binary_info = BinaryInfo(prologue * 2)
+        binary_info.base_addr = BASE
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            analysis_timeout=False,
+            code_map={},
+        )
+        manager.bitness = 64
+        manager._code_areas = [[BASE + 4, BASE + 8]]
+        manager.locatePrologueCandidates()
+        self.assertNotIn(BASE, manager.candidates)
+        self.assertIn(BASE + 4, manager.candidates)
+
 
 class TestAArch64FunctionBoundaries(unittest.TestCase):
     def _disassemble_words(self, words, oep=None):
@@ -1520,6 +1538,125 @@ class TestAArch64AddressMaterialization(unittest.TestCase):
         # a zero immediate yields the PC's own page regardless of PC offset within it
         self.assertEqual(adrp_page_value(0x90000000, 0x401ABC), 0x401000)
 
+    def test_adr_pc_value_is_pc_plus_signed_imm(self):
+        self.assertEqual(adr_pc_value(0x10000000, 0x401000), 0x401000)
+        self.assertEqual(_dataRefImmediatesFromWord((0x90000000).to_bytes(4, "little"), 0x401ABC), (0x401000,))
+        self.assertEqual(_dataRefImmediatesFromWord((0x91000400).to_bytes(4, "little"), 0x401000), (1,))
+        self.assertIsNone(_dataRefImmediatesFromWord((0x91000000).to_bytes(4, "little"), 0x401000))
+        self.assertIsNone(_dataRefImmediatesFromWord((0xD503201F).to_bytes(4, "little"), 0x401000))
+        self.assertEqual(_dataRefImmediatesFromWord((0xD2800020).to_bytes(4, "little"), 0x401000), (1,))
+        self.assertEqual(_dataRefImmediatesFromWord((0xF2800020).to_bytes(4, "little"), 0x401000), (1,))
+        self.assertEqual(_dataRefImmediatesFromWord((0x12800008).to_bytes(4, "little"), 0x401000), (-1,))
+        self.assertEqual(_dataRefImmediatesFromWord((0x7140069F).to_bytes(4, "little"), 0x401000), (1,))
+        self.assertIsNone(_dataRefImmediatesFromWord(b"\x00", 0x401000))
+        self.assertIsNone(_dataRefImmediatesFromWord((0x52C00000).to_bytes(4, "little"), 0x401000))
+        self.assertEqual(adr_pc_value(0x10800000, 0x401000), 0x301000)
+        self.assertEqual(_dataRefImmediatesFromWord((0x10000000).to_bytes(4, "little"), 0x401000), (0x401000,))
+        self.assertEqual(_dataRefImmediatesFromWord((0x12B00008).to_bytes(4, "little"), 0x401000), (0x7FFFFFFF,))
+
+    def test_record_data_refs_capstone_fallback_handles_empty_decode_and_abs_mem(self):
+        nop = (0xD503201F).to_bytes(4, "little")
+
+        class _Mem:
+            def __init__(self, base, disp):
+                self.base = base
+                self.disp = disp
+
+        class _Operand:
+            def __init__(self, op_type, imm=None, mem=None):
+                self.type = op_type
+                self.imm = imm
+                self.mem = mem
+
+        class _Insn:
+            def __init__(self, operands):
+                self.operands = operands
+
+        class _Capstone:
+            def __init__(self, insns):
+                self._insns = insns
+
+            def disasm(self, *_args, **_kwargs):
+                yield from self._insns
+
+        class _State:
+            def __init__(self):
+                self.refs = []
+
+            def addDataRef(self, addr_from, addr_to, size=1):
+                del size
+                self.refs.append((addr_from, addr_to))
+
+        def _disassembler(insns, raw=nop, size=0x4000, areas=None):
+            binary_info = BinaryInfo(raw)
+            binary_info.base_addr = 0
+            binary_info.binary_size = size
+            binary_info.code_areas = areas or [[0x1000, 0x2000]]
+            disassembly = SimpleNamespace(
+                binary_info=binary_info,
+                getBytes=lambda _addr, _size: raw,
+                isAddrWithinMemoryImage=lambda value: 0 <= value < size,
+            )
+            return SimpleNamespace(disassembly=disassembly, capstone=_Capstone(insns))
+
+        empty_state = _State()
+        AArch64Backend._recordDataRefs(_disassembler([]), (0, 4, "nop", "#0x10"), empty_state)
+        self.assertEqual(empty_state.refs, [])
+
+        short_state = _State()
+        AArch64Backend._recordDataRefs(_disassembler([], raw=b"\x00"), (0, 4, "nop", "#0x10"), short_state)
+        self.assertEqual(short_state.refs, [])
+
+        mem_state = _State()
+        AArch64Backend._recordDataRefs(
+            _disassembler(
+                [
+                    _Insn(
+                        [
+                            _Operand(ARM64_OP_MEM, mem=_Mem(0, 0x3000)),
+                            _Operand(ARM64_OP_IMM, imm=1),
+                            _Operand(0, imm=None, mem=None),
+                        ]
+                    )
+                ]
+            ),
+            (0, 4, "ldr", "#0x3000"),
+            mem_state,
+        )
+        self.assertEqual(mem_state.refs, [(0, 0x3000), (0, 1)])
+
+        word_state = _State()
+        adrp = (0x90000000).to_bytes(4, "little")
+        AArch64Backend._recordDataRefs(
+            _disassembler([], raw=adrp, size=0x500000, areas=[[0x1000, 0x2000]]),
+            (0x401ABC, 4, "adrp", "#0x401000"),
+            word_state,
+        )
+        self.assertEqual(word_state.refs, [(0x401ABC, 0x401000)])
+
+        cf_state = _State()
+        AArch64Backend._recordDataRefs(_disassembler([]), (0, 4, "bl", "#0x10"), cf_state)
+        self.assertEqual(cf_state.refs, [])
+
+        in_code_state = _State()
+        AArch64Backend._recordDataRefs(
+            _disassembler([], raw=adrp, size=0x500000, areas=[[0x401000, 0x402000]]),
+            (0x401ABC, 4, "adrp", "#0x401000"),
+            in_code_state,
+        )
+        self.assertEqual(in_code_state.refs, [])
+
+        dup_state = _State()
+        import smda.aarch64.AArch64Backend as ab_mod
+
+        original = ab_mod._dataRefImmediatesFromWord
+        ab_mod._dataRefImmediatesFromWord = lambda *_args, **_kwargs: (0x3000, 0x3000)
+        try:
+            AArch64Backend._recordDataRefs(_disassembler([], raw=nop), (0, 4, "nop", "#0x3000"), dup_state)
+        finally:
+            ab_mod._dataRefImmediatesFromWord = original
+        self.assertEqual(dup_state.refs, [(0, 0x3000)])
+
     def test_adrp_ldr_ref_recovery(self):
         base = 0x400000
         words = [
@@ -1676,6 +1813,19 @@ class TestAArch64GapScan(unittest.TestCase):
         manager._candidate_offsets = set()
 
         self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4, 0xD503245F))
+
+    def test_prologue_scan_stops_when_the_analysis_timeout_is_already_tripped(self):
+        binary_info = BinaryInfo(b"\x00" * 8)
+        binary_info.base_addr = BASE
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            analysis_timeout=True,
+            code_map={},
+        )
+        manager.bitness = 64
+        manager.locatePrologueCandidates()
+        self.assertEqual(manager.candidates, {})
 
 
 class TestAArch64StaticFixture(unittest.TestCase):

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -1542,7 +1542,7 @@ class TestAArch64AddressMaterialization(unittest.TestCase):
         self.assertEqual(adr_pc_value(0x10000000, 0x401000), 0x401000)
         self.assertEqual(_dataRefImmediatesFromWord((0x90000000).to_bytes(4, "little"), 0x401ABC), (0x401000,))
         self.assertEqual(_dataRefImmediatesFromWord((0x91000400).to_bytes(4, "little"), 0x401000), (1,))
-        self.assertIsNone(_dataRefImmediatesFromWord((0x91000000).to_bytes(4, "little"), 0x401000))
+        self.assertEqual(_dataRefImmediatesFromWord((0x91000000).to_bytes(4, "little"), 0x401000), (0,))
         self.assertIsNone(_dataRefImmediatesFromWord((0xD503201F).to_bytes(4, "little"), 0x401000))
         self.assertEqual(_dataRefImmediatesFromWord((0xD2800020).to_bytes(4, "little"), 0x401000), (1,))
         self.assertEqual(_dataRefImmediatesFromWord((0xF2800020).to_bytes(4, "little"), 0x401000), (1,))
@@ -1553,6 +1553,32 @@ class TestAArch64AddressMaterialization(unittest.TestCase):
         self.assertEqual(adr_pc_value(0x10800000, 0x401000), 0x301000)
         self.assertEqual(_dataRefImmediatesFromWord((0x10000000).to_bytes(4, "little"), 0x401000), (0x401000,))
         self.assertEqual(_dataRefImmediatesFromWord((0x12B00008).to_bytes(4, "little"), 0x401000), (0x7FFFFFFF,))
+
+    def test_data_ref_word_skips_register_relative_loads(self):
+        unsigned_ldr = 0xF9400820  # ldr x0, [x1, #0x10]
+        unsigned_str = 0xF9000000  # str x0, [x0]
+        ldur = 0xF8400000  # ldur x0, [x0]
+        ldr_reg = 0xF8616800  # ldr x0, [x0, x1]
+        ldr_pre = 0xF8408C20  # ldr x0, [x1, #8]!
+        ldtr = 0xF85F0820  # ldtr x0, [x1, #-0x10]
+        ldraa = 0xF8616C20  # ldraa x0, [x1, #-0xf50]!
+        ldp_signed = 0xA9400400  # ldp x0, x1, [x0]
+        ldp_pre = 0xA9C17BFD  # ldp x29, x30, [sp, #0x10]!
+        ldnp = 0xA8400400  # ldnp x0, x1, [x0]
+        ldp_post = 0xA8C17BFD  # ldp x29, x30, [sp], #0x10
+        str_post = 0xF8008409  # str x9, [x0], #8
+        self.assertEqual(_dataRefImmediatesFromWord(unsigned_ldr.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(unsigned_str.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldur.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldr_reg.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldr_pre.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldtr.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldraa.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldp_signed.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldp_pre.to_bytes(4, "little"), 0), ())
+        self.assertEqual(_dataRefImmediatesFromWord(ldnp.to_bytes(4, "little"), 0), ())
+        self.assertIsNone(_dataRefImmediatesFromWord(ldp_post.to_bytes(4, "little"), 0))
+        self.assertIsNone(_dataRefImmediatesFromWord(str_post.to_bytes(4, "little"), 0))
 
     def test_record_data_refs_capstone_fallback_handles_empty_decode_and_abs_mem(self):
         nop = (0xD503201F).to_bytes(4, "little")
@@ -1656,6 +1682,54 @@ class TestAArch64AddressMaterialization(unittest.TestCase):
         finally:
             ab_mod._dataRefImmediatesFromWord = original
         self.assertEqual(dup_state.refs, [(0, 0x3000)])
+
+        class _BoomCapstone:
+            def disasm(self, *_args, **_kwargs):
+                raise AssertionError("capstone detail should not run for a word-path encoding")
+
+        def _boom_disassembler(raw, size=0x4000, areas=None):
+            binary_info = BinaryInfo(raw)
+            binary_info.base_addr = 0
+            binary_info.binary_size = size
+            binary_info.code_areas = areas or [[0x1000, 0x2000]]
+            disassembly = SimpleNamespace(
+                binary_info=binary_info,
+                getBytes=lambda _addr, _size: raw,
+                isAddrWithinMemoryImage=lambda value: 0 <= value < size,
+            )
+            return SimpleNamespace(disassembly=disassembly, capstone=_BoomCapstone())
+
+        add0_state = _State()
+        add0 = (0x91000000).to_bytes(4, "little")
+        AArch64Backend._recordDataRefs(_boom_disassembler(add0), (0, 4, "add", "x0, x0, #0"), add0_state)
+        self.assertEqual(add0_state.refs, [(0, 0)])
+
+        unsigned_state = _State()
+        unsigned_ldr = (0xF9400820).to_bytes(4, "little")
+        AArch64Backend._recordDataRefs(
+            _boom_disassembler(unsigned_ldr),
+            (0, 4, "ldr", "x0, [x1, #0x10]"),
+            unsigned_state,
+        )
+        self.assertEqual(unsigned_state.refs, [])
+
+        pre_state = _State()
+        ldr_pre = (0xF8408C20).to_bytes(4, "little")
+        AArch64Backend._recordDataRefs(
+            _boom_disassembler(ldr_pre),
+            (0, 4, "ldr", "x0, [x1, #8]!"),
+            pre_state,
+        )
+        self.assertEqual(pre_state.refs, [])
+
+        pair_pre_state = _State()
+        ldp_pre = (0xA9C17BFD).to_bytes(4, "little")
+        AArch64Backend._recordDataRefs(
+            _boom_disassembler(ldp_pre),
+            (0, 4, "ldp", "x29, x30, [sp, #0x10]!"),
+            pair_pre_state,
+        )
+        self.assertEqual(pair_pre_state.refs, [])
 
     def test_adrp_ldr_ref_recovery(self):
         base = 0x400000

--- a/tests/testAArch64JumpTableLsl.py
+++ b/tests/testAArch64JumpTableLsl.py
@@ -1,5 +1,6 @@
 import struct
 import unittest
+from types import SimpleNamespace
 
 from smda.common.BinaryInfo import BinaryInfo
 from smda.DisassemblyResult import DisassemblyResult
@@ -208,6 +209,19 @@ class TestAArch64JumpTableLsl(unittest.TestCase):
         # anchor 0x411100 + (delta << 2): two entries resolve *before* the table, which is
         # exactly what the unsigned read cannot express.
         self.assertEqual(targets[:3], [0x411000, 0x410F00, 0x411200])
+
+    def test_next_known_boundary_prefers_the_closer_of_candidate_and_border(self):
+        from smda.aarch64.analyzers import AArch64JumpTableAnalyzer
+
+        class FakeDisassembler:
+            def __init__(self):
+                self.fc_manager = SimpleNamespace(candidates={0x2000: object()})
+                self.disassembly = SimpleNamespace(function_borders={0x100: (0x1500, 0x1600)})
+
+        analyzer = AArch64JumpTableAnalyzer(FakeDisassembler())
+        self.assertEqual(analyzer._nextKnownBoundary(0x1400), 0x1500)
+        self.assertEqual(analyzer._nextKnownBoundary(0x1500), 0x2000)
+        self.assertIsNone(analyzer._nextKnownBoundary(0x2000))
 
 
 if __name__ == "__main__":

--- a/tests/testBracketQueue.py
+++ b/tests/testBracketQueue.py
@@ -255,6 +255,109 @@ class BracketQueueTestSuite(unittest.TestCase):
         self.assertIs(next(queue), high)
         self.assertIs(next(queue), low)
 
+    def test_priority_queue_add_does_not_duplicate_resident_candidate(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        high.addCallRef(0x100)
+
+        queue = PriorityQueue([low, high])
+        queue.add(high)
+        queue.add(low)
+
+        self.assertIs(next(queue), high)
+        self.assertIs(next(queue), low)
+        with self.assertRaises(StopIteration):
+            next(queue)
+
+    def test_priority_queue_update_reorders_existing_candidate(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        high.addCallRef(0x100)
+
+        queue = PriorityQueue([low, high])
+        low.addCallRef(0x200)
+        low.addCallRef(0x300)
+        queue.add(low)
+        queue.update(low)
+
+        self.assertIs(next(queue), low)
+        self.assertIs(next(queue), high)
+
+    def test_priority_queue_update_after_score_decrease(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        low.addCallRef(0x400)
+        high.addCallRef(0x100)
+        high.addCallRef(0x200)
+        high.addCallRef(0x300)
+
+        queue = PriorityQueue([low, high])
+        high.removeCallRefs([0x100, 0x200, 0x300])
+        queue.update(high)
+
+        self.assertIs(next(queue), low)
+        self.assertIs(next(queue), high)
+
+    def test_priority_queue_score_change_without_update_is_not_lost(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        high.addCallRef(0x100)
+
+        queue = PriorityQueue([low, high])
+        low.addCallRef(0x200)
+        low.addCallRef(0x300)
+
+        produced = [next(queue), next(queue)]
+        self.assertEqual(set(produced), {low, high})
+        with self.assertRaises(StopIteration):
+            next(queue)
+
+    def test_priority_queue_readd_after_pop(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        first = FunctionCandidate(binary_info, 0x10)
+        first.addCallRef(0x100)
+        second = FunctionCandidate(binary_info, 0x20)
+        second.addCallRef(0x100)
+
+        queue = PriorityQueue([first, second])
+        popped = next(queue)
+        self.assertIs(popped, first)
+        queue.add(popped)
+        self.assertIs(next(queue), first)
+        self.assertIs(next(queue), second)
+
+    def test_priority_queue_update_without_target_rebuilds_from_resident_set(self):
+        binary_info = BinaryInfo(b"\x90" * 0x40)
+        binary_info.base_addr = 0
+        binary_info.bitness = 32
+        low = FunctionCandidate(binary_info, 0x20)
+        high = FunctionCandidate(binary_info, 0x10)
+        high.addCallRef(0x100)
+        high.addCallRef(0x200)
+        high.addCallRef(0x300)
+
+        queue = PriorityQueue([low, high])
+        high.removeCallRefs([0x100, 0x200, 0x300])
+        low.addCallRef(0x400)
+        queue.update()
+
+        self.assertIs(next(queue), low)
+        self.assertIs(next(queue), high)
+
 
 class _ScoredCandidate:
     def __init__(self, addr, score, num_call_refs=0):

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -552,6 +552,21 @@ class TestCommonModels(unittest.TestCase):
 
         self.assertTrue(function.isApiThunk())
 
+    def test_instruction_from_tuple_matches_list_constructor(self):
+        raw = (0x401000, 2, "mov", "eax, ebx", b"\x89\xc3")
+        from_list = SmdaInstruction([raw[0], raw[4].hex(), str(raw[2]), str(raw[3])])
+        from_tuple = SmdaInstruction.from_tuple(raw)
+        self.assertEqual(from_tuple.offset, from_list.offset)
+        self.assertEqual(from_tuple.bytes, from_list.bytes)
+        self.assertEqual(from_tuple.mnemonic, from_list.mnemonic)
+        self.assertEqual(from_tuple.operands, from_list.operands)
+
+    def test_instruction_from_tuple_stringifies_non_str_fields(self):
+        instruction = SmdaInstruction.from_tuple((0x10, 1, b"ret", None, b"\xc3"))
+        self.assertEqual(instruction.mnemonic, "b'ret'")
+        self.assertEqual(instruction.operands, "None")
+        self.assertEqual(instruction.bytes, "c3")
+
 
 class TestBinaryInfoCodeAreas(unittest.TestCase):
     def test_address_one_past_the_image_is_not_inside(self):
@@ -562,6 +577,27 @@ class TestBinaryInfoCodeAreas(unittest.TestCase):
         self.assertTrue(binary_info.isInCodeAreas(0x400000))
         self.assertTrue(binary_info.isInCodeAreas(0x4000FF))
         self.assertFalse(binary_info.isInCodeAreas(0x400100))
+
+    def test_overlapping_code_areas_are_merged_for_membership(self):
+        binary_info = BinaryInfo(b"\x90" * 0x200)
+        binary_info.base_addr = 0
+        binary_info.binary_size = 0x200
+        binary_info.code_areas = [[0, 100], [50, 60], [150, 180]]
+
+        self.assertTrue(binary_info.isInCodeAreas(70))
+        self.assertTrue(binary_info.isInCodeAreas(55))
+        self.assertFalse(binary_info.isInCodeAreas(120))
+        self.assertTrue(binary_info.isInCodeAreas(160))
+        self.assertFalse(binary_info.isInCodeAreas(180))
+
+    def test_overlapping_code_areas_extend_the_merged_end(self):
+        binary_info = BinaryInfo(b"\x90" * 0x200)
+        binary_info.base_addr = 0
+        binary_info.binary_size = 0x200
+        binary_info.code_areas = [[0, 100], [90, 150]]
+
+        self.assertTrue(binary_info.isInCodeAreas(120))
+        self.assertFalse(binary_info.isInCodeAreas(150))
 
 
 class TestBinaryInfoBinaryData(unittest.TestCase):

--- a/tests/testCommonModels.py
+++ b/tests/testCommonModels.py
@@ -595,6 +595,15 @@ class TestSmdaFunctionRobustness(unittest.TestCase):
 
         self.assertEqual(function.getNormalizedBlockRefs(), {0x100: []})
 
+    def test_blockrefs_without_try_ranges_are_deduplicated_and_sorted(self):
+        function = SmdaFunction()
+        function.offset = 0x100
+        function.blocks = {0x200: [], 0x100: []}
+        function.blockrefs = {0x100: [0x200, 0x200, 0x080]}
+        function.architecture_metadata = {}
+
+        self.assertEqual(function.getNormalizedBlockRefs(), {0x100: [0x080, 0x200], 0x200: []})
+
     def test_code_xrefs_skip_a_function_whose_offset_is_not_an_instruction(self):
         report = SmdaReport(None)
         report._offset2ins = {0x2000: object()}

--- a/tests/testDisassemblyResultGetOutRefs.py
+++ b/tests/testDisassemblyResultGetOutRefs.py
@@ -30,6 +30,19 @@ class TestDisassemblyResultGetOutRefs(unittest.TestCase):
         self.assertIn(ins_addr, out_refs)
         self.assertEqual(out_refs[ins_addr], [last_valid_addr])
 
+    def test_out_refs_are_sorted_and_exclude_in_function_destinations(self):
+        disassembly = DisassemblyResult()
+        disassembly.binary_info = SimpleNamespace(base_addr=0x1000, binary_size=0x200)
+        func_addr = 0x1000
+        call_addr = 0x1000
+        fallthrough = 0x1005
+        disassembly.functions[func_addr] = [
+            [(call_addr, 5, "call", "0x1100"), (fallthrough, 1, "ret", "")],
+        ]
+        disassembly.code_refs_from[call_addr] = {0x1180, 0x1100, fallthrough, func_addr}
+        out_refs = disassembly.getOutRefs(func_addr)
+        self.assertEqual(out_refs[call_addr], [func_addr, 0x1100, 0x1180])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -1,10 +1,13 @@
 import unittest
+from types import SimpleNamespace
 
 from smda.cil.FunctionAnalysisState import FunctionAnalysisState as CilFunctionAnalysisState
 from smda.common.BinaryInfo import BinaryInfo
 from smda.common.FunctionAnalysisState import FunctionAnalysisState
+from smda.common.FunctionCandidateManager import FunctionCandidateManager
 from smda.dalvik.DalvikFunctionAnalysisState import DalvikFunctionAnalysisState
 from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
 
 
 class _BareState(FunctionAnalysisState):
@@ -50,6 +53,16 @@ class FunctionAnalysisStateTestSuite(unittest.TestCase):
         starts = {block[0][0] for block in state.getBlocks()}
         self.assertNotIn(0x106, starts)
 
+    def test_code_refs_setter_rebuilds_from_and_to_maps(self):
+        state = _BareState(0x100)
+        state.addCodeRef(0x10, 0x99)
+        state.code_refs = {(0x10, 0x20), (0x10, 0x30)}
+        self.assertEqual(state.code_refs_from[0x10], {0x20, 0x30})
+        self.assertEqual(state.code_refs_to[0x20], {0x10})
+        self.assertEqual(state.code_refs_to[0x30], {0x10})
+        self.assertNotIn(0x99, state.code_refs_to)
+        self.assertEqual(state.code_refs, {(0x10, 0x20), (0x10, 0x30)})
+
 
 class CilFunctionAnalysisStateTestSuite(unittest.TestCase):
     """The CIL state carries its own copy of the edge book-keeping."""
@@ -73,6 +86,28 @@ class CilFunctionAnalysisStateTestSuite(unittest.TestCase):
 
         self.assertNotIn(0x106, state.jump_targets)
 
+    def test_code_refs_setter_rebuilds_from_and_to_maps(self):
+        state = CilFunctionAnalysisState(0x100, 0x100, None)
+        state.code_refs = {(0x10, 0x20), (0x10, 0x30)}
+        self.assertEqual(state.code_refs_from[0x10], {0x20, 0x30})
+        self.assertEqual(state.code_refs_to[0x20], {0x10})
+        self.assertEqual(state.code_refs, {(0x10, 0x20), (0x10, 0x30)})
+        state.code_refs = set()
+        self.assertEqual(state.code_refs_from, {})
+        self.assertEqual(state.code_refs_to, {})
+
+    def test_finalize_merges_into_existing_disassembly_refs(self):
+        disassembly = _RecordingDisassembly()
+        disassembly.code_refs_from[0x200] = {0x300}
+        disassembly.code_refs_to[0x300] = {0x100}
+        state = CilFunctionAnalysisState(0x200, 0x200, disassembly)
+        state.addInstruction(0x200, 1, "nop", "", b"\x00")
+        state.addCodeRef(0x200, 0x400)
+        state.finalizeAnalysis()
+        self.assertEqual(disassembly.code_refs_from[0x200], {0x300, 0x400, 0x201})
+        self.assertIn(0x200, disassembly.code_refs_to[0x400])
+        self.assertIn(0x100, disassembly.code_refs_to[0x300])
+
 
 class DalvikFunctionAnalysisStateTestSuite(unittest.TestCase):
     """The Dalvik state carries its own copy of the edge book-keeping."""
@@ -95,6 +130,31 @@ class DalvikFunctionAnalysisStateTestSuite(unittest.TestCase):
         state.removeCodeRef(0x100, 0x106)
 
         self.assertNotIn(0x106, state.jump_targets)
+
+    def test_code_refs_setter_rebuilds_from_and_to_maps(self):
+        state = DalvikFunctionAnalysisState(0x100, None)
+        state.code_refs = {(0x10, 0x20), (0x10, 0x30)}
+        self.assertEqual(state.code_refs_from[0x10], {0x20, 0x30})
+        self.assertEqual(state.code_refs_to[0x20], {0x10})
+        self.assertEqual(state.code_refs, {(0x10, 0x20), (0x10, 0x30)})
+        state.code_refs = set()
+        self.assertEqual(state.code_refs_from, {})
+        self.assertEqual(state.code_refs_to, {})
+
+    def test_finalize_merges_into_existing_disassembly_refs(self):
+        disassembly = _RecordingDisassembly()
+        disassembly.function_metadata = {}
+        disassembly.code_refs_from[0x200] = {0x300}
+        disassembly.code_refs_to[0x300] = {0x100}
+        state = DalvikFunctionAnalysisState(0x200, disassembly)
+        state.label = "Lfoo;->bar()V"
+        state.addInstruction(0x200, 2, "nop", "", b"\x00\x00")
+        state.addCodeRef(0x200, 0x400)
+        state.endBlock()
+        state._finalizeRegularAnalysis()
+        self.assertEqual(disassembly.code_refs_from[0x200], {0x300, 0x400, 0x202})
+        self.assertIn(0x200, disassembly.code_refs_to[0x400])
+        self.assertIn(0x100, disassembly.code_refs_to[0x300])
 
 
 class _RecordingDisassembly:
@@ -316,6 +376,44 @@ class FunctionEntryIntegrityTestSuite(unittest.TestCase):
         self.assertTrue(state.finalizeAnalysis())
         self.assertIn(0x100, disassembly.functions)
         self.assertIn(0x100, {block[0][0] for block in disassembly.functions[0x100]})
+
+
+class GapConstructionTestSuite(unittest.TestCase):
+    def test_interior_holes_match_the_covered_byte_walk(self):
+        class _Manager(FunctionCandidateManager):
+            CANDIDATE_CLASS = None
+
+            def locateCandidates(self):
+                return
+
+        manager = _Manager(SmdaConfig())
+        manager.bitness = 32
+        manager._code_areas = [[0x1000, 0x2000]]
+        manager.disassembly = SimpleNamespace(
+            functions={
+                0x1000: [[(0x1000, 4, "nop", "", b"\x90" * 4)]],
+                0x1010: [[(0x1010, 2, "ret", "", b"\xc3\x00")]],
+            },
+            binary_info=SimpleNamespace(base_addr=0x1000, binary_size=0x1000),
+            code_map={},
+        )
+        manager.updateFunctionGaps()
+        interior = [gap for gap in manager.function_gaps if gap[0] == 0x1004]
+        self.assertEqual(interior, [[0x1004, 0x1010, 12]])
+
+    def test_overlapping_code_areas_extend_the_merged_end(self):
+        class _Manager(FunctionCandidateManager):
+            CANDIDATE_CLASS = None
+
+            def locateCandidates(self):
+                return
+
+        manager = _Manager(SmdaConfig())
+        manager._code_areas = [[0, 100], [90, 150]]
+        self.assertTrue(manager._passesCodeFilter(120))
+        self.assertTrue(manager._passesCodeFilter(70))
+        self.assertFalse(manager._passesCodeFilter(150))
+        self.assertFalse(manager._passesCodeFilter(None))
 
 
 if __name__ == "__main__":

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -379,7 +379,8 @@ class FunctionEntryIntegrityTestSuite(unittest.TestCase):
 
 
 class GapConstructionTestSuite(unittest.TestCase):
-    def test_interior_holes_match_the_covered_byte_walk(self):
+    @staticmethod
+    def _gapManager(code_map, functions):
         class _Manager(FunctionCandidateManager):
             CANDIDATE_CLASS = None
 
@@ -390,16 +391,31 @@ class GapConstructionTestSuite(unittest.TestCase):
         manager.bitness = 32
         manager._code_areas = [[0x1000, 0x2000]]
         manager.disassembly = SimpleNamespace(
-            functions={
-                0x1000: [[(0x1000, 4, "nop", "", b"\x90" * 4)]],
-                0x1010: [[(0x1010, 2, "ret", "", b"\xc3\x00")]],
-            },
+            functions=functions,
             binary_info=SimpleNamespace(base_addr=0x1000, binary_size=0x1000),
-            code_map={},
+            code_map=code_map,
         )
         manager.updateFunctionGaps()
+        return manager
+
+    def test_interior_holes_match_the_covered_byte_walk(self):
+        manager = self._gapManager(
+            code_map=dict.fromkeys(list(range(0x1000, 0x1004)) + [0x1010, 0x1011], 1),
+            functions={},
+        )
         interior = [gap for gap in manager.function_gaps if gap[0] == 0x1004]
-        self.assertEqual(interior, [[0x1004, 0x1010, 12]])
+        self.assertEqual(interior, [[0x1004, 0x1010, 13]])
+
+    def test_gaps_follow_code_map_coverage_not_recovered_function_extents(self):
+        """code_map covers every decoded byte; disassembly.functions covers only finalized
+        functions. Deriving gaps from the latter drops the decoded-but-unattributed region
+        from the scan, which silently costs function discovery on gap-dominated binaries."""
+        manager = self._gapManager(
+            code_map=dict.fromkeys(list(range(0x1000, 0x1004)) + [0x1010, 0x1011], 1),
+            functions={0x1000: [[(0x1000, 4, "nop", "", b"\x90" * 4)]]},
+        )
+        self.assertIn([0x1004, 0x1010, 13], manager.function_gaps)
+        self.assertEqual([gap for gap in manager.function_gaps if gap[0] == 0x1003], [])
 
     def test_overlapping_code_areas_extend_the_merged_end(self):
         class _Manager(FunctionCandidateManager):

--- a/tests/testFunctionAnalysisState.py
+++ b/tests/testFunctionAnalysisState.py
@@ -399,6 +399,14 @@ class GapConstructionTestSuite(unittest.TestCase):
         return manager
 
     def test_interior_holes_match_the_covered_byte_walk(self):
+        """A hole between decoded bytes is a gap, and `code_map` is what says a byte was decoded.
+
+        The `code_map` here is populated on purpose. An earlier version of this test passed an
+        empty one and asserted a length derived from `disassembly.functions` instead, which
+        pinned the behaviour of the change under review under a name describing the contract it
+        broke -- so the suite could not object to it. Both sources have to carry something for
+        the assertion to be about which of them the gap scan reads.
+        """
         manager = self._gapManager(
             code_map=dict.fromkeys(list(range(0x1000, 0x1004)) + [0x1010, 0x1011], 1),
             functions={},

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -805,6 +805,52 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(manager.nextGapCandidate(), 0x1003)
 
+    def test_gap_scan_skips_multibyte_nop_instruction(self):
+        config = SmdaConfig()
+        binary_info = BinaryInfo(b"\x0f\x1f\x00\x55\xc3")
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = len(binary_info.binary)
+
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            code_map={},
+            data_map={},
+            getRawBytes=lambda offset, size: binary_info.binary[offset : offset + size],
+        )
+        manager.bitness = 32
+        manager.capstone = Cs(CS_ARCH_X86, CS_MODE_32)
+        manager.function_gaps = [[0x1000, 0x1005, 5]]
+        manager.gap_pointer = 0x1000
+
+        self.assertEqual(manager.nextGapCandidate(), 0x1003)
+
+    def test_gap_scan_does_not_disassemble_bytes_that_cannot_be_nop(self):
+        config = SmdaConfig()
+        binary_info = BinaryInfo(b"\xe8\x00\x00\x00\x00\xc3")
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = len(binary_info.binary)
+
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            code_map={},
+            data_map={},
+            getRawBytes=lambda offset, size: binary_info.binary[offset : offset + size],
+        )
+        manager.bitness = 32
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("disasm_lite should not run for a non-nop first byte")
+
+        manager.capstone = SimpleNamespace(disasm_lite=boom)
+        manager.function_gaps = [[0x1000, 0x1006, 6]]
+        manager.gap_pointer = 0x1000
+
+        self.assertEqual(manager.nextGapCandidate(), 0x1000)
+
     def test_locate_prologue_candidates_seeds_extended_amd64_prologues(self):
         # each pattern is separated by a ret and a byte of padding. Packed back to back they
         # would describe one function's prologue followed by its own body, and a match that
@@ -1411,6 +1457,14 @@ class StubChainCandidateTestSuite(unittest.TestCase):
 
     def test_jmp_stub_chain_yields_one_candidate_per_entry(self):
         chain = b"\xff\x25\x11\x22\x33\x44" + b"\xff\x25\x55\x66\x77\x88"
+
+        manager = self._locate(chain)
+
+        base = _StubChainCandidateManager.BASE_ADDR + len(self.PAD)
+        self.assertEqual([base, base + 6], manager.recovered)
+
+    def test_jmp_stub_chain_matches_a_displacement_containing_newline(self):
+        chain = b"\xff\x25\x0a\x22\x33\x44" + b"\xff\x25\x55\x66\x77\x88"
 
         manager = self._locate(chain)
 

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -826,6 +826,67 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertEqual(manager.nextGapCandidate(), 0x1003)
 
+    def test_gap_scan_skips_a_rex_prefixed_nop_in_64bit(self):
+        # Every REX prefix can open an instruction capstone spells `nop`, so a 64-bit
+        # first-byte filter that omits 0x40-0x4F stops recognising REX-padded alignment
+        # filler and books a candidate on the padding itself. Three encodings, each
+        # followed by a real prologue so the address the scan should reach is unambiguous.
+        for label, nop in (
+            ("48 0f 1f 00", b"\x48\x0f\x1f\x00"),
+            ("41 0f 1f 00", b"\x41\x0f\x1f\x00"),
+            ("40 90", b"\x40\x90"),
+        ):
+            with self.subTest(nop=label):
+                config = SmdaConfig()
+                binary_info = BinaryInfo(nop + b"\x55\x48\x89\xe5\xc3")
+                binary_info.base_addr = 0x1000
+                binary_info.bitness = 64
+                binary_info.binary_size = len(binary_info.binary)
+
+                manager = FunctionCandidateManager(config)
+                manager.disassembly = SimpleNamespace(
+                    binary_info=binary_info,
+                    code_map={},
+                    data_map={},
+                    # bound as a default so the reader is this subtest's buffer, not the
+                    # loop variable as it stands whenever the lambda happens to run
+                    getRawBytes=lambda offset, size, info=binary_info: info.binary[offset : offset + size],
+                )
+                manager.bitness = 64
+                manager.capstone = Cs(CS_ARCH_X86, CS_MODE_64)
+                manager.function_gaps = [[0x1000, 0x1000 + binary_info.binary_size, binary_info.binary_size]]
+                manager.gap_pointer = 0x1000
+
+                self.assertEqual(manager.nextGapCandidate(), 0x1000 + len(nop))
+
+    def test_gap_scan_does_not_disassemble_a_rex_byte_in_32bit(self):
+        # 0x40-0x4F are inc/dec at 32 bits and can never be a nop, so the probe the test
+        # above requires must not run here: admitting the range unconditionally would
+        # spend a 15-byte disassembly on every inc/dec that opens a gap.
+        config = SmdaConfig()
+        binary_info = BinaryInfo(b"\x48\x0f\x1f\x00\xc3")
+        binary_info.base_addr = 0x1000
+        binary_info.bitness = 32
+        binary_info.binary_size = len(binary_info.binary)
+
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = SimpleNamespace(
+            binary_info=binary_info,
+            code_map={},
+            data_map={},
+            getRawBytes=lambda offset, size: binary_info.binary[offset : offset + size],
+        )
+        manager.bitness = 32
+
+        def boom(*_args, **_kwargs):
+            raise AssertionError("disasm_lite should not run for a REX byte at 32 bits")
+
+        manager.capstone = SimpleNamespace(disasm_lite=boom)
+        manager.function_gaps = [[0x1000, 0x1005, 5]]
+        manager.gap_pointer = 0x1000
+
+        self.assertEqual(manager.nextGapCandidate(), 0x1000)
+
     def test_gap_scan_does_not_disassemble_bytes_that_cannot_be_nop(self):
         config = SmdaConfig()
         binary_info = BinaryInfo(b"\xe8\x00\x00\x00\x00\xc3")

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -137,6 +137,12 @@ class TestPeSymbolProviderImports(unittest.TestCase):
         self.assertEqual(resolver.getApi(0, 0x1000), (None, None))
         self.assertEqual(resolver.getApi(0, 0x3000), ("second.dll", "SharedAddress"))
 
+    def test_resolve_os_name_keeps_an_already_pinned_name(self):
+        resolver = WinApiResolver(SimpleNamespace(API_COLLECTION_FILES={}))
+        resolver.setOsName("pinned")
+        resolver._resolveOsName()
+        self.assertEqual(resolver._os_name, "pinned")
+
     def test_win_api_resolver_defers_parsing_uncached_databases(self):
         api_db = {
             "os_name": "testos",

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -165,6 +165,32 @@ class TestPeSymbolProviderImports(unittest.TestCase):
             self.assertEqual(resolver._os_name, "testos")
             self.assertIsNone(resolver._deferred_dbs)
 
+    def test_win_api_resolver_keeps_an_explicit_os_name_across_deferred_loading(self):
+        api_db = {
+            "os_name": "present",
+            "dlls": {
+                "0000_test_presentdll.dll": {
+                    "bitness": 32,
+                    "base_address": 0x70000000,
+                    "exports": [{"name": "PresentApi", "address": 0x1000, "ordinal": 1}],
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = os.path.join(tmp_dir, "apiscout_present.json")
+            with open(db_path, "w", encoding="utf-8") as f_json:
+                json.dump(api_db, f_json)
+            config = SimpleNamespace(
+                API_COLLECTION_FILES={"present": db_path, "absent": os.path.join(tmp_dir, "missing.json")}
+            )
+            resolver = WinApiResolver(config)
+            resolver.setOsName("absent")
+            resolver.update(SimpleNamespace(is_buffer=True))
+
+            # only one of the two databases loads, but the caller pinned the other one
+            self.assertEqual(resolver.getApi(0, 0x70001000), (None, None))
+            self.assertEqual(resolver._os_name, "absent")
+
     def test_parse_imports_uses_active_base_addr_not_imagebase(self):
         provider = PeSymbolProvider(None)
         pe_binary = _MockPeBinary(

--- a/tests/testPeSymbolProvider.py
+++ b/tests/testPeSymbolProvider.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import tempfile
@@ -135,6 +136,34 @@ class TestPeSymbolProviderImports(unittest.TestCase):
         resolver.setOsName("second")
         self.assertEqual(resolver.getApi(0, 0x1000), (None, None))
         self.assertEqual(resolver.getApi(0, 0x3000), ("second.dll", "SharedAddress"))
+
+    def test_win_api_resolver_defers_parsing_uncached_databases(self):
+        api_db = {
+            "os_name": "testos",
+            "dlls": {
+                "0000_test_testdll.dll": {
+                    "bitness": 32,
+                    "base_address": 0x70000000,
+                    "exports": [{"name": "TestApi", "address": 0x1000, "ordinal": 1}],
+                }
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = os.path.join(tmp_dir, "apiscout_testos.json")
+            with open(db_path, "w", encoding="utf-8") as f_json:
+                json.dump(api_db, f_json)
+            config = SimpleNamespace(API_COLLECTION_FILES={"testos": db_path})
+            resolver = WinApiResolver(config)
+
+            # an uncached database is only parsed once an API lookup needs it
+            self.assertEqual(list(resolver._api_map.keys()), ["lief"])
+            self.assertIsNone(resolver._os_name)
+            self.assertEqual(resolver._deferred_dbs, [("testos", db_path)])
+
+            resolver.update(SimpleNamespace(is_buffer=True))
+            self.assertEqual(resolver.getApi(0, 0x70001000), ("testdll.dll", "TestApi"))
+            self.assertEqual(resolver._os_name, "testos")
+            self.assertIsNone(resolver._deferred_dbs)
 
     def test_parse_imports_uses_active_base_addr_not_imagebase(self):
         provider = PeSymbolProvider(None)

--- a/tests/testSynthesis.py
+++ b/tests/testSynthesis.py
@@ -557,6 +557,21 @@ class SynthesisLayoutTestSuite(unittest.TestCase):
         thunk_rvas = {entry.iat_address for imported in parsed.imports for entry in imported.entries}
         assert {slot - report.base_addr for slot in slots} <= thunk_rvas
 
+    def test_non_dict_imported_functions_do_not_crash_synthesis(self):
+        report = copy.deepcopy(self.pe_report)
+        report.xmetadata["imported_functions"] = "not-a-map"
+        synthesized = report.synthesizeBinary(output_format=FORMAT_PE, with_strings=False)
+        self.assertTrue(synthesized)
+        self.assertIsNotNone(lief.parse(synthesized))
+
+        report.xmetadata["imported_functions"] = {
+            0x401000: "ExitProcess",
+            "not-an-address": ("kernel32.dll", "CreateFileA"),
+        }
+        synthesized = report.synthesizeBinary(output_format=FORMAT_PE, with_strings=False)
+        self.assertTrue(synthesized)
+        self.assertIsNotNone(lief.parse(synthesized))
+
     def test_an_import_slot_below_the_image_base_places_no_negative_section(self):
         report = copy.deepcopy(self.pe_report)
         report.xheader = None


### PR DESCRIPTION
## Summary

Six focused changes that cut measurable overhead from the analysis pipeline, plus a follow-up commit fixing two defects that self-review found in two of them.

| Commit | What it does | Indicative effect |
| --- | --- | --- |
| hoist per-instruction lookups out of `analyzeFunction` | binds `code_map`/`data_map`/`ins2fn`/buffer/bound methods to locals in the instruction loop (~180k attribute chains per 29k-instruction sample); containers are only mutated in place, so aliasing is safe | ~1-3% end-to-end |
| reuse escape results + skip redundant report-build work | PIC-hash escaping memoized behind a size-capped cache keyed on the complete input tuple of `escapeBinary`; `getNormalizedBlockRefs` fast path for functions without try_ranges; drop a duplicate `fix_graph()` in the nesting-depth pass | real binaries repeat 30-50% of instructions (98% in a DEX classes dump) |
| prefilter AArch64 candidate scans by top byte | BL encodings have top byte 0x94-0x97 and prologues {0xA9, 0xD5, 0xF8} - verified exhaustively over each pattern's free bits - so one `bytes.translate` over the top-byte lane skips non-matching words at C speed; full per-hit verification kept, timeout polling boundaries unchanged | prologue scan 4.14ms -> 0.74ms, BL 1.17ms -> 0.59ms; scans are O(image bytes), so large ARM64 dumps save proportionally more |
| trust the block queue as the emptiness signal | `hasUnprocessedBlocks()` allocated a set difference on every call although the queue and processed sets are disjoint by construction; O(blocks^2) allocation on wide functions | removes the quadratic trap |
| hoist Dalvik resolver closure | one resolver closure per analysis pass instead of one per decoded instruction (~9.8k allocations avoided) | small but free |
| defer ApiScout DB parsing to first API lookup | uncached databases cost ~26ms at backend construction even when no API is ever resolved; cached ones still attach eagerly so os-name selection stays cheap | cold-start only when API files are configured |

Every change was benchmarked before and after, and full serialized reports hash byte-for-byte equal to master across ten bundled fixtures covering all four backends (intel x86/x86-64 memory dumps, aarch64 static + Mach-O, dalvik DEX classes, CIL), with volatile fields (`timestamp`, `execution_time`) excluded from the comparison.

Interleaved median wall-clock vs master on this machine: aarch64_static -9 to -10%, komplex -6 to -7%, blockblast/asprox -2 to -4%, cutwail/njrat neutral within noise.

## Follow-up fixes

Self-review of the six commits above found two defects. Both live on paths that no bundled fixture reaches, which is exactly why the report-identity check could not see either one: neither can move a fixture hash. Both are fixed in the final commit, each with a regression test that fails on the pre-fix source.

**An explicit ApiScout OS name was silently discarded.** Deferring database parsing moved the os-name inference out of `WinApiResolver.__init__` and into the first `getApi()` call, where it ran unconditionally and overwrote a name an intervening `setOsName()` had pinned. Before the deferral, the inference could only run while no caller had yet had the chance to set one, so the setter always won. It now returns early when a name is already set, matching `Disassembler._ensureHashes`, which fills only fields that are still unset. `_deferred_dbs` is initialized on both construction paths as well, so reading it needs no `getattr` fallback and the non-deferred path no longer raises `AttributeError`.

**The `getNormalizedBlockRefs()` fast path stopped normalizing.** It returned each successor list unchanged, on the grounds that `getBlockRefs()` already emits them sorted and deduplicated. That holds for analysis-produced data, but the same method is also the normalizer on the `fromDict()` path, where blockrefs come from a report this code did not necessarily write; there it became a no-op, and duplicates reached the SCC and dominator-tree passes. Restoring `sorted(set(...))` keeps what the fast path actually saves - it still skips the per-block try-range overlap test and the intermediate dict - and it stays 1.85x faster than the slow path it bypasses, measured interleaved over 319 functions harvested from two bundled fixtures. Equivalence with the slow path was then re-checked over 3000 randomized inputs, including blockrefs carrying keys absent from `blocks`: values, key set and key order all match.

A whole-tree sweep for each root-cause signature found no further sites in `src/smda/`.

## A third defect, and what it says about the validation above

The report-identity check missed a third defect, and this one is worse than the two above: the path was not unreached, it was under-represented. `perf(common): drop redundant ref bookkeeping and speed hot lookups` re-keyed `updateFunctionGaps()` from a walk over `code_map` byte keys to merging the instruction intervals of `disassembly.functions`, leaving the byte walk reachable only when `functions` is empty.

The two are not interchangeable. `code_map` records every decoded byte; `disassembly.functions` records only finalized functions. Deriving gaps from the latter drops the decoded-but-unattributed regions out of the gap scan, and with them every candidate the scan would have seeded there. On a 32-bit MSVC PE cross-compiled from Rust (hyperfine 1.19.0, `i686-pc-windows-msvc`), recovery falls from 6249 functions to 5247 - a loss of 1002, or 16%. Measured revision by revision across this branch, everything before that commit reports 6249 and everything after reports 5247.

The rewrite did not pay for itself either. `updateFunctionGaps()` runs once per analysis, and the interval merge costs more than the byte walk it replaced: 0.0410s against 0.0365s cumulative under cProfile. Reverting restores 6249 at unchanged wall-clock, so the speedups claimed above are unaffected.

Only that hunk is reverted. The rest of the commit keeps its wins - the `_passesCodeFilter` bisect index, the candidate-queue update, the reference-pair bookkeeping removal, and the `SmdaInstruction.from_tuple` and `getOutRefs` work are untouched.

The same commit also added `test_interior_holes_match_the_covered_byte_walk`, which passed an empty `code_map` and asserted a gap length derived from function intervals - pinning the new behaviour under a name describing the old contract, so the suite could not object to it. It now exercises `code_map`, and a second test asserts that gaps follow `code_map` coverage when both sources are populated; that test fails on the pre-revert source.

None of the ten bundled fixtures is gap-dominated, which is why a 16% recall loss could not move a single hash. The lesson from the two defects above generalizes further than it was first written: a report-identity comparison is evidence about the fixtures, not about the change, and it is only ever as strong as the fixtures are representative.

## Changed behavior

Reports serialize identically on all fixtures listed above, and the golden corpus expectations are untouched. That statement is about the fixtures and not about every binary: as described in the section above, one commit did change recovery on a 32-bit MSVC PE outside the fixture set, and the revert restores it. Three behavioral nuances are intentional. An uncached ApiScout database is now parsed at the first `getApi()` call rather than at resolver construction, so the missing-file log timing moves with it. An explicit `setOsName()` outranks the os-name inference regardless of when the deferred load fires, restoring the pre-deferral ordering. And `getNormalizedBlockRefs()` still deduplicates and sorts successor lists on the `fromDict()` path, as it did before the fast path was introduced.

Approaches that were tried and rejected after measurement, for the record: enlarging Capstone disassembly windows (slower despite fewer calls - object construction dominates), batch-decoding instruction details for string extraction (slower for the same reason), fusing the intel candidate-scan regexes (measured 1.0x), interval-backed `processed_bytes` (no gain).

## Validation

- `python -m pytest tests/` : 1847 passed, 1 skipped, 2584 subtests
- `make lint` and `ruff format --check .`: clean
- `make typecheck`: exit 0, diagnostic count unchanged against the same tree without these changes
- Report-identity hashes (serialized `toDict()` SHA256, volatile fields scrubbed) equal to master across 10 fixtures spanning intel/aarch64/dalvik/cil, default config and WITH_STRINGS=True
- Function recovery on the 32-bit MSVC PE described above: 5247 -> 6249, `status: ok`, analysis ~1.8s
- Diff coverage against the base branch: 99% overall, 100% on the lines changed by the revert. The two uncovered lines are the residual per-hit verification arms of the AArch64 top-byte prefilter (a word whose top byte matches but whose full encoding does not, and a prologue rejected by the code filter); neither is reached by a bundled fixture today.

