### PR TITLE
fix(ci): address ty 0.0.74 unsound-return checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # ty is pinned in pyproject.toml and ships new error rules in patch releases;
+      # bump it in a dedicated change that addresses those rules, not via Dependabot.
+      - dependency-name: "ty"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dev = [
     "ruff",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
-    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield, 35 errors
-    # against an unchanged tree). Bump deliberately, with the new rules addressed.
+    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74
+    # promotes those plus unsound-assignment). Bump deliberately, with the new
+    # rules addressed.
     "ty==0.0.74",
     "tqdm",
     "twine",
@@ -208,7 +209,9 @@ rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
 
 [[tool.ty.overrides]]
 include = ["src/smda/cil/CilDisassembler.py"]
-rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
+# dnfile/dncil expose heap lookups and PE reads as Any/Unknown; ty 0.0.74 treats
+# those as unsound against the local bytes/str annotations rather than as gradual Any.
+rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore", "unsound-assignment" = "ignore", "unsound-return-statement" = "ignore" }
 
 # LIEF's type stubs declare PE Section.name as bytes; the runtime returns str.
 [[tool.ty.overrides]]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -295,7 +295,7 @@ class Disassembler:
             )
         return smda_report
 
-    def _disassemble(self, binary_info, timeout=0):
+    def _disassemble(self, binary_info, timeout=0) -> SmdaReport:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
@@ -319,7 +319,7 @@ class Disassembler:
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
-    def _createErrorReport(self, start, exception):
+    def _createErrorReport(self, start, exception) -> SmdaReport:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
@@ -330,7 +330,7 @@ class Disassembler:
         report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         return report
 
-    def _handleDisassemblyException(self, start, exception, log_message):
+    def _handleDisassemblyException(self, start, exception, log_message) -> SmdaReport:
         reraise_non_operational_exception(exception)
         LOGGER.error(log_message)
         return self._createErrorReport(start, exception)

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,7 +111,7 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from typing import Optional
 
 import lief
 
@@ -47,11 +48,11 @@ class BinaryInfo:
     """
 
     architecture = ""
-    base_addr = 0
-    binary = b""
-    raw_data = b""
+    base_addr: int = 0
+    binary: bytes = b""
+    raw_data: bytes = b""
     binary_size = 0
-    bitness = None
+    bitness: Optional[int] = None
     code_areas = None
     component = ""
     family = ""
@@ -70,7 +71,7 @@ class BinaryInfo:
     symbols = None
     oep = None
 
-    def __init__(self, binary):
+    def __init__(self, binary: bytes):
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)

--- a/src/smda/common/BlockLocator.py
+++ b/src/smda/common/BlockLocator.py
@@ -1,5 +1,8 @@
 import bisect
 import itertools
+from typing import Any, Dict, List, Optional
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 
 
 class BlockLocator:
@@ -7,8 +10,8 @@ class BlockLocator:
     When instantiated, creates the required data structures.
     """
 
-    sorted_blocks_addresses = None
-    blocks_dict = None
+    sorted_blocks_addresses: Optional[List[Any]] = None
+    blocks_dict: Optional[Dict[Any, SmdaBasicBlock]] = None
 
     def __init__(self, functions):
         # Instantiate the datastructures required :
@@ -23,7 +26,7 @@ class BlockLocator:
         last_ins = block.instructions[-1]
         return last_ins.offset + len(last_ins.bytes) // 2  # bytes is actuall a hex string
 
-    def findBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address) -> Optional[SmdaBasicBlock]:
         sorted_addresses = self.sorted_blocks_addresses
         if sorted_addresses is None:
             return None

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -1,16 +1,19 @@
 import hashlib
 import struct
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from smda.common.SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaFunction import SmdaFunction
 
 # sentinel distinguishing "hash not yet computed" from "hash computed as None (uncomputable)"
 _UNSET = object()
 
 
 class SmdaBasicBlock:
-    smda_function = None
-    instructions = None
+    smda_function: Optional["SmdaFunction"] = None
+    instructions: Optional[List[SmdaInstruction]] = None
     _picblockhash = _UNSET
     _opcblockhash = _UNSET
     offset = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -167,7 +167,7 @@ class SmdaFunction:
     is_exported = False
     architecture_metadata: Dict[str, Any] = {}
     # metadata
-    binweight = 0
+    binweight: float = 0.0
     characteristics: Optional[str] = ""
     confidence: Optional[float] = 0.0
     function_name = ""
@@ -177,6 +177,7 @@ class SmdaFunction:
     nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
+    _basic_blocks: Optional[List["SmdaBasicBlock"]] = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
@@ -380,7 +381,7 @@ class SmdaFunction:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset) -> List["SmdaInstruction"]:
+    def getInstructionsForBlock(self, offset):
         if offset is None:
             offset = self.offset
         if offset is None:

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -12,8 +12,8 @@ LOGGER = logging.getLogger(__name__)
 
 class SmdaInstruction:
     smda_function = None
-    offset = None
-    bytes = None
+    offset: Optional[int] = None
+    bytes: Optional[str] = None
     mnemonic = None
     operands = None
     detailed = None
@@ -186,7 +186,7 @@ class SmdaInstruction:
         return self.bytes
 
     @classmethod
-    def fromDict(cls, instruction_dict, smda_function=None) -> Optional["SmdaInstruction"]:
+    def fromDict(cls, instruction_dict, smda_function=None) -> "SmdaInstruction":
         smda_instruction = cls(None)
         smda_instruction.smda_function = smda_function
         smda_instruction.offset = instruction_dict[0]

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import zipfile
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from capstone import CS_ARCH_ARM64, CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_MODE_LITTLE_ENDIAN, Cs
 
@@ -67,10 +67,11 @@ class SmdaReport:
     abi = None
     base_addr = None
     binary_size = None
-    binweight = 0
+    binweight: float = 0.0
     bitness = None
-    block_locator = None
-    buffer = None
+    block_locator: Optional[BlockLocator] = None
+    buffer: Optional[bytes] = None
+    _sorted_functions: Optional[List["SmdaFunction"]] = None
     code_areas = None
     # immutable-by-convention sentinel: __init__ always rebinds this to a fresh list
     code_sections: List[Any] = []
@@ -99,19 +100,20 @@ class SmdaReport:
     xcfg: Dict[int, "SmdaFunction"] = {}
     xheader = None
     pe_header_hash = None
-    data_refs_from = None
+    data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
+    _string_cache: Dict[Any, Optional[Tuple[str, str]]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
     # in case we need to re-disassemble with more detail, we hold an initialized capstone instance as singleton
     capstone = None
 
-    def __init__(self, disassembly=None, config=None, buffer=None):
+    def __init__(self, disassembly=None, config=None, buffer: Optional[bytes] = None):
         # caches owned by SmdaReport but populated lazily by StringExtractor; declared here so
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
-        self._string_cache = {}
+        self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
         self._derefs_cache = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
@@ -128,7 +130,7 @@ class SmdaReport:
             self.abi = disassembly.binary_info.abi
             self.base_addr = disassembly.binary_info.base_addr
             self.binary_size = disassembly.binary_info.binary_size
-            self.binweight = 0
+            self.binweight = 0.0
             self.bitness = disassembly.binary_info.bitness
             self.buffer = buffer
             self.code_areas = disassembly.binary_info.code_areas
@@ -227,10 +229,10 @@ class SmdaReport:
         return self.xcfg.get(function_addr, None)
 
     def getFunctions(self) -> Iterator["SmdaFunction"]:
-        if getattr(self, "_sorted_functions", None) is None:
-            self._sorted_functions = []
-            if self.xcfg:
-                self._sorted_functions = [smda_function for _, smda_function in sorted(self.xcfg.items())]
+        if self._sorted_functions is None:
+            self._sorted_functions = (
+                [smda_function for _, smda_function in sorted(self.xcfg.items())] if self.xcfg else []
+            )
         yield from self._sorted_functions
 
     def getExportedFunctions(self):

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -136,8 +136,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._binary_info = None
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 0
         self._scan_ranges: List[Tuple[int, int]] = []
         self._func_symbols: Dict[int, str] = {}

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -227,11 +227,11 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._func_symbols = {}
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 32
-        self._code_start = 0
-        self._code_end = 0
+        self._code_start: int = 0
+        self._code_end: int = 0
         self._settings = None
 
     def update(self, binary_info):

--- a/src/smda/common/labelprovider/RustSymbolEvidence.py
+++ b/src/smda/common/labelprovider/RustSymbolEvidence.py
@@ -11,7 +11,7 @@ RUST_DEMANGLE_ERRORS = (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDem
 _LEGACY_RUST_HASHED_SYMBOL = re.compile(r"^(?:_)?_ZN.*17h[0-9a-f]{16}E(?:[.$].*)?$")
 
 
-def is_rust_language_evidence(name):
+def is_rust_language_evidence(name) -> bool:
     """Return whether a mangled name has Rust-specific, parseable structure."""
     if not name:
         return False

--- a/src/smda/common/labelprovider/rust_demangler/main.py
+++ b/src/smda/common/labelprovider/rust_demangler/main.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from .rust import RustDemangler
 
 _DEMANGLER = RustDemangler()
-_DEMANGLE_CACHE = {}
+_DEMANGLE_CACHE: Dict[str, Union[str, Exception]] = {}
 # the cache is process-lifetime and keyed by every mangled name ever seen; bound it so a
 # long-running batch cannot grow it without limit (the sibling demanglers use
 # lru_cache(maxsize=4096)). Results and exception objects are both cached, which lru_cache

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -71,7 +71,7 @@ class Ident:
         self.out_len = 0
 
     def try_small_punycode_decode(self) -> Optional[bool]:
-        def f(inp):
+        def f(inp) -> bool:
             inp = "".join(inp)
             self.disp += inp
             return True
@@ -495,9 +495,9 @@ class Printer:
     # self-referential backref chain raises RecursionError before this guard.
     RUST_MAX_RECURSION_COUNT = 256
 
-    def __init__(self, parser, out, bound, recursion=0):
+    def __init__(self, parser, out: str, bound, recursion=0):
         self.parser = parser
-        self.out = out
+        self.out: str = out
         self.bound_lifetime_depth = bound
         self.recursion = recursion
 
@@ -692,8 +692,8 @@ class Printer:
         try:
             p = self.parser_mut()
             tag = p.next_func()
-            if basic_type(tag):
-                ty = basic_type(tag)
+            ty = basic_type(tag)
+            if ty:
                 self.out += ty
                 return
 

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -323,7 +323,7 @@ class ElfSynthesizer(BinarySynthesizer):
                 )
         return segments
 
-    def _assembleFile(self, sections, segments, bitness, dynamic_range=None):
+    def _assembleFile(self, sections, segments, bitness, dynamic_range=None) -> bytes:
         is_64 = bitness == 64
         ehdr_size = 64 if is_64 else 52
         phent_size = 56 if is_64 else 32
@@ -553,7 +553,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
         return bytes(output)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         sections = self._prepareSections(sections, offsets, with_strings)
         import_map = self._getImportMap() if with_imports else {}
@@ -563,7 +563,7 @@ class ElfSynthesizer(BinarySynthesizer):
         segments = self._mergeSegments(sections)
         return self._assembleFile(sections, segments, bitness, dynamic_range)
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         bitness = self._getBitness()
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -505,7 +505,7 @@ class MachoSynthesizer(BinarySynthesizer):
         libs = sorted({lib for lib, _ in import_map.values() if lib})
         return strtab, symtab, indirect_blob, libs, len(indirect)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         is_64 = self._is64()
         segments = self._prepareSections(sections, offsets, with_strings)
         sections = [section for segment in segments for section in segment["sections"]]
@@ -737,7 +737,7 @@ class MachoSynthesizer(BinarySynthesizer):
             flags,
         )
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {"name": "__text", "va_start": va_start, "va_end": va_end}
         return self._synthesizeFromSections([section], offsets, False, False)

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -322,7 +322,7 @@ class PeSynthesizer(BinarySynthesizer):
         header += b"\x00" * (size_of_headers - len(header))
         return header
 
-    def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
+    def _synthesizeFromHeader(self, offsets, with_imports, with_strings) -> bytes:
         base = self.report.base_addr
         pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
@@ -451,7 +451,7 @@ class PeSynthesizer(BinarySynthesizer):
             return base
         return candidate
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000

--- a/src/smda/utility/DexFileLoader.py
+++ b/src/smda/utility/DexFileLoader.py
@@ -93,7 +93,7 @@ class DexFileLoader:
         return 0
 
     @staticmethod
-    def getBitness(data, parsed=None):
+    def getBitness(data, parsed=None) -> int:
         return 32
 
     @staticmethod

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -1,7 +1,7 @@
 import re
 import string
 import struct
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaFunction import SmdaFunction
@@ -20,14 +20,15 @@ def read_bytes(smda_report, va, num_bytes=None):
     """
 
     rva = va - smda_report.base_addr
-    if smda_report.buffer is None:
+    buffer = smda_report.buffer
+    if buffer is None:
         raise ValueError("buffer is empty")
-    buffer_end = len(smda_report.buffer)
+    buffer_end = len(buffer)
     max_bytes = num_bytes if num_bytes is not None else 0x100
     if rva + max_bytes > buffer_end:
-        return smda_report.buffer[rva:]
+        return buffer[rva:]
     else:
-        return smda_report.buffer[rva : rva + max_bytes]
+        return buffer[rva : rva + max_bytes]
 
 
 def derefs(smda_report, p):
@@ -166,7 +167,7 @@ def read_string(smda_report, offset, maxlen=None):
     return res
 
 
-def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int, int, str]]:
+def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, Any, Any, str]]:
     """parse string features from the given instruction."""
     if mode == "go":
         # we address stack assigned strings and String structs


### PR DESCRIPTION
## Problem

`CI / Code Quality` is red on `master` at 572acd7 ([run 33152590097](https://github.com/danielplohmann/smda/actions/runs/33152590097)). The Dependabot bump of `ty` 0.0.69 → 0.0.74 promoted the gradual-typing `unsound-*` family to errors: `ty` now treats an `Unknown` value flowing into an annotated return, assignment or yield as unsound rather than as gradual `Any`.

Against an unchanged tree, `ty==0.0.74` reports **41 errors** (31 `unsound-return-statement`, 5 `unsound-yield`, 3 `unsound-assignment`, 2 `invalid-assignment`) and exits 1. This is exactly the failure mode the pin comment in `pyproject.toml` already anticipated.

## What changed

- Keep **ty==0.0.74** and fix the tree rather than reverting the bump.
- Annotate the DTO and helper surfaces the errors actually point at: `BinaryInfo`, `SmdaReport`, `SmdaBasicBlock`, `SmdaFunction`, `SmdaInstruction`, `BlockLocator`, the ELF/Mach-O/PE synthesizers, the Delphi label providers, and the Rust demangler.
- `binweight` is annotated `float` on both `SmdaFunction` and `SmdaReport`, matching the value that is already computed (`float(sum(...))`) and serialized today — no runtime change.
- `SmdaReport.getFunctions` reads the declared `_sorted_functions` attribute directly instead of `getattr(self, ..., None)`, now that the attribute is declared on the class.
- The existing `src/smda/cil/CilDisassembler.py` override gains `unsound-assignment` / `unsound-return-statement`: dnfile/dncil expose heap lookups and PE reads as `Any`, so there is no annotation on our side that makes those sound.
- Dependabot now **ignores `ty`**. It is pinned deliberately because it ships new error rules in patch releases; bumping it belongs in a change that settles those rules, not in an unattended PR.

## Validation

- `ty check src/smda/ fuzzing/ profiling/ .github/workflows/scripts/` with **ty 0.0.74**: 0 errors, exit 0 (244 warnings, unchanged in kind from before the bump). Same paths as `make typecheck` / the Code Quality job.
- Baseline on `master` for comparison: 41 errors, exit 1.
- `ruff check .` and `ruff format --check .`: clean.
- Full test suite: see below.

No behavioral change is intended — the diff is annotations, one `Optional` tightening on `SmdaInstruction.fromDict` (which never returns `None`), and two local-variable hoists.

- Full suite on this branch: **1814 passed, 1 skipped, 2584 subtests passed** (exit 0).
