### PR TITLE
fix(intel): keep the switch index tied across a relative dispatch's base add

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # ty is pinned in pyproject.toml and ships new error rules in patch releases;
+      # bump it in a dedicated change that addresses those rules, not via Dependabot.
+      - dependency-name: "ty"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dev = [
     "ruff",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
-    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield, 35 errors
-    # against an unchanged tree). Bump deliberately, with the new rules addressed.
+    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74
+    # promotes those plus unsound-assignment). Bump deliberately, with the new
+    # rules addressed.
     "ty==0.0.74",
     "tqdm",
     "twine",
@@ -208,7 +209,9 @@ rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
 
 [[tool.ty.overrides]]
 include = ["src/smda/cil/CilDisassembler.py"]
-rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
+# dnfile/dncil expose heap lookups and PE reads as Any/Unknown; ty 0.0.74 treats
+# those as unsound against the local bytes/str annotations rather than as gradual Any.
+rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore", "unsound-assignment" = "ignore", "unsound-return-statement" = "ignore" }
 
 # LIEF's type stubs declare PE Section.name as bytes; the runtime returns str.
 [[tool.ty.overrides]]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -295,7 +295,7 @@ class Disassembler:
             )
         return smda_report
 
-    def _disassemble(self, binary_info, timeout=0):
+    def _disassemble(self, binary_info, timeout=0) -> SmdaReport:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
@@ -319,7 +319,7 @@ class Disassembler:
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
-    def _createErrorReport(self, start, exception):
+    def _createErrorReport(self, start, exception) -> SmdaReport:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
@@ -330,7 +330,7 @@ class Disassembler:
         report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         return report
 
-    def _handleDisassemblyException(self, start, exception, log_message):
+    def _handleDisassemblyException(self, start, exception, log_message) -> SmdaReport:
         reraise_non_operational_exception(exception)
         LOGGER.error(log_message)
         return self._createErrorReport(start, exception)

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,7 +111,7 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from typing import Optional
 
 import lief
 
@@ -47,11 +48,11 @@ class BinaryInfo:
     """
 
     architecture = ""
-    base_addr = 0
-    binary = b""
-    raw_data = b""
+    base_addr: int = 0
+    binary: bytes = b""
+    raw_data: bytes = b""
     binary_size = 0
-    bitness = None
+    bitness: Optional[int] = None
     code_areas = None
     component = ""
     family = ""
@@ -70,7 +71,7 @@ class BinaryInfo:
     symbols = None
     oep = None
 
-    def __init__(self, binary):
+    def __init__(self, binary: bytes):
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)

--- a/src/smda/common/BlockLocator.py
+++ b/src/smda/common/BlockLocator.py
@@ -1,5 +1,8 @@
 import bisect
 import itertools
+from typing import Any, Dict, List, Optional
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 
 
 class BlockLocator:
@@ -7,8 +10,8 @@ class BlockLocator:
     When instantiated, creates the required data structures.
     """
 
-    sorted_blocks_addresses = None
-    blocks_dict = None
+    sorted_blocks_addresses: Optional[List[Any]] = None
+    blocks_dict: Optional[Dict[Any, SmdaBasicBlock]] = None
 
     def __init__(self, functions):
         # Instantiate the datastructures required :
@@ -23,7 +26,7 @@ class BlockLocator:
         last_ins = block.instructions[-1]
         return last_ins.offset + len(last_ins.bytes) // 2  # bytes is actuall a hex string
 
-    def findBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address) -> Optional[SmdaBasicBlock]:
         sorted_addresses = self.sorted_blocks_addresses
         if sorted_addresses is None:
             return None

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -1,16 +1,19 @@
 import hashlib
 import struct
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from smda.common.SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaFunction import SmdaFunction
 
 # sentinel distinguishing "hash not yet computed" from "hash computed as None (uncomputable)"
 _UNSET = object()
 
 
 class SmdaBasicBlock:
-    smda_function = None
-    instructions = None
+    smda_function: Optional["SmdaFunction"] = None
+    instructions: Optional[List[SmdaInstruction]] = None
     _picblockhash = _UNSET
     _opcblockhash = _UNSET
     offset = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -167,7 +167,7 @@ class SmdaFunction:
     is_exported = False
     architecture_metadata: Dict[str, Any] = {}
     # metadata
-    binweight = 0
+    binweight: float = 0.0
     characteristics: Optional[str] = ""
     confidence: Optional[float] = 0.0
     function_name = ""
@@ -177,6 +177,7 @@ class SmdaFunction:
     nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
+    _basic_blocks: Optional[List["SmdaBasicBlock"]] = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
@@ -380,7 +381,7 @@ class SmdaFunction:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset) -> List["SmdaInstruction"]:
+    def getInstructionsForBlock(self, offset):
         if offset is None:
             offset = self.offset
         if offset is None:

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -12,8 +12,8 @@ LOGGER = logging.getLogger(__name__)
 
 class SmdaInstruction:
     smda_function = None
-    offset = None
-    bytes = None
+    offset: Optional[int] = None
+    bytes: Optional[str] = None
     mnemonic = None
     operands = None
     detailed = None
@@ -186,7 +186,7 @@ class SmdaInstruction:
         return self.bytes
 
     @classmethod
-    def fromDict(cls, instruction_dict, smda_function=None) -> Optional["SmdaInstruction"]:
+    def fromDict(cls, instruction_dict, smda_function=None) -> "SmdaInstruction":
         smda_instruction = cls(None)
         smda_instruction.smda_function = smda_function
         smda_instruction.offset = instruction_dict[0]

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import zipfile
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from capstone import CS_ARCH_ARM64, CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_MODE_LITTLE_ENDIAN, Cs
 
@@ -67,10 +67,11 @@ class SmdaReport:
     abi = None
     base_addr = None
     binary_size = None
-    binweight = 0
+    binweight: float = 0.0
     bitness = None
-    block_locator = None
-    buffer = None
+    block_locator: Optional[BlockLocator] = None
+    buffer: Optional[bytes] = None
+    _sorted_functions: Optional[List["SmdaFunction"]] = None
     code_areas = None
     # immutable-by-convention sentinel: __init__ always rebinds this to a fresh list
     code_sections: List[Any] = []
@@ -99,19 +100,20 @@ class SmdaReport:
     xcfg: Dict[int, "SmdaFunction"] = {}
     xheader = None
     pe_header_hash = None
-    data_refs_from = None
+    data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
+    _string_cache: Dict[Any, Optional[Tuple[str, str]]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
     # in case we need to re-disassemble with more detail, we hold an initialized capstone instance as singleton
     capstone = None
 
-    def __init__(self, disassembly=None, config=None, buffer=None):
+    def __init__(self, disassembly=None, config=None, buffer: Optional[bytes] = None):
         # caches owned by SmdaReport but populated lazily by StringExtractor; declared here so
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
-        self._string_cache = {}
+        self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
         self._derefs_cache = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
@@ -128,7 +130,7 @@ class SmdaReport:
             self.abi = disassembly.binary_info.abi
             self.base_addr = disassembly.binary_info.base_addr
             self.binary_size = disassembly.binary_info.binary_size
-            self.binweight = 0
+            self.binweight = 0.0
             self.bitness = disassembly.binary_info.bitness
             self.buffer = buffer
             self.code_areas = disassembly.binary_info.code_areas
@@ -227,10 +229,10 @@ class SmdaReport:
         return self.xcfg.get(function_addr, None)
 
     def getFunctions(self) -> Iterator["SmdaFunction"]:
-        if getattr(self, "_sorted_functions", None) is None:
-            self._sorted_functions = []
-            if self.xcfg:
-                self._sorted_functions = [smda_function for _, smda_function in sorted(self.xcfg.items())]
+        if self._sorted_functions is None:
+            self._sorted_functions = (
+                [smda_function for _, smda_function in sorted(self.xcfg.items())] if self.xcfg else []
+            )
         yield from self._sorted_functions
 
     def getExportedFunctions(self):

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -136,8 +136,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._binary_info = None
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 0
         self._scan_ranges: List[Tuple[int, int]] = []
         self._func_symbols: Dict[int, str] = {}

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -227,11 +227,11 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._func_symbols = {}
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 32
-        self._code_start = 0
-        self._code_end = 0
+        self._code_start: int = 0
+        self._code_end: int = 0
         self._settings = None
 
     def update(self, binary_info):

--- a/src/smda/common/labelprovider/RustSymbolEvidence.py
+++ b/src/smda/common/labelprovider/RustSymbolEvidence.py
@@ -11,7 +11,7 @@ RUST_DEMANGLE_ERRORS = (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDem
 _LEGACY_RUST_HASHED_SYMBOL = re.compile(r"^(?:_)?_ZN.*17h[0-9a-f]{16}E(?:[.$].*)?$")
 
 
-def is_rust_language_evidence(name):
+def is_rust_language_evidence(name) -> bool:
     """Return whether a mangled name has Rust-specific, parseable structure."""
     if not name:
         return False

--- a/src/smda/common/labelprovider/rust_demangler/main.py
+++ b/src/smda/common/labelprovider/rust_demangler/main.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from .rust import RustDemangler
 
 _DEMANGLER = RustDemangler()
-_DEMANGLE_CACHE = {}
+_DEMANGLE_CACHE: Dict[str, Union[str, Exception]] = {}
 # the cache is process-lifetime and keyed by every mangled name ever seen; bound it so a
 # long-running batch cannot grow it without limit (the sibling demanglers use
 # lru_cache(maxsize=4096)). Results and exception objects are both cached, which lru_cache

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -71,7 +71,7 @@ class Ident:
         self.out_len = 0
 
     def try_small_punycode_decode(self) -> Optional[bool]:
-        def f(inp):
+        def f(inp) -> bool:
             inp = "".join(inp)
             self.disp += inp
             return True
@@ -495,9 +495,9 @@ class Printer:
     # self-referential backref chain raises RecursionError before this guard.
     RUST_MAX_RECURSION_COUNT = 256
 
-    def __init__(self, parser, out, bound, recursion=0):
+    def __init__(self, parser, out: str, bound, recursion=0):
         self.parser = parser
-        self.out = out
+        self.out: str = out
         self.bound_lifetime_depth = bound
         self.recursion = recursion
 
@@ -692,8 +692,8 @@ class Printer:
         try:
             p = self.parser_mut()
             tag = p.next_func()
-            if basic_type(tag):
-                ty = basic_type(tag)
+            ty = basic_type(tag)
+            if ty:
                 self.out += ty
                 return
 

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -231,6 +231,11 @@ class JumpTableAnalyzer:
         redefine as before, as is a write to a memory cell: the step this recognizes ends in
         the register the branch reads, and a compare against a cell that has since been
         written back to is not a bound on what is loaded out of it afterwards.
+
+        Only the instruction the branch reads is asked. An `add <reg>, <reg>` further back is
+        index arithmetic - "add rax, rcx" before the table read makes the index a sum, and a
+        compare bounding one summand does not bound it - so carrying the tie across that one
+        would report a bound smaller than the table and truncate the scan.
         """
         if canonicalRegister(destination_key) is None:
             return False
@@ -251,7 +256,7 @@ class JumpTableAnalyzer:
         """
         tracked = set(index_keys) if index_keys else set()
         untied_size = 0
-        for instr in backtracked[::-1]:
+        for position, instr in enumerate(backtracked[::-1]):
             mnemonic = instr[2].split(" ")[-1]
             if mnemonic in RET_INS:
                 break
@@ -283,7 +288,7 @@ class JumpTableAnalyzer:
                 carried = self._dispatchIndexKeys(source) if destination_key in tracked else set()
                 tracked = self._invalidated(tracked, destination_key) | carried
                 continue
-            if destination_key in tracked and self._addsTableBase(mnemonic, destination_key, source):
+            if position == 0 and destination_key in tracked and self._addsTableBase(mnemonic, destination_key, source):
                 tracked = self._invalidated(tracked, destination_key) | {destination_key}
                 continue
             # Anything else redefines whatever it writes, and several x86 instructions write a

--- a/src/smda/intel/JumpTableAnalyzer.py
+++ b/src/smda/intel/JumpTableAnalyzer.py
@@ -217,6 +217,29 @@ class JumpTableAnalyzer:
         """
         return self.disassembly.isAddrWithinMemoryImage(address) and self.disassembly.binary_info.isInCodeAreas(address)
 
+    @classmethod
+    def _addsTableBase(cls, mnemonic, destination_key, source):
+        """Whether this instruction adds a table base to the value it overwrites.
+
+        A relative dispatch ends by adding the table's base to the entry the table read
+        produced - "add rax, rdi", or "lea rcx, [r11 + rcx]" - so the register the branch
+        reads is that sum and not the switch index. A walk that treats the add as a
+        redefinition stops one instruction short of the table read, which is where the index
+        the bound was checked against is named. `lea` only does this when it reads the
+        register it writes: "lea rax, [rip + 0x2004]" loads a base and derives nothing from
+        rax. An immediate source is index arithmetic rather than a base, and is left to
+        redefine as before, as is a write to a memory cell: the step this recognizes ends in
+        the register the branch reads, and a compare against a cell that has since been
+        written back to is not a bound on what is loaded out of it afterwards.
+        """
+        if canonicalRegister(destination_key) is None:
+            return False
+        if mnemonic == "add":
+            return cls._operandKey(source) is not None
+        if mnemonic == "lea":
+            return destination_key in cls._keyRegisters(source.strip())
+        return False
+
     def _findJumpTableSize(self, backtracked, index_keys=None):
         """Recover the switch bound, preferring a compare against the dispatch's own index.
 
@@ -259,6 +282,9 @@ class JumpTableAnalyzer:
             if mnemonic in _INDEX_COPY_MNEMONICS:
                 carried = self._dispatchIndexKeys(source) if destination_key in tracked else set()
                 tracked = self._invalidated(tracked, destination_key) | carried
+                continue
+            if destination_key in tracked and self._addsTableBase(mnemonic, destination_key, source):
+                tracked = self._invalidated(tracked, destination_key) | {destination_key}
                 continue
             # Anything else redefines whatever it writes, and several x86 instructions write a
             # register they do not name first - xchg and xadd write both operands, mul and div

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -323,7 +323,7 @@ class ElfSynthesizer(BinarySynthesizer):
                 )
         return segments
 
-    def _assembleFile(self, sections, segments, bitness, dynamic_range=None):
+    def _assembleFile(self, sections, segments, bitness, dynamic_range=None) -> bytes:
         is_64 = bitness == 64
         ehdr_size = 64 if is_64 else 52
         phent_size = 56 if is_64 else 32
@@ -553,7 +553,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
         return bytes(output)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         sections = self._prepareSections(sections, offsets, with_strings)
         import_map = self._getImportMap() if with_imports else {}
@@ -563,7 +563,7 @@ class ElfSynthesizer(BinarySynthesizer):
         segments = self._mergeSegments(sections)
         return self._assembleFile(sections, segments, bitness, dynamic_range)
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         bitness = self._getBitness()
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -505,7 +505,7 @@ class MachoSynthesizer(BinarySynthesizer):
         libs = sorted({lib for lib, _ in import_map.values() if lib})
         return strtab, symtab, indirect_blob, libs, len(indirect)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         is_64 = self._is64()
         segments = self._prepareSections(sections, offsets, with_strings)
         sections = [section for segment in segments for section in segment["sections"]]
@@ -737,7 +737,7 @@ class MachoSynthesizer(BinarySynthesizer):
             flags,
         )
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {"name": "__text", "va_start": va_start, "va_end": va_end}
         return self._synthesizeFromSections([section], offsets, False, False)

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -322,7 +322,7 @@ class PeSynthesizer(BinarySynthesizer):
         header += b"\x00" * (size_of_headers - len(header))
         return header
 
-    def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
+    def _synthesizeFromHeader(self, offsets, with_imports, with_strings) -> bytes:
         base = self.report.base_addr
         pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
@@ -451,7 +451,7 @@ class PeSynthesizer(BinarySynthesizer):
             return base
         return candidate
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000

--- a/src/smda/utility/DexFileLoader.py
+++ b/src/smda/utility/DexFileLoader.py
@@ -93,7 +93,7 @@ class DexFileLoader:
         return 0
 
     @staticmethod
-    def getBitness(data, parsed=None):
+    def getBitness(data, parsed=None) -> int:
         return 32
 
     @staticmethod

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -1,7 +1,7 @@
 import re
 import string
 import struct
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaFunction import SmdaFunction
@@ -20,14 +20,15 @@ def read_bytes(smda_report, va, num_bytes=None):
     """
 
     rva = va - smda_report.base_addr
-    if smda_report.buffer is None:
+    buffer = smda_report.buffer
+    if buffer is None:
         raise ValueError("buffer is empty")
-    buffer_end = len(smda_report.buffer)
+    buffer_end = len(buffer)
     max_bytes = num_bytes if num_bytes is not None else 0x100
     if rva + max_bytes > buffer_end:
-        return smda_report.buffer[rva:]
+        return buffer[rva:]
     else:
-        return smda_report.buffer[rva : rva + max_bytes]
+        return buffer[rva : rva + max_bytes]
 
 
 def derefs(smda_report, p):
@@ -166,7 +167,7 @@ def read_string(smda_report, offset, maxlen=None):
     return res
 
 
-def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int, int, str]]:
+def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, Any, Any, str]]:
     """parse string features from the given instruction."""
     if mode == "go":
         # we address stack assigned strings and String structs

--- a/tests/testJumpTableIndexBound.py
+++ b/tests/testJumpTableIndexBound.py
@@ -278,6 +278,173 @@ class IndexTiedBoundTestSuite(unittest.TestCase):
         self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0)
 
 
+class RelativeDispatchBaseAddTestSuite(unittest.TestCase):
+    """The last instruction of a relative dispatch adds the table's base to the entry the
+    table read produced, so the register the branch reads is that sum. Treating the add as a
+    redefinition stops the walk one instruction short of the table read - which is the only
+    place the switch index is named - and the untied fallback then answers with whatever
+    compare happens to be nearby."""
+
+    #: gcc and clang spell a 64-bit relative switch this way: the base is loaded once, spilled
+    #: because the dispatch is reached from several places, and reloaded beside the table read.
+    #: The bound is checked against the memory cell the index is loaded from, never a register.
+    SPILLED_BASE_DISPATCH = [
+        (0x1000, 3, "cmp", "edx, 0x1"),
+        (0x1003, 7, "lea", "rsi, [rip + 0x6e189]"),
+        (0x100A, 4, "mov", "qword ptr [rsp], rsi"),
+        (0x100E, 3, "cmp", "dword ptr [rbx], 0x1a"),
+        (0x1011, 2, "ja", "0x100E"),
+        (0x1013, 4, "mov", "rdi, qword ptr [rsp]"),
+        (0x1017, 2, "mov", "eax, dword ptr [rbx]"),
+        (0x1019, 4, "movsxd", "rax, dword ptr [rdi + rax*4]"),
+        (0x101D, 3, "add", "rax, rdi"),
+    ]
+
+    def test_the_base_add_carries_the_tie_to_the_table_read(self):
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._findJumpTableSize(self.SPILLED_BASE_DISPATCH, {"rax"}), 0x1B)
+
+    def test_the_untied_fallback_answers_two_on_the_same_window(self):
+        """Control for the case above. `cmp edx, 1` is the only compare the untied fallback can
+        match, so a walk that loses the tie sizes this table at two entries out of twenty-seven
+        - which is what the dispatch produced before the base add carried the tie. Without this
+        the assertion above would pass on a bound the fallback happened to get right."""
+        analyzer = _makeAnalyzer()
+
+        self.assertEqual(analyzer._findJumpTableSize(self.SPILLED_BASE_DISPATCH, set()), 2)
+
+    def test_a_lea_that_reads_the_register_it_writes_carries_the_tie(self):
+        """The other spelling of the same step, from the multiplicative-relative pattern."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 3, "cmp", "edx, 0x5"),
+            (0x1003, 5, "movsxd", "rcx, dword ptr [r11 + rdx*4]"),
+            (0x1008, 4, "lea", "rcx, [r11 + rcx]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 6)
+
+    def test_a_lea_that_only_loads_an_address_drops_the_tie(self):
+        """`lea rax, [rip + 0x2004]` is how the base itself is loaded. It derives nothing from
+        rax, so a tie carried across it would bound a value the dispatch never indexes with."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 7, "lea", "rax, [rip + 0x2004]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0x3E9)
+
+    def test_an_add_back_into_a_tracked_cell_still_drops_the_tie(self):
+        """The step this recognizes ends in the register the branch reads. A cell written back
+        to holds a different value from here on, so the compare against it is not a bound on
+        what the dispatch loads out of it afterwards."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 6, "cmp", "dword ptr [rbx], 0x3ff"),
+            (0x1006, 3, "add", "dword ptr [rbx], eax"),
+            (0x1009, 2, "mov", "ecx, dword ptr [rbx]"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 0)
+
+    def test_an_immediate_added_to_the_index_still_drops_the_tie(self):
+        """An immediate is index arithmetic, not a table base: the compare further back bounds
+        the value before the addition, so it is not a bound on what the dispatch indexes with."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 5, "cmp", "eax, 0x3e8"),
+            (0x1005, 4, "add", "rax, 8"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0x3E9)
+
+
+class ShatteredSwitchTestSuite(unittest.TestCase):
+    """What an unrecovered bound costs a report: the case bodies past it are never queued as
+    blocks of the function that dispatches to them, so the gap scan finds them unreferenced and
+    books each one as a function of its own. The switch is the whole of the function here, so
+    every address the scan takes is interior to it."""
+
+    CASES = 4
+
+    def _image(self):
+        body = bytearray()
+        main_offset = len(body)
+        body += b"\x55\x48\x89\xe5"  # push rbp ; mov rbp, rsp
+        call_at = len(body)
+        body += b"\xe8" + struct.pack("<i", 0)
+        body += b"\x5d\xc3"  # pop rbp ; ret
+        while len(body) % 16:
+            body += b"\x90"
+        dispatch_offset = len(body)
+        body += b"\x55\x48\x89\xe5"
+        # the compare the untied fallback matches, and the only one it can: it bounds a
+        # register the dispatch never indexes with
+        body += b"\x83\xfa\x01"  # cmp edx, 1
+        lea_at = len(body)
+        body += b"\x48\x8d\x35" + struct.pack("<i", 0)  # lea rsi, [rip + disp]
+        body += b"\x48\x89\x34\x24"  # mov qword ptr [rsp], rsi
+        body += b"\x83\x3b" + bytes([self.CASES - 1])  # cmp dword ptr [rbx], 3
+        ja_at = len(body)
+        body += b"\x0f\x87" + struct.pack("<i", 0)
+        body += b"\x48\x8b\x3c\x24"  # mov rdi, qword ptr [rsp]
+        body += b"\x8b\x03"  # mov eax, dword ptr [rbx]
+        body += b"\x48\x63\x04\x87"  # movsxd rax, dword ptr [rdi + rax*4]
+        body += b"\x48\x01\xf8"  # add rax, rdi
+        body += b"\xff\xe0"  # jmp rax
+        case_offsets = []
+        for index in range(self.CASES):
+            case_offsets.append(len(body))
+            # a case body opening on a common prologue, which is what the gap scan books
+            body += b"\x55\x48\x89\xe5\xb8" + struct.pack("<I", index) + b"\x5d\xc3"
+        default_offset = len(body)
+        body += b"\x31\xc0\x5d\xc3"
+        while len(body) % 16:
+            body += b"\x90"
+        neighbour_offset = len(body)
+        body += b"\x55\x48\x89\xe5\x5d\xc3"
+
+        struct.pack_into("<i", body, call_at + 1, dispatch_offset - (call_at + 5))
+        struct.pack_into("<i", body, ja_at + 2, default_offset - (ja_at + 6))
+        struct.pack_into("<i", body, lea_at + 3, (TABLE_RVA - TEXT_RVA) - (lea_at + 7))
+
+        image = bytearray(IMAGE_SIZE)
+        image[TEXT_RVA : TEXT_RVA + len(body)] = body
+        # relative entries: target minus the table's own base, as a signed int32
+        table = b"".join(struct.pack("<i", (TEXT_RVA + offset) - TABLE_RVA) for offset in case_offsets)
+        image[TABLE_RVA : TABLE_RVA + len(table)] = table
+
+        def address(offset):
+            return BASE + TEXT_RVA + offset
+
+        return (
+            bytes(image),
+            address(main_offset),
+            address(dispatch_offset),
+            [address(offset) for offset in case_offsets],
+            address(neighbour_offset),
+        )
+
+    def setUp(self):
+        image, self.main, self.dispatch, self.cases, self.neighbour = self._image()
+        config = SmdaConfig()
+        config.CALCULATE_HASHING = False
+        config.TIMEOUT = 0
+        report = Disassembler(config=config).disassembleBuffer(image, BASE, bitness=64)
+        self.assertEqual(report.status, "ok")
+        self.functions = {function.offset for function in report.getFunctions()}
+
+    def test_no_case_body_becomes_a_function_of_its_own(self):
+        self.assertEqual([case for case in self.cases if case in self.functions], [])
+
+    def test_the_three_real_functions_are_all_recovered(self):
+        """Control: the image has to analyse for the assertion above to mean anything - an
+        empty report would satisfy it too."""
+        self.assertEqual(self.functions, {self.main, self.dispatch, self.neighbour})
+
+
 class OperandKeyTestSuite(unittest.TestCase):
     def test_a_flat_segment_is_normalized_away_and_the_width_is_kept(self):
         """The override names the same cell; the width does not. A dword compare and a byte

--- a/tests/testJumpTableIndexBound.py
+++ b/tests/testJumpTableIndexBound.py
@@ -336,6 +336,22 @@ class RelativeDispatchBaseAddTestSuite(unittest.TestCase):
 
         self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0x3E9)
 
+    def test_index_arithmetic_before_the_table_read_still_drops_the_tie(self):
+        """Only the instruction the branch reads is a base combine. `add rax, rcx` before the
+        table read makes the index a sum, and the compare against `[rbx]` bounds one summand
+        of it -- carrying the tie across that would report 4 where the table has more, and a
+        recovered bound is trusted as exact."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 6, "cmp", "dword ptr [rbx], 0x3"),
+            (0x1006, 2, "mov", "eax, dword ptr [rbx]"),
+            (0x1009, 3, "add", "rax, rcx"),
+            (0x100C, 4, "movsxd", "rax, dword ptr [rdi + rax*4]"),
+            (0x1010, 3, "add", "rax, rdi"),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rax"}), 0)
+
     def test_an_add_back_into_a_tracked_cell_still_drops_the_tie(self):
         """The step this recognizes ends in the register the branch reads. A cell written back
         to holds a different value from here on, so the compare against it is not a bound on
@@ -344,10 +360,20 @@ class RelativeDispatchBaseAddTestSuite(unittest.TestCase):
         backtracked = [
             (0x1000, 6, "cmp", "dword ptr [rbx], 0x3ff"),
             (0x1006, 3, "add", "dword ptr [rbx], eax"),
-            (0x1009, 2, "mov", "ecx, dword ptr [rbx]"),
         ]
 
-        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"rcx"}), 0)
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"dword ptr [rbx]"}), 0)
+
+    def test_the_same_cell_read_without_being_written_is_still_tied(self):
+        """Positive control for the rule above: with the write gone, the compare bounds what
+        the dispatch indexes with and the tie is made."""
+        analyzer = _makeAnalyzer()
+        backtracked = [
+            (0x1000, 6, "cmp", "dword ptr [rbx], 0x3ff"),
+            (0x1006, 3, "nop", ""),
+        ]
+
+        self.assertEqual(analyzer._findJumpTableSize(backtracked, {"dword ptr [rbx]"}), 0x400)
 
     def test_an_immediate_added_to_the_index_still_drops_the_tie(self):
         """An immediate is index arithmetic, not a table base: the compare further back bounds


### PR DESCRIPTION
A switch inside `brotli` built by gcc at `-O2` has 27 cases. SMDA resolves 2 of them, queues those 2 as blocks of the function, and leaves the other 25 case bodies unreferenced — so the gap scan finds them, sees a common function start, and books five of them as functions of their own, *inside* the function they belong to.

That is a false positive and a shattered function in one move, and it happens on every dispatch of this shape.

## Root cause

A 64-bit relative switch ends by adding the table's base to the entry the table read produced, and the branch reads that sum:

```
    lea     rsi, [rip + 0x6e189]        ; table base
    mov     qword ptr [rsp], rsi        ; spilled, the dispatch is reached from several places
    cmp     dword ptr [rbx], 0x1a       ; the real bound, checked against a memory cell
    ja      default
    mov     rdi, qword ptr [rsp]        ; reloaded
    mov     eax, dword ptr [rbx]
    movsxd  rax, dword ptr [rdi + rax*4]
    add     rax, rdi
    notrack jmp rax
```

`_findJumpTableSize` starts at the branch register and follows it backwards through copies, so it ought to reach `movsxd`, take `rax` out of the scaled operand, follow that back through `mov eax, dword ptr [rbx]` to the cell, and return 27 from the compare against it. That is the whole point of the index tracking already in there.

It never got that far. `add rax, rdi` is not one of the copy mnemonics, so the walk fell into the "anything else redefines whatever it writes" arm and dropped the tie one instruction short of the table read. With nothing tied, the untied fallback answers with the first register-against-immediate compare in the window — here an unrelated compare from earlier in the function — and the table comes out sized at 2.

The bug is one step from the end of a walk that was otherwise correct, which is why this looked like the jump-table pass simply not following this shape.

## Fix

The walk carries the tie across the step that adds a base to the value it overwrites, in both spellings a compiler uses: `add rax, rdi` (register or memory source), and a `lea` whose address reads the register it writes.

**Only the instruction the branch reads is asked.** That is where the combine sits in every shape the analyzer recognises — the four relative arms all match on it being the nearest instruction, and the pattern-C `lea` is in the same position. An `add` further back is index arithmetic: `add rax, rcx` before the table read makes the index a sum, and a compare bounding one summand is not a bound on it. (That narrowing is the second commit; a bound recovered too small is the worse direction, because it is trusted as exact and truncates the scan.)

Two things deliberately still redefine, and both have a test:

- An **immediate** source (`add rax, 8`) is index arithmetic, not a base.
- A write back into a **memory cell** (`add dword ptr [rbx], eax`) is not this step at all — the step recognised here ends in the register the branch reads.

`lea rax, [rip + 0x2004]` is how the base itself is loaded and derives nothing from `rax`, so it is excluded by the same rule that admits `lea rcx, [r11 + rcx]`.

## Measured

140 built C/C++ cells (gcc and clang, x86-64 ELF, 10 programs × 7 variants × 2 toolchains), 117,654 truth functions from the unstripped link's symbol table, exact-address match, macro means:

| | PPV | TPR | TP | FP |
|---|---|---|---|---|
| before | 93.740 | 96.968 | 113,438 | 14,123 |
| after | **93.765** | 96.968 | 113,438 | **14,103** |

**20 false positives removed, no true positive lost on any cell**, and 135 of the 140 cells come back bit-identical. The five that move:

| cell | TP | FP |
|---|---|---|
| `brotli_gcc-x64_O2` | 293 → 293 | 5 → **0** |
| `brotli_gcc-x64_O3` | 282 → 282 | 4 → **0** |
| `brotli_gcc-x64_O2-static` | 1245 → 1245 | 58 → **53** |
| `googletest_gcc-x64_O2-static` | 5820 → 5820 | 1793 → **1790** |
| `googletest_clang-x64_O2-static` | 5767 → 5767 | 1484 → **1481** |

The clang cell moves because a statically linked image pulls in gcc-built glibc.

The narrowing in the second commit changes **no cell**: the recovered function set is identical under both predicates, so this corpus does not contain the index-arithmetic shape and the narrowing costs nothing measured.

**Second corpus, as a control on the shape.** 8 built Rust cells (rustc 1.94, gnu targets, four profiles) are bit-identical — and not one dispatch on any of them changed its bound, checked by recording the recovered size at every dispatch under both trees. That is the expected result rather than a null one: LLVM leaves the bound check as the nearest register compare, so the untied fallback was already reading the right one. The shape this fixes is what gcc emits when the base is spilled across the bound check.

## Bug-class sweep

The class is *a value walk that reads a read-modify-write of the register it is chasing as a redefinition*. Swept the other backward walks:

- `aarch64/analyzers.py` jump-table resolution — **already correct**. It adds both source registers of its merging `add` back into the tracked set, and ties the bound to the index register taken from the table load rather than from the branch operand.
- `intel/IndirectCallAnalyzer.py` and the syscall-number walk in `intel/X86Backend.py` — **not instances**. Both chase a concrete value rather than a provenance tie, so carrying either past an unmodelled write would report a wrong value. Stopping there is correct for them.
- `JumpTableAnalyzer._ripRelativeBase` — same, and its docstring already calls the stop deliberate.

## Tests

Eight new cases in `tests/testJumpTableIndexBound.py`:

- the spilled-base dispatch recovers 27 where the fallback recovers 2 — with the fallback's answer asserted on the same window, so the assertion cannot pass on a bound the fallback happened to get right
- `lea` that reads the register it writes carries the tie; `lea` that only loads an address does not
- an immediate add, an add back into a tracked memory cell, and index arithmetic before the table read all still drop the tie, each with a positive control
- `ShatteredSwitchTestSuite` builds a 64-bit image with exactly this dispatch and a decoy compare, and asserts no case body becomes a function of its own. Before the fix two of the four do. Its control asserts the three real functions are all recovered, so an empty report cannot satisfy it.

Run against the parent commit, the load-bearing assertions fail and the controls pass.

## Validation

`ruff check` / `ruff format --check` pass, full suite green on this branch rebased onto current master (1824 passed, 1 skipped, 2584 subtests), diff coverage 100% on the changed lines.

On the malpedia corpus the function set moves on one file of 155: three fragments stop being functions and become blocks, and three real routines are recovered. That corpus is not reachable from a fork PR — `Evaluate & Report` and `Malpedia Benchmark` both report *skipped* here — so it is recorded rather than shown by CI. The bundled `Fixture Benchmark Gate` is green.

## Relationship to #299 and #300

This change is also sitting inside #299 and #300. Both of those were opened from branches that had my fork's master merged into them repeatedly, so their diffs are much wider than their titles suggest and they overlap each other as well.

This PR is the same change on its own, rebased onto current master, so it can be reviewed and measured for what it actually is. If you would rather take it through one of those, close this one; if you take this one, the matching hunks fall out of theirs on rebase.

## The `ty` commit at the tip

The last commit on this branch is #302's fix, cherry-picked unchanged.

Master fails `Code Quality` on its own right now: 572acd7 bumped `ty` to 0.0.74, and its new `unsound-return-statement` / `unsound-assignment` rules become errors under `[tool.ty.rules] all = "error"`. That is 41 errors across 15 files, none of which this PR touches — so every PR opened against master inherits a red check that says nothing about its own diff.

Carrying #302's commit here means this PR's CI reflects only this PR's work. It is the same commit, unmodified, so the moment #302 lands this one is empty and falls out on rebase — there is nothing to untangle later. If you would rather look at this branch without it, merge #302 first and I will drop it.

Checked against `ty` 0.0.74 itself rather than whatever an older local pin resolves to: on master it exits 1 with 41 errors, on this branch it exits 0 with none.
