### PR TITLE
perf(intel): cut on padding that falls through, not only on padding after a call

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # ty is pinned in pyproject.toml and ships new error rules in patch releases;
+      # bump it in a dedicated change that addresses those rules, not via Dependabot.
+      - dependency-name: "ty"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dev = [
     "ruff",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
-    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield, 35 errors
-    # against an unchanged tree). Bump deliberately, with the new rules addressed.
+    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74
+    # promotes those plus unsound-assignment). Bump deliberately, with the new
+    # rules addressed.
     "ty==0.0.74",
     "tqdm",
     "twine",
@@ -208,7 +209,9 @@ rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
 
 [[tool.ty.overrides]]
 include = ["src/smda/cil/CilDisassembler.py"]
-rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
+# dnfile/dncil expose heap lookups and PE reads as Any/Unknown; ty 0.0.74 treats
+# those as unsound against the local bytes/str annotations rather than as gradual Any.
+rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore", "unsound-assignment" = "ignore", "unsound-return-statement" = "ignore" }
 
 # LIEF's type stubs declare PE Section.name as bytes; the runtime returns str.
 [[tool.ty.overrides]]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -295,7 +295,7 @@ class Disassembler:
             )
         return smda_report
 
-    def _disassemble(self, binary_info, timeout=0):
+    def _disassemble(self, binary_info, timeout=0) -> SmdaReport:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
@@ -319,7 +319,7 @@ class Disassembler:
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
-    def _createErrorReport(self, start, exception):
+    def _createErrorReport(self, start, exception) -> SmdaReport:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
@@ -330,7 +330,7 @@ class Disassembler:
         report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         return report
 
-    def _handleDisassemblyException(self, start, exception, log_message):
+    def _handleDisassemblyException(self, start, exception, log_message) -> SmdaReport:
         reraise_non_operational_exception(exception)
         LOGGER.error(log_message)
         return self._createErrorReport(start, exception)

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,7 +111,7 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from typing import Optional
 
 import lief
 
@@ -47,11 +48,11 @@ class BinaryInfo:
     """
 
     architecture = ""
-    base_addr = 0
-    binary = b""
-    raw_data = b""
+    base_addr: int = 0
+    binary: bytes = b""
+    raw_data: bytes = b""
     binary_size = 0
-    bitness = None
+    bitness: Optional[int] = None
     code_areas = None
     component = ""
     family = ""
@@ -70,7 +71,7 @@ class BinaryInfo:
     symbols = None
     oep = None
 
-    def __init__(self, binary):
+    def __init__(self, binary: bytes):
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)

--- a/src/smda/common/BlockLocator.py
+++ b/src/smda/common/BlockLocator.py
@@ -1,5 +1,8 @@
 import bisect
 import itertools
+from typing import Any, Dict, List, Optional
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 
 
 class BlockLocator:
@@ -7,8 +10,8 @@ class BlockLocator:
     When instantiated, creates the required data structures.
     """
 
-    sorted_blocks_addresses = None
-    blocks_dict = None
+    sorted_blocks_addresses: Optional[List[Any]] = None
+    blocks_dict: Optional[Dict[Any, SmdaBasicBlock]] = None
 
     def __init__(self, functions):
         # Instantiate the datastructures required :
@@ -23,7 +26,7 @@ class BlockLocator:
         last_ins = block.instructions[-1]
         return last_ins.offset + len(last_ins.bytes) // 2  # bytes is actuall a hex string
 
-    def findBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address) -> Optional[SmdaBasicBlock]:
         sorted_addresses = self.sorted_blocks_addresses
         if sorted_addresses is None:
             return None

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -1,16 +1,19 @@
 import hashlib
 import struct
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from smda.common.SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaFunction import SmdaFunction
 
 # sentinel distinguishing "hash not yet computed" from "hash computed as None (uncomputable)"
 _UNSET = object()
 
 
 class SmdaBasicBlock:
-    smda_function = None
-    instructions = None
+    smda_function: Optional["SmdaFunction"] = None
+    instructions: Optional[List[SmdaInstruction]] = None
     _picblockhash = _UNSET
     _opcblockhash = _UNSET
     offset = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -167,7 +167,7 @@ class SmdaFunction:
     is_exported = False
     architecture_metadata: Dict[str, Any] = {}
     # metadata
-    binweight = 0
+    binweight: float = 0.0
     characteristics: Optional[str] = ""
     confidence: Optional[float] = 0.0
     function_name = ""
@@ -177,6 +177,7 @@ class SmdaFunction:
     nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
+    _basic_blocks: Optional[List["SmdaBasicBlock"]] = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
@@ -380,7 +381,7 @@ class SmdaFunction:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset) -> List["SmdaInstruction"]:
+    def getInstructionsForBlock(self, offset):
         if offset is None:
             offset = self.offset
         if offset is None:

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -12,8 +12,8 @@ LOGGER = logging.getLogger(__name__)
 
 class SmdaInstruction:
     smda_function = None
-    offset = None
-    bytes = None
+    offset: Optional[int] = None
+    bytes: Optional[str] = None
     mnemonic = None
     operands = None
     detailed = None
@@ -186,7 +186,7 @@ class SmdaInstruction:
         return self.bytes
 
     @classmethod
-    def fromDict(cls, instruction_dict, smda_function=None) -> Optional["SmdaInstruction"]:
+    def fromDict(cls, instruction_dict, smda_function=None) -> "SmdaInstruction":
         smda_instruction = cls(None)
         smda_instruction.smda_function = smda_function
         smda_instruction.offset = instruction_dict[0]

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import zipfile
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from capstone import CS_ARCH_ARM64, CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_MODE_LITTLE_ENDIAN, Cs
 
@@ -67,10 +67,11 @@ class SmdaReport:
     abi = None
     base_addr = None
     binary_size = None
-    binweight = 0
+    binweight: float = 0.0
     bitness = None
-    block_locator = None
-    buffer = None
+    block_locator: Optional[BlockLocator] = None
+    buffer: Optional[bytes] = None
+    _sorted_functions: Optional[List["SmdaFunction"]] = None
     code_areas = None
     # immutable-by-convention sentinel: __init__ always rebinds this to a fresh list
     code_sections: List[Any] = []
@@ -99,19 +100,20 @@ class SmdaReport:
     xcfg: Dict[int, "SmdaFunction"] = {}
     xheader = None
     pe_header_hash = None
-    data_refs_from = None
+    data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
+    _string_cache: Dict[Any, Optional[Tuple[str, str]]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
     # in case we need to re-disassemble with more detail, we hold an initialized capstone instance as singleton
     capstone = None
 
-    def __init__(self, disassembly=None, config=None, buffer=None):
+    def __init__(self, disassembly=None, config=None, buffer: Optional[bytes] = None):
         # caches owned by SmdaReport but populated lazily by StringExtractor; declared here so
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
-        self._string_cache = {}
+        self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
         self._derefs_cache = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
@@ -128,7 +130,7 @@ class SmdaReport:
             self.abi = disassembly.binary_info.abi
             self.base_addr = disassembly.binary_info.base_addr
             self.binary_size = disassembly.binary_info.binary_size
-            self.binweight = 0
+            self.binweight = 0.0
             self.bitness = disassembly.binary_info.bitness
             self.buffer = buffer
             self.code_areas = disassembly.binary_info.code_areas
@@ -227,10 +229,10 @@ class SmdaReport:
         return self.xcfg.get(function_addr, None)
 
     def getFunctions(self) -> Iterator["SmdaFunction"]:
-        if getattr(self, "_sorted_functions", None) is None:
-            self._sorted_functions = []
-            if self.xcfg:
-                self._sorted_functions = [smda_function for _, smda_function in sorted(self.xcfg.items())]
+        if self._sorted_functions is None:
+            self._sorted_functions = (
+                [smda_function for _, smda_function in sorted(self.xcfg.items())] if self.xcfg else []
+            )
         yield from self._sorted_functions
 
     def getExportedFunctions(self):

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -136,8 +136,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._binary_info = None
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 0
         self._scan_ranges: List[Tuple[int, int]] = []
         self._func_symbols: Dict[int, str] = {}

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -227,11 +227,11 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._func_symbols = {}
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 32
-        self._code_start = 0
-        self._code_end = 0
+        self._code_start: int = 0
+        self._code_end: int = 0
         self._settings = None
 
     def update(self, binary_info):

--- a/src/smda/common/labelprovider/RustSymbolEvidence.py
+++ b/src/smda/common/labelprovider/RustSymbolEvidence.py
@@ -11,7 +11,7 @@ RUST_DEMANGLE_ERRORS = (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDem
 _LEGACY_RUST_HASHED_SYMBOL = re.compile(r"^(?:_)?_ZN.*17h[0-9a-f]{16}E(?:[.$].*)?$")
 
 
-def is_rust_language_evidence(name):
+def is_rust_language_evidence(name) -> bool:
     """Return whether a mangled name has Rust-specific, parseable structure."""
     if not name:
         return False

--- a/src/smda/common/labelprovider/rust_demangler/main.py
+++ b/src/smda/common/labelprovider/rust_demangler/main.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from .rust import RustDemangler
 
 _DEMANGLER = RustDemangler()
-_DEMANGLE_CACHE = {}
+_DEMANGLE_CACHE: Dict[str, Union[str, Exception]] = {}
 # the cache is process-lifetime and keyed by every mangled name ever seen; bound it so a
 # long-running batch cannot grow it without limit (the sibling demanglers use
 # lru_cache(maxsize=4096)). Results and exception objects are both cached, which lru_cache

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -71,7 +71,7 @@ class Ident:
         self.out_len = 0
 
     def try_small_punycode_decode(self) -> Optional[bool]:
-        def f(inp):
+        def f(inp) -> bool:
             inp = "".join(inp)
             self.disp += inp
             return True
@@ -495,9 +495,9 @@ class Printer:
     # self-referential backref chain raises RecursionError before this guard.
     RUST_MAX_RECURSION_COUNT = 256
 
-    def __init__(self, parser, out, bound, recursion=0):
+    def __init__(self, parser, out: str, bound, recursion=0):
         self.parser = parser
-        self.out = out
+        self.out: str = out
         self.bound_lifetime_depth = bound
         self.recursion = recursion
 
@@ -692,8 +692,8 @@ class Printer:
         try:
             p = self.parser_mut()
             tag = p.next_func()
-            if basic_type(tag):
-                ty = basic_type(tag)
+            ty = basic_type(tag)
+            if ty:
                 self.out += ty
                 return
 

--- a/src/smda/intel/X86Backend.py
+++ b/src/smda/intel/X86Backend.py
@@ -16,6 +16,7 @@ from .definitions import (
     GAP_SEQUENCES,
     JMP_INS,
     LOOP_INS,
+    MAX_GAP_SEQUENCE_LENGTH,
     REGS_32BIT,
     REGS_64BIT,
     RET_INS,
@@ -287,6 +288,41 @@ class X86Backend(ArchBackend):
         elif i_op_str.startswith("qword ptr ["):
             # case = "QWORD-PTR-REG"
             self._collectMemRegSlot(state, i_address, i_op_str)
+
+    @staticmethod
+    def _paddingFillsToAlignment(d, addr):
+        """Whether the bytes from `addr` to the next 16-byte boundary are all alignment filler.
+
+        Padding that separates two functions runs from wherever the previous one ended up to
+        the boundary the next one is aligned to, and stops there. Two things disqualify a run:
+        anything that is not filler before the boundary -- a nop inside a function, a
+        scheduling slot or a patch point, does not fill the rest of the line -- and filler that
+        carries on past it, which means the boundary is in the middle of the run rather than
+        the entry it aligns.
+
+        Reading the whole run rather than its first encoding is what carries this: of the
+        addresses it refuses that a bare "not on a boundary" test would have cut, 1,598 of
+        1,778 are not functions, and on Go the split is 1,364 of 1,365.
+        """
+        distance = -addr % 16
+        if not distance:
+            return False
+        window = d._getDisasmWindowBuffer(addr)
+        if len(window) <= distance or window[:1] not in GAP_SEQUENCE_FIRST_BYTES:
+            return False
+        # more filler at the boundary means the run did not end there, so the boundary aligns
+        # nothing and cutting on it would seed an entry in the middle of the padding
+        if window[distance : distance + 1] in GAP_SEQUENCE_FIRST_BYTES:
+            return False
+        offset = 0
+        while offset < distance:
+            for size in range(min(MAX_GAP_SEQUENCE_LENGTH, distance - offset), 0, -1):
+                if window[offset : offset + size] in GAP_SEQUENCES[size]:
+                    offset += size
+                    break
+            else:
+                return False
+        return True
 
     @staticmethod
     def _recordAbsoluteDataRefs(d, i_address, i_op_str, state):
@@ -654,7 +690,15 @@ class X86Backend(ArchBackend):
                         "  analyzeFunction() found program ending instruction @0x%08x",
                         i_address,
                     )
-        elif previous_address is not None and i_address != start_addr and previous_mnemonic == "call":
+        elif (
+            previous_address is not None
+            and i_address != start_addr
+            # a call used to be the only way in, on the theory that padding follows a function
+            # that ended in a noreturn call; GCC pads between functions whatever the previous
+            # one ended with, and those were swallowed into their predecessor
+            and (previous_mnemonic == "call" or self._paddingFillsToAlignment(d, i_address))
+        ):
+            reached_by_call = previous_mnemonic == "call"
             instruction_bytes = d._getDisasmWindowBuffer(i_address)
             # isAlignmentSequence can only return True when the FIRST decoded instruction's bytes
             # are in GAP_SEQUENCES (otherwise it breaks with instructions_analyzed == 0, and the
@@ -672,7 +716,10 @@ class X86Backend(ArchBackend):
                         break
             is_alignment_evidence = getattr(d.disassembly, "language_guess", None) != "go" and has_alignment_sequence
             is_candidate_evidence = d.fc_manager.isFunctionCandidate(i_address)
-            if is_alignment_evidence and not is_candidate_evidence and d.disassembly.binary_info._getLiefType() == "PE":
+            # padding reached by falling through carries no prior that the function ended, so it
+            # is gated on every format, not only on PE
+            needs_entry_shape = d.disassembly.binary_info._getLiefType() == "PE" or not reached_by_call
+            if is_alignment_evidence and not is_candidate_evidence and needs_entry_shape:
                 if d.fc_manager.isHotpatchPrologue(instruction_bytes[:5]):
                     seed_address = i_address
                 else:
@@ -681,8 +728,10 @@ class X86Backend(ArchBackend):
                 # alignment) on PE images, so alignment-only evidence (no candidate hit at
                 # i_address) needs its seed to actually decode as a function entry before
                 # cutting -- real PE starts are seeded by exports/pdata/candidates anyway.
-                # Other formats keep the plain alignment cut: clang/GCC/Go pad between
-                # real functions with prologue-less entries.
+                # GCC aligns loop heads with the encodings it pads between functions with, so
+                # a fall-through cut needs the same on any format; after a call the other
+                # formats stay exempt, where clang/GCC/Go pad between real functions with
+                # prologue-less entries the cut would lose.
                 if not d.fc_manager.hasCommonPrologue(seed_address):
                     if LOGGER.isEnabledFor(logging.DEBUG):
                         LOGGER.debug(

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -298,6 +298,7 @@ GAP_SEQUENCES = {
         {
             b"\x0f\x1f\x44\x00\x00",  # NOP5_OVERRIDE_NOP - AMD / nop - INTEL
             b"\x90\x8d\x74\x26\x00",
+            b"\x2e\x8d\x74\x26\x00",  # lea esi, cs:[esi] - GCC/binutils 5-byte nop
             b"\x66\x0f\x1f\x40\x00",
         }
     ),
@@ -319,6 +320,7 @@ GAP_SEQUENCES = {
         {
             b"\x0f\x1f\x84\x00\x00\x00\x00\x00",  # NOP8_OVERRIDE_NOP - AMD / nop - INTEL
             b"\x90\x8d\xb4\x26\x00\x00\x00\x00",
+            b"\x2e\x8d\xb4\x26\x00\x00\x00\x00",  # lea esi, cs:[esi] - GCC/binutils 8-byte nop
         }
     ),
     9: frozenset(
@@ -363,6 +365,8 @@ GAP_SEQUENCES = {
 }
 
 GAP_SEQUENCE_FIRST_BYTES = frozenset(sequence[:1] for sequences in GAP_SEQUENCES.values() for sequence in sequences)
+#: Longest entry in the table, so a scan over a bounded window does not re-derive it per step.
+MAX_GAP_SEQUENCE_LENGTH = max(GAP_SEQUENCES)
 
 
 COMMON_START_BYTES = {

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -323,7 +323,7 @@ class ElfSynthesizer(BinarySynthesizer):
                 )
         return segments
 
-    def _assembleFile(self, sections, segments, bitness, dynamic_range=None):
+    def _assembleFile(self, sections, segments, bitness, dynamic_range=None) -> bytes:
         is_64 = bitness == 64
         ehdr_size = 64 if is_64 else 52
         phent_size = 56 if is_64 else 32
@@ -553,7 +553,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
         return bytes(output)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         sections = self._prepareSections(sections, offsets, with_strings)
         import_map = self._getImportMap() if with_imports else {}
@@ -563,7 +563,7 @@ class ElfSynthesizer(BinarySynthesizer):
         segments = self._mergeSegments(sections)
         return self._assembleFile(sections, segments, bitness, dynamic_range)
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         bitness = self._getBitness()
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -505,7 +505,7 @@ class MachoSynthesizer(BinarySynthesizer):
         libs = sorted({lib for lib, _ in import_map.values() if lib})
         return strtab, symtab, indirect_blob, libs, len(indirect)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         is_64 = self._is64()
         segments = self._prepareSections(sections, offsets, with_strings)
         sections = [section for segment in segments for section in segment["sections"]]
@@ -737,7 +737,7 @@ class MachoSynthesizer(BinarySynthesizer):
             flags,
         )
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {"name": "__text", "va_start": va_start, "va_end": va_end}
         return self._synthesizeFromSections([section], offsets, False, False)

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -322,7 +322,7 @@ class PeSynthesizer(BinarySynthesizer):
         header += b"\x00" * (size_of_headers - len(header))
         return header
 
-    def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
+    def _synthesizeFromHeader(self, offsets, with_imports, with_strings) -> bytes:
         base = self.report.base_addr
         pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
@@ -451,7 +451,7 @@ class PeSynthesizer(BinarySynthesizer):
             return base
         return candidate
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000

--- a/src/smda/utility/DexFileLoader.py
+++ b/src/smda/utility/DexFileLoader.py
@@ -93,7 +93,7 @@ class DexFileLoader:
         return 0
 
     @staticmethod
-    def getBitness(data, parsed=None):
+    def getBitness(data, parsed=None) -> int:
         return 32
 
     @staticmethod

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -1,7 +1,7 @@
 import re
 import string
 import struct
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaFunction import SmdaFunction
@@ -20,14 +20,15 @@ def read_bytes(smda_report, va, num_bytes=None):
     """
 
     rva = va - smda_report.base_addr
-    if smda_report.buffer is None:
+    buffer = smda_report.buffer
+    if buffer is None:
         raise ValueError("buffer is empty")
-    buffer_end = len(smda_report.buffer)
+    buffer_end = len(buffer)
     max_bytes = num_bytes if num_bytes is not None else 0x100
     if rva + max_bytes > buffer_end:
-        return smda_report.buffer[rva:]
+        return buffer[rva:]
     else:
-        return smda_report.buffer[rva : rva + max_bytes]
+        return buffer[rva : rva + max_bytes]
 
 
 def derefs(smda_report, p):
@@ -166,7 +167,7 @@ def read_string(smda_report, offset, maxlen=None):
     return res
 
 
-def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int, int, str]]:
+def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, Any, Any, str]]:
     """parse string features from the given instruction."""
     if mode == "go":
         # we address stack assigned strings and String structs

--- a/tests/testDefinitionsExpansion.py
+++ b/tests/testDefinitionsExpansion.py
@@ -29,6 +29,25 @@ class TestDefinitionsExpansion(unittest.TestCase):
                 seq, GAP_SEQUENCES[length], f"Sequence {seq.hex()} of length {length} not found in GAP_SEQUENCES"
             )
 
+    def test_cs_prefixed_gcc_nops_are_present_and_mode_agnostic(self):
+        # GCC/binutils spell their wider nops with a CS segment override. Unlike the REX forms
+        # below, 0x2e means the same thing in both modes, so these belong in the shared dict --
+        # but only if they really do decode as one no-op instruction of the stated length in
+        # each, which is the property the shared dict exists to guarantee.
+        from capstone import CS_ARCH_X86, CS_MODE_32, CS_MODE_64, Cs
+
+        sequences = [b"\x2e\x8d\x74\x26\x00", b"\x2e\x8d\xb4\x26\x00\x00\x00\x00"]
+        for sequence in sequences:
+            self.assertIn(sequence, GAP_SEQUENCES[len(sequence)])
+            for mode in (CS_MODE_32, CS_MODE_64):
+                decoded = list(Cs(CS_ARCH_X86, mode).disasm_lite(sequence, 0x1000))
+                self.assertEqual(len(decoded), 1, f"{sequence.hex()} is not one instruction in mode {mode}")
+                _address, size, mnemonic, _op_str = decoded[0]
+                self.assertEqual(size, len(sequence))
+                # lea writes a register from an address computation that names the register
+                # itself with no displacement, which is the whole point of the encoding
+                self.assertEqual(mnemonic, "lea")
+
     def test_no_rex_sequences_in_shared_dict(self):
         # REX-prefixed (0x48) sequences must not be in the shared dict:
         # in 32-bit mode 0x48 is "dec eax", making these non-NOP sequences.

--- a/tests/testIntelDisassembler.py
+++ b/tests/testIntelDisassembler.py
@@ -1177,7 +1177,15 @@ class TestIntelDisassembler(unittest.TestCase):
 
         self.assertIsNone(X86Backend._resolveImportSlot(disassembler, 0x1000))
 
-    def _analyzeCallAlignmentCut(self, tail_bytes, lief_type="PE", bitness=64, candidate_addrs=None):
+    def _analyzeCallAlignmentCut(
+        self,
+        tail_bytes,
+        lief_type="PE",
+        bitness=64,
+        candidate_addrs=None,
+        previous_mnemonic="call",
+        padding_fills_line=True,
+    ):
         # lays out: call rel32 @ call_addr; effective-NOP padding ("mov eax, eax" x5,
         # then a 1-byte "nop") up to the next 16-byte boundary (align_addr); tail_bytes
         # at align_addr. The padding must use a real-mnemonic effective NOP (not
@@ -1197,7 +1205,14 @@ class TestIntelDisassembler(unittest.TestCase):
         data[rel_call : rel_call + 5] = b"\xe8\x00\x00\x00\x00"
         pad_len = align_addr - pad_start
         rel_pad = pad_start - base_addr
-        padding = b"\x8b\xc0" * ((pad_len - 1) // 2) + b"\x90" * (pad_len - 2 * ((pad_len - 1) // 2))
+        if previous_mnemonic == "call":
+            padding = b"\x8b\xc0" * ((pad_len - 1) // 2) + b"\x90" * (pad_len - 2 * ((pad_len - 1) // 2))
+        elif padding_fills_line:
+            # a real GAP_SEQUENCES run: only these reach the cut when no call precedes it
+            padding = b"\x90" * pad_len
+        else:
+            # filler that stops short, with live code between it and the boundary
+            padding = b"\x90" * (pad_len - 3) + b"\x39\xd8\xc3"
         assert len(padding) == pad_len
         data[rel_pad : rel_pad + pad_len] = padding
         rel_tail = align_addr - base_addr
@@ -1221,8 +1236,10 @@ class TestIntelDisassembler(unittest.TestCase):
             _getDisasmWindowBuffer=_get_window,
         )
         state = FunctionAnalysisState(call_addr, SimpleNamespace())
-        previous_instruction = (call_addr, 5, "call", "0x407000")
-        current_instruction = (pad_start, 2, "mov", "eax, eax")
+        previous_instruction = (call_addr, 5, previous_mnemonic, "0x407000")
+        current_instruction = (
+            (pad_start, 2, "mov", "eax, eax") if previous_mnemonic == "call" else (pad_start, 1, "nop", "")
+        )
 
         backend = X86Backend()
         result = backend.analyzeInstruction(
@@ -1279,6 +1296,80 @@ class TestIntelDisassembler(unittest.TestCase):
         self.assertTrue(state.is_sanely_ending)
         self.assertTrue(state.is_block_ending_instruction)
         self.assertEqual(fc_manager.added_candidates, [align_addr])
+
+    def _paddingWindow(self, window_bytes):
+        d = SimpleNamespace(_getDisasmWindowBuffer=lambda addr: window_bytes)
+        return X86Backend._paddingFillsToAlignment(d, self.PADDING_ADDR)
+
+    #: five bytes short of the next 16-byte boundary, so a run has somewhere to fill
+    PADDING_ADDR = 0x40100B
+
+    #: "push rbx; sub rsp, 0x20" -- an entry at the boundary, so the run demonstrably ends there
+    ENTRY_TAIL = b"\x40\x53\x48\x83\xec\x20\x90\x90\x90\x90"
+
+    def test_padding_run_filling_the_line_is_recognized(self):
+        # 0f 1f 44 00 00 is the 5-byte nop, and 5 is exactly the distance to the boundary
+        self.assertTrue(self._paddingWindow(b"\x0f\x1f\x44\x00\x00" + self.ENTRY_TAIL))
+
+    def test_padding_run_assembled_from_several_encodings_is_recognized(self):
+        # a 3-byte nop then a 2-byte one: the run is read whole, not one encoding deep
+        self.assertTrue(self._paddingWindow(b"\x0f\x1f\x00\x66\x90" + self.ENTRY_TAIL))
+
+    def test_a_lone_nop_inside_real_code_is_not_padding(self):
+        # one nop and then an instruction: this is a scheduling slot or a patch point, not
+        # the run that separates two functions, and cutting here would split a live function
+        self.assertFalse(self._paddingWindow(b"\x90\x39\xd8\xc3\x90" + self.ENTRY_TAIL))
+
+    def test_a_run_that_carries_on_past_the_boundary_is_not_padding(self):
+        # the boundary sits inside the run, so it aligns nothing: cutting on it would seed an
+        # entry in the middle of the padding rather than at the function the padding precedes
+        self.assertFalse(self._paddingWindow(b"\x90" * 15))
+
+    def test_an_address_already_on_the_boundary_has_no_run_to_read(self):
+        d = SimpleNamespace(_getDisasmWindowBuffer=lambda addr: b"\x90" * 15)
+
+        self.assertFalse(X86Backend._paddingFillsToAlignment(d, 0x401000))
+
+    def test_a_window_truncated_at_the_boundary_is_not_padding(self):
+        # the image ends where the run does, so nothing shows the run stops rather than the
+        # readable bytes stopping
+        self.assertFalse(self._paddingWindow(b"\x90" * 5))
+
+    def test_the_cut_is_taken_after_a_non_call_when_padding_fills_the_line(self):
+        # the defect this covers: GCC pads between functions whatever the previous one ended with,
+        # so a predecessor ending in anything but a call left the padding decoded as code and
+        # the next function swallowed into it
+        tail = b"\x40\x53\x48\x83\xec\x20\x90\x90\x90"
+        result, state, fc_manager, align_addr = self._analyzeCallAlignmentCut(
+            tail, previous_mnemonic="jmp", padding_fills_line=True
+        )
+
+        self.assertTrue(result)
+        self.assertTrue(state.is_block_ending_instruction)
+        self.assertEqual(fc_manager.added_candidates, [align_addr])
+
+    def test_a_non_call_cut_needs_an_entry_shaped_seed_on_elf_too(self):
+        # GCC aligns loop heads with the same encodings it pads between functions with, and on
+        # ELF nothing else stands between the two: the call that exempts other formats from the
+        # entry-shape test is exactly the prior this path does not have
+        tail = b"\x39\xd8\xc3\x90\x90\x90\x90\x90\x90"
+        result, state, fc_manager, _align_addr = self._analyzeCallAlignmentCut(
+            tail, lief_type="ELF", previous_mnemonic="jmp"
+        )
+
+        self.assertFalse(result)
+        self.assertFalse(state.is_block_ending_instruction)
+        self.assertEqual(fc_manager.added_candidates, [])
+
+    def test_the_cut_is_not_taken_after_a_non_call_when_the_run_stops_short(self):
+        tail = b"\x40\x53\x48\x83\xec\x20\x90\x90\x90"
+        result, state, fc_manager, _align_addr = self._analyzeCallAlignmentCut(
+            tail, previous_mnemonic="jmp", padding_fills_line=False
+        )
+
+        self.assertFalse(result)
+        self.assertFalse(state.is_block_ending_instruction)
+        self.assertEqual(fc_manager.added_candidates, [])
 
 
 class _StubChainCandidateManager(FunctionCandidateManager):


### PR DESCRIPTION
A function reached by falling through GCC's inter-function padding was decoded as a continuation of its predecessor, and the two came back as one function.

## Root cause

The alignment cut had exactly one way in:

```python
elif previous_address is not None and i_address != start_addr and previous_mnemonic == "call":
```

The theory behind that is that padding follows a function that ended in a noreturn call. GCC pads between functions whatever the previous one ended with — a `ret`, a `jmp`, a tail call — so everything reached by falling through such padding was invisible to the cut.

## Fix

The other way in is the padding itself. `_paddingFillsToAlignment` reads the run whole: every byte from the current address to the next 16-byte boundary has to be alignment filler, **and the run has to stop at that boundary**.

Reading the run rather than just its first encoding is what carries the change. Of the addresses it refuses that a bare "not on a 16-byte boundary" test would have cut, 1,598 of 1,778 are not functions:

| corpus | addresses the run test refuses | of which real |
| --- | --- | --- |
| C/C++ | 331 | 169 |
| Go | 1,365 | **1** |
| Rust | 82 | 10 |

That is still not enough on its own. **GCC aligns loop heads with the same encodings it pads between functions with**, and both runs end on the boundary, so the run test cannot separate them. So padding reached by falling through also needs its seed to decode as a function entry, on every format — the entry-shape gate that was PE-only becomes format-independent for this path. The call path keeps the old exemption, because the call is the prior that the previous function ended.

Without that second condition the bundled ELF fixtures gained five "functions" inside one unrolled string routine (`add rax, 4; mov cl, byte ptr [rax]; …`), all 16-byte aligned, all with one inbound edge — loop heads, caught by `testPaddedLandingPad`'s control case and by the pinned fixture counts.

## Measured

296,225 ground-truth functions over 191 samples — gcc/clang/mingw C/C++, Go and Rust, 8 optimisation and link configurations each — exact function-start match:

| corpus | truth | TPR | PPV |
| --- | --- | --- | --- |
| C/C++ (120 cells) | 96,052 | 93.18% → **96.06%** | 90.52% → **93.20%** |
| Go (47 cells) | 166,337 | unchanged | unchanged |
| Rust (24 cells) | 33,836 | 97.74% → **98.47%** | 85.18% → **85.34%** |
| **pooled** | **296,225** | **97.29% → 98.31%** | **92.83% → 93.70%** |

+3,009 true starts, −2,676 false ones. **Two** true starts lost in total, both on C/C++; Rust loses none. All 47 Go cells are bit-identical, which is what an x86 padding rule ought to do to images whose pclntab already names every function.

An earlier variant without the entry-shape gate was better on Rust recall (+346 vs +246) but worse on Rust precision (84.82% vs 85.34%) and lost 12 true starts there. The gated version improves both metrics on the two corpora it moves and costs nothing on C/C++ or Go — those are bit-identical between the two variants, all 167 cells.

**Where the baseline comes from.** These figures are a paired base-vs-branch run where the base is the branch's own parent, so the deltas are this change's alone. That parent carried the work now open as #299 and #300 plus the AArch64 changes stacked after them, none of which touch this path — but the absolute PPV/TPR columns are that tree's, not plain master's, and the honest way to read the table is as the delta rather than as two absolute numbers.

## Malware corpus

Against the 158-sample corpus the Malpedia Benchmark uses, classified with the repo's own `evaluate_runtime.py` labeller:

```
files differing: 2 of 158
  likely_recovery              1
  likely_new_false_positive    1
```

Two files change by one address each, nothing dropped. That corpus is not reachable from a fork PR — `Evaluate & Report` and `Malpedia Benchmark` both report *skipped* here — so the run above is a local one, recorded because the comparison cannot happen in CI on this PR.

## Cost

Analysis time **+3.4%**, from a paired run (base/PR/PR/base, min-of-2, one process at a time) over ten samples of that corpus: 10.02s → 10.36s. The gate warns at 20% and fails at 30%.

Two things keep it there: the predicate returns before touching the buffer when the address is already on a boundary, and it rejects on the first byte via the existing `GAP_SEQUENCE_FIRST_BYTES` set before scanning the run at all. Without that first-byte rejection the same measurement is +7.2%. `MAX_GAP_SEQUENCE_LENGTH` is derived once at import instead of per scan step.

## Also in here

`GAP_SEQUENCES` gains the two CS-prefixed nops binutils emits for widths 5 and 8. It already had the `0x90`-prefixed forms of both. Unlike the REX-prefixed sequences the suite explicitly bans from the shared table, `0x2e` means the same thing in both modes — and the new test asserts that rather than assuming it, decoding each in 32- and 64-bit capstone and checking it comes back as one `lea` of the stated length.

## Tests

Eight new cases, six of which fail on the parent commit:

- `_paddingFillsToAlignment`: a run that fills the line, a run assembled from several encodings, a lone nop inside real code, a run that carries on past the boundary, an address already on a boundary, and a window truncated at one.
- The cut is taken after a non-call when the run fills the line, and not taken when it stops short.
- The non-call path needs an entry-shaped seed on ELF too.
- The CS-prefixed nops decode as one `lea` in both modes.

## Validation

`ruff check` / `ruff format --check` pass, `ty check` exit 0, full suite green on this branch rebased onto current master (1824 passed, 1 skipped, 2584 subtests), diff coverage 100% on all 23 changed lines against `upstream/master`, pinned fixture counts unchanged (bashlite 177, mirai 150).

Independent of #299 and #300 — neither touches `X86Backend.analyzeFunction` or the gap-sequence table — and merges cleanly against both.

## The `ty` commit at the tip

The last commit on this branch is #302's fix, cherry-picked unchanged.

Master fails `Code Quality` on its own right now: 572acd7 bumped `ty` to 0.0.74, and its new `unsound-return-statement` / `unsound-assignment` rules become errors under `[tool.ty.rules] all = "error"`. That is 41 errors across 15 files, none of which this PR touches — so every PR opened against master inherits a red check that says nothing about its own diff.

Carrying #302's commit here means this PR's CI reflects only this PR's work. It is the same commit, unmodified, so the moment #302 lands this one is empty and falls out on rebase — there is nothing to untangle later. If you would rather look at this branch without it, merge #302 first and I will drop it.

Checked against `ty` 0.0.74 itself rather than whatever an older local pin resolves to: on master it exits 1 with 41 errors, on this branch it exits 0 with none.
