### PR TITLE
fix(aarch64): stop recording a branch target as an inbound call reference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # ty is pinned in pyproject.toml and ships new error rules in patch releases;
+      # bump it in a dedicated change that addresses those rules, not via Dependabot.
+      - dependency-name: "ty"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dev = [
     "ruff",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
-    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield, 35 errors
-    # against an unchanged tree). Bump deliberately, with the new rules addressed.
+    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74
+    # promotes those plus unsound-assignment). Bump deliberately, with the new
+    # rules addressed.
     "ty==0.0.74",
     "tqdm",
     "twine",
@@ -208,7 +209,9 @@ rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
 
 [[tool.ty.overrides]]
 include = ["src/smda/cil/CilDisassembler.py"]
-rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
+# dnfile/dncil expose heap lookups and PE reads as Any/Unknown; ty 0.0.74 treats
+# those as unsound against the local bytes/str annotations rather than as gradual Any.
+rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore", "unsound-assignment" = "ignore", "unsound-return-statement" = "ignore" }
 
 # LIEF's type stubs declare PE Section.name as bytes; the runtime returns str.
 [[tool.ty.overrides]]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -295,7 +295,7 @@ class Disassembler:
             )
         return smda_report
 
-    def _disassemble(self, binary_info, timeout=0):
+    def _disassemble(self, binary_info, timeout=0) -> SmdaReport:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
@@ -319,7 +319,7 @@ class Disassembler:
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
-    def _createErrorReport(self, start, exception):
+    def _createErrorReport(self, start, exception) -> SmdaReport:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
@@ -330,7 +330,7 @@ class Disassembler:
         report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         return report
 
-    def _handleDisassemblyException(self, start, exception, log_message):
+    def _handleDisassemblyException(self, start, exception, log_message) -> SmdaReport:
         reraise_non_operational_exception(exception)
         LOGGER.error(log_message)
         return self._createErrorReport(start, exception)

--- a/src/smda/aarch64/AArch64Backend.py
+++ b/src/smda/aarch64/AArch64Backend.py
@@ -236,7 +236,7 @@ class AArch64Backend(ArchBackend):
             elif self._isBackwardTailcallTarget(target, state) or self._isShortBranchStub(d, state, target):
                 # A direct branch to code before the current entry, or from a short
                 # no-frame stub, is a tailcall/shared thunk target, not a local block.
-                d.fc_manager.addTailcallCandidate(target, reference_source=i_address)
+                d.fc_manager.addTailcallCandidate(target)
                 state.setSanelyEnding(True)
             elif target in d.fc_manager.getFunctionStartCandidates():
                 # case = "TAILCALL?" — leave for its own analysis

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,7 +111,7 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -716,19 +716,21 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             self.addPrologueCandidate(addr)
             self.setInitialCandidate(addr)
 
-    def addTailcallCandidate(self, addr, reference_source=None):
+    def addTailcallCandidate(self, addr):
+        """Book a tailcall target, and queue it - which the shared base leaves to its caller.
+
+        No inbound call reference is recorded for it. A branch is not a call, and scoring one
+        as if it were is the difference between admitting an address as a candidate and
+        pushing it past the functions that would otherwise absorb it.
+        """
         if not self._passesCodeFilter(addr):
             return False
-        is_new = self.ensureCandidate(addr)
+        self.ensureCandidate(addr)
         if addr not in self.candidates:
             return False
-        candidate = self.candidates[addr]
-        candidate.setIsTailcallCandidate(True)
-        score_changed = self._addCappedCallRef(candidate, reference_source) if reference_source is not None else False
+        self.candidates[addr].setIsTailcallCandidate(True)
         self._candidate_offsets.add(addr)
-        self.candidate_queue.add(candidate)
-        if score_changed and not is_new:
-            self.candidate_queue.update(candidate)
+        self.candidate_queue.add(self.candidates[addr])
         return True
 
     def _cachedExecutableSectionRanges(self):

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from typing import Optional
 
 import lief
 
@@ -47,11 +48,11 @@ class BinaryInfo:
     """
 
     architecture = ""
-    base_addr = 0
-    binary = b""
-    raw_data = b""
+    base_addr: int = 0
+    binary: bytes = b""
+    raw_data: bytes = b""
     binary_size = 0
-    bitness = None
+    bitness: Optional[int] = None
     code_areas = None
     component = ""
     family = ""
@@ -70,7 +71,7 @@ class BinaryInfo:
     symbols = None
     oep = None
 
-    def __init__(self, binary):
+    def __init__(self, binary: bytes):
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)

--- a/src/smda/common/BlockLocator.py
+++ b/src/smda/common/BlockLocator.py
@@ -1,5 +1,8 @@
 import bisect
 import itertools
+from typing import Any, Dict, List, Optional
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 
 
 class BlockLocator:
@@ -7,8 +10,8 @@ class BlockLocator:
     When instantiated, creates the required data structures.
     """
 
-    sorted_blocks_addresses = None
-    blocks_dict = None
+    sorted_blocks_addresses: Optional[List[Any]] = None
+    blocks_dict: Optional[Dict[Any, SmdaBasicBlock]] = None
 
     def __init__(self, functions):
         # Instantiate the datastructures required :
@@ -23,7 +26,7 @@ class BlockLocator:
         last_ins = block.instructions[-1]
         return last_ins.offset + len(last_ins.bytes) // 2  # bytes is actuall a hex string
 
-    def findBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address) -> Optional[SmdaBasicBlock]:
         sorted_addresses = self.sorted_blocks_addresses
         if sorted_addresses is None:
             return None

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -1,16 +1,19 @@
 import hashlib
 import struct
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from smda.common.SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaFunction import SmdaFunction
 
 # sentinel distinguishing "hash not yet computed" from "hash computed as None (uncomputable)"
 _UNSET = object()
 
 
 class SmdaBasicBlock:
-    smda_function = None
-    instructions = None
+    smda_function: Optional["SmdaFunction"] = None
+    instructions: Optional[List[SmdaInstruction]] = None
     _picblockhash = _UNSET
     _opcblockhash = _UNSET
     offset = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -167,7 +167,7 @@ class SmdaFunction:
     is_exported = False
     architecture_metadata: Dict[str, Any] = {}
     # metadata
-    binweight = 0
+    binweight: float = 0.0
     characteristics: Optional[str] = ""
     confidence: Optional[float] = 0.0
     function_name = ""
@@ -177,6 +177,7 @@ class SmdaFunction:
     nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
+    _basic_blocks: Optional[List["SmdaBasicBlock"]] = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
@@ -380,7 +381,7 @@ class SmdaFunction:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset) -> List["SmdaInstruction"]:
+    def getInstructionsForBlock(self, offset):
         if offset is None:
             offset = self.offset
         if offset is None:

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -12,8 +12,8 @@ LOGGER = logging.getLogger(__name__)
 
 class SmdaInstruction:
     smda_function = None
-    offset = None
-    bytes = None
+    offset: Optional[int] = None
+    bytes: Optional[str] = None
     mnemonic = None
     operands = None
     detailed = None
@@ -186,7 +186,7 @@ class SmdaInstruction:
         return self.bytes
 
     @classmethod
-    def fromDict(cls, instruction_dict, smda_function=None) -> Optional["SmdaInstruction"]:
+    def fromDict(cls, instruction_dict, smda_function=None) -> "SmdaInstruction":
         smda_instruction = cls(None)
         smda_instruction.smda_function = smda_function
         smda_instruction.offset = instruction_dict[0]

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import zipfile
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from capstone import CS_ARCH_ARM64, CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_MODE_LITTLE_ENDIAN, Cs
 
@@ -67,10 +67,11 @@ class SmdaReport:
     abi = None
     base_addr = None
     binary_size = None
-    binweight = 0
+    binweight: float = 0.0
     bitness = None
-    block_locator = None
-    buffer = None
+    block_locator: Optional[BlockLocator] = None
+    buffer: Optional[bytes] = None
+    _sorted_functions: Optional[List["SmdaFunction"]] = None
     code_areas = None
     # immutable-by-convention sentinel: __init__ always rebinds this to a fresh list
     code_sections: List[Any] = []
@@ -99,19 +100,20 @@ class SmdaReport:
     xcfg: Dict[int, "SmdaFunction"] = {}
     xheader = None
     pe_header_hash = None
-    data_refs_from = None
+    data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
+    _string_cache: Dict[Any, Optional[Tuple[str, str]]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
     # in case we need to re-disassemble with more detail, we hold an initialized capstone instance as singleton
     capstone = None
 
-    def __init__(self, disassembly=None, config=None, buffer=None):
+    def __init__(self, disassembly=None, config=None, buffer: Optional[bytes] = None):
         # caches owned by SmdaReport but populated lazily by StringExtractor; declared here so
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
-        self._string_cache = {}
+        self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
         self._derefs_cache = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
@@ -128,7 +130,7 @@ class SmdaReport:
             self.abi = disassembly.binary_info.abi
             self.base_addr = disassembly.binary_info.base_addr
             self.binary_size = disassembly.binary_info.binary_size
-            self.binweight = 0
+            self.binweight = 0.0
             self.bitness = disassembly.binary_info.bitness
             self.buffer = buffer
             self.code_areas = disassembly.binary_info.code_areas
@@ -227,10 +229,10 @@ class SmdaReport:
         return self.xcfg.get(function_addr, None)
 
     def getFunctions(self) -> Iterator["SmdaFunction"]:
-        if getattr(self, "_sorted_functions", None) is None:
-            self._sorted_functions = []
-            if self.xcfg:
-                self._sorted_functions = [smda_function for _, smda_function in sorted(self.xcfg.items())]
+        if self._sorted_functions is None:
+            self._sorted_functions = (
+                [smda_function for _, smda_function in sorted(self.xcfg.items())] if self.xcfg else []
+            )
         yield from self._sorted_functions
 
     def getExportedFunctions(self):

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -136,8 +136,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._binary_info = None
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 0
         self._scan_ranges: List[Tuple[int, int]] = []
         self._func_symbols: Dict[int, str] = {}

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -227,11 +227,11 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._func_symbols = {}
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 32
-        self._code_start = 0
-        self._code_end = 0
+        self._code_start: int = 0
+        self._code_end: int = 0
         self._settings = None
 
     def update(self, binary_info):

--- a/src/smda/common/labelprovider/RustSymbolEvidence.py
+++ b/src/smda/common/labelprovider/RustSymbolEvidence.py
@@ -11,7 +11,7 @@ RUST_DEMANGLE_ERRORS = (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDem
 _LEGACY_RUST_HASHED_SYMBOL = re.compile(r"^(?:_)?_ZN.*17h[0-9a-f]{16}E(?:[.$].*)?$")
 
 
-def is_rust_language_evidence(name):
+def is_rust_language_evidence(name) -> bool:
     """Return whether a mangled name has Rust-specific, parseable structure."""
     if not name:
         return False

--- a/src/smda/common/labelprovider/rust_demangler/main.py
+++ b/src/smda/common/labelprovider/rust_demangler/main.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from .rust import RustDemangler
 
 _DEMANGLER = RustDemangler()
-_DEMANGLE_CACHE = {}
+_DEMANGLE_CACHE: Dict[str, Union[str, Exception]] = {}
 # the cache is process-lifetime and keyed by every mangled name ever seen; bound it so a
 # long-running batch cannot grow it without limit (the sibling demanglers use
 # lru_cache(maxsize=4096)). Results and exception objects are both cached, which lru_cache

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -71,7 +71,7 @@ class Ident:
         self.out_len = 0
 
     def try_small_punycode_decode(self) -> Optional[bool]:
-        def f(inp):
+        def f(inp) -> bool:
             inp = "".join(inp)
             self.disp += inp
             return True
@@ -495,9 +495,9 @@ class Printer:
     # self-referential backref chain raises RecursionError before this guard.
     RUST_MAX_RECURSION_COUNT = 256
 
-    def __init__(self, parser, out, bound, recursion=0):
+    def __init__(self, parser, out: str, bound, recursion=0):
         self.parser = parser
-        self.out = out
+        self.out: str = out
         self.bound_lifetime_depth = bound
         self.recursion = recursion
 
@@ -692,8 +692,8 @@ class Printer:
         try:
             p = self.parser_mut()
             tag = p.next_func()
-            if basic_type(tag):
-                ty = basic_type(tag)
+            ty = basic_type(tag)
+            if ty:
                 self.out += ty
                 return
 

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -323,7 +323,7 @@ class ElfSynthesizer(BinarySynthesizer):
                 )
         return segments
 
-    def _assembleFile(self, sections, segments, bitness, dynamic_range=None):
+    def _assembleFile(self, sections, segments, bitness, dynamic_range=None) -> bytes:
         is_64 = bitness == 64
         ehdr_size = 64 if is_64 else 52
         phent_size = 56 if is_64 else 32
@@ -553,7 +553,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
         return bytes(output)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         sections = self._prepareSections(sections, offsets, with_strings)
         import_map = self._getImportMap() if with_imports else {}
@@ -563,7 +563,7 @@ class ElfSynthesizer(BinarySynthesizer):
         segments = self._mergeSegments(sections)
         return self._assembleFile(sections, segments, bitness, dynamic_range)
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         bitness = self._getBitness()
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -505,7 +505,7 @@ class MachoSynthesizer(BinarySynthesizer):
         libs = sorted({lib for lib, _ in import_map.values() if lib})
         return strtab, symtab, indirect_blob, libs, len(indirect)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         is_64 = self._is64()
         segments = self._prepareSections(sections, offsets, with_strings)
         sections = [section for segment in segments for section in segment["sections"]]
@@ -737,7 +737,7 @@ class MachoSynthesizer(BinarySynthesizer):
             flags,
         )
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {"name": "__text", "va_start": va_start, "va_end": va_end}
         return self._synthesizeFromSections([section], offsets, False, False)

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -322,7 +322,7 @@ class PeSynthesizer(BinarySynthesizer):
         header += b"\x00" * (size_of_headers - len(header))
         return header
 
-    def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
+    def _synthesizeFromHeader(self, offsets, with_imports, with_strings) -> bytes:
         base = self.report.base_addr
         pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
@@ -451,7 +451,7 @@ class PeSynthesizer(BinarySynthesizer):
             return base
         return candidate
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000

--- a/src/smda/utility/DexFileLoader.py
+++ b/src/smda/utility/DexFileLoader.py
@@ -93,7 +93,7 @@ class DexFileLoader:
         return 0
 
     @staticmethod
-    def getBitness(data, parsed=None):
+    def getBitness(data, parsed=None) -> int:
         return 32
 
     @staticmethod

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -1,7 +1,7 @@
 import re
 import string
 import struct
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaFunction import SmdaFunction
@@ -20,14 +20,15 @@ def read_bytes(smda_report, va, num_bytes=None):
     """
 
     rva = va - smda_report.base_addr
-    if smda_report.buffer is None:
+    buffer = smda_report.buffer
+    if buffer is None:
         raise ValueError("buffer is empty")
-    buffer_end = len(smda_report.buffer)
+    buffer_end = len(buffer)
     max_bytes = num_bytes if num_bytes is not None else 0x100
     if rva + max_bytes > buffer_end:
-        return smda_report.buffer[rva:]
+        return buffer[rva:]
     else:
-        return smda_report.buffer[rva : rva + max_bytes]
+        return buffer[rva : rva + max_bytes]
 
 
 def derefs(smda_report, p):
@@ -166,7 +167,7 @@ def read_string(smda_report, offset, maxlen=None):
     return res
 
 
-def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int, int, str]]:
+def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, Any, Any, str]]:
     """parse string features from the given instruction."""
     if mode == "go":
         # we address stack assigned strings and String structs

--- a/tests/testAArch64TailcallSeedEvidence.py
+++ b/tests/testAArch64TailcallSeedEvidence.py
@@ -37,6 +37,11 @@ class TailcallSeedEvidenceTest(unittest.TestCase):
     """
 
     def _image(self):
+        """An image with three parts: the leaves and their caller, which give the alignment
+        floor something to infer 16 from; a victim, which is a 16-aligned routine holding a
+        merely 4-aligned word, opening on no prologue and called by nothing, so the gap scan
+        is what recovers it and that happens after every candidate booked in the first pass;
+        and a seeder, a routine ending in a backward branch into the victim's body."""
         words = {}
         leaves = [BASE + 0x1000 + index * 0x10 for index in range(LEAF_COUNT)]
         for leaf in leaves:
@@ -52,14 +57,10 @@ class TailcallSeedEvidenceTest(unittest.TestCase):
         words[address] = EPILOGUE
         words[address + 4] = RET
 
-        # A 16-aligned routine whose body holds a merely 4-aligned word. It opens on no
-        # prologue and nothing calls it, so the gap scan is what recovers it -- which is
-        # after every candidate booked in the first pass.
         victim = BASE + 0x2000
         interior = victim + 4
         words.update({victim: MOV_W1_2, interior: MOV_W0_1, victim + 8: MOV_W2_3, victim + 12: RET})
 
-        # the seeding site: a routine ending in a backward branch into that body
         seeder = BASE + 0x3000
         words.update({seeder: PROLOGUE, seeder + 4: EPILOGUE, seeder + 8: _b(seeder + 8, interior)})
 

--- a/tests/testAArch64TailcallSeedEvidence.py
+++ b/tests/testAArch64TailcallSeedEvidence.py
@@ -1,0 +1,142 @@
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+IMAGE_SIZE = 0x3100
+
+NOP = 0xD503201F
+RET = 0xD65F03C0
+PROLOGUE = 0xA9BF7BFD  # stp x29, x30, [sp, #-16]!
+EPILOGUE = 0xA8C17BFD  # ldp x29, x30, [sp], #16
+MOV_W0_1 = 0x52800020
+MOV_W1_2 = 0x52800041
+MOV_W2_3 = 0x52800062
+
+#: enough call-referenced entries, all 16-aligned, for the alignment floor to infer 16.
+#: The inference needs more than twenty candidates carrying more than one reference each.
+LEAF_COUNT = 22
+
+
+def _bl(source, target):
+    return 0x94000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+def _b(source, target):
+    return 0x14000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+class TailcallSeedEvidenceTest(unittest.TestCase):
+    """A direct branch is not a direct call, and only the second is the image's own evidence.
+
+    Candidate discovery infers an alignment for function starts and refuses a candidate below
+    it, exempting the ones a call reference vouches for. Recording a branch target as an
+    inbound call reference puts a mid-function address through that exemption, where it
+    outranks the routine it sits inside.
+    """
+
+    def _image(self):
+        words = {}
+        leaves = [BASE + 0x1000 + index * 0x10 for index in range(LEAF_COUNT)]
+        for leaf in leaves:
+            words.update({leaf: PROLOGUE, leaf + 4: MOV_W0_1, leaf + 8: EPILOGUE, leaf + 12: RET})
+
+        address = BASE
+        words[address] = PROLOGUE
+        address += 4
+        for leaf in leaves:
+            for _call in range(2):
+                words[address] = _bl(address, leaf)
+                address += 4
+        words[address] = EPILOGUE
+        words[address + 4] = RET
+
+        # A 16-aligned routine whose body holds a merely 4-aligned word. It opens on no
+        # prologue and nothing calls it, so the gap scan is what recovers it -- which is
+        # after every candidate booked in the first pass.
+        victim = BASE + 0x2000
+        interior = victim + 4
+        words.update({victim: MOV_W1_2, interior: MOV_W0_1, victim + 8: MOV_W2_3, victim + 12: RET})
+
+        # the seeding site: a routine ending in a backward branch into that body
+        seeder = BASE + 0x3000
+        words.update({seeder: PROLOGUE, seeder + 4: EPILOGUE, seeder + 8: _b(seeder + 8, interior)})
+
+        image = bytearray(NOP.to_bytes(4, "little") * (IMAGE_SIZE // 4))
+        for word_address, word in words.items():
+            image[word_address - BASE : word_address - BASE + 4] = word.to_bytes(4, "little")
+        return bytes(image), victim, interior, seeder
+
+    def setUp(self):
+        image, self.victim, self.interior, self.seeder = self._image()
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        report = Disassembler(config, backend="aarch64").disassembleBuffer(
+            image,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + IMAGE_SIZE]],
+            architecture="aarch64",
+        )
+        self.assertEqual(report.status, "ok")
+        self.functions = {function.offset for function in report.getFunctions()}
+
+    def testTheBranchTargetIsNotBookedAsAFunction(self):
+        self.assertNotIn(self.interior, self.functions)
+
+    def testTheRoutineItSitsInsideIsRecovered(self):
+        """The other half of the same move: the interior address did not merely stop being a
+        function, it stopped displacing the one it belongs to."""
+        self.assertIn(self.victim, self.functions)
+
+    def testTheBranchingRoutineIsStillRecovered(self):
+        """Control. Both assertions above would hold on an image that failed to analyse."""
+        self.assertIn(self.seeder, self.functions)
+        self.assertIn(BASE, self.functions)
+
+
+class TailcallCandidateHasNoCallReferenceTest(unittest.TestCase):
+    """The mechanism, isolated from the traversal that reaches it."""
+
+    def _manager(self):
+        import types
+
+        from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+
+        config = SmdaConfig()
+        manager = FunctionCandidateManager(config)
+        manager.disassembly = types.SimpleNamespace(
+            binary_info=types.SimpleNamespace(bitness=64, base_addr=0, binary=b"\x00" * 0x10000),
+            analysis_timeout=False,
+        )
+        manager.bitness = 64
+        manager.identified_alignment = 16
+        manager._code_areas = []
+        return manager
+
+    def testABookedTailcallCarriesNoInboundCallReference(self):
+        manager = self._manager()
+
+        self.assertTrue(manager.addTailcallCandidate(0x1004))
+        self.assertEqual(manager.candidates[0x1004].call_ref_sources, set())
+
+    def testTheAlignmentFloorThenRefusesIt(self):
+        manager = self._manager()
+        manager.addTailcallCandidate(0x1004)
+        manager._buildQueue()
+
+        self.assertNotIn(0x1004, [candidate.addr for candidate in manager.getNextFunctionStartCandidate()])
+
+    def testACalledAddressIsStillExemptFromTheFloor(self):
+        """Control: the exemption is not removed, only stopped from being manufactured. An
+        address something really calls still passes the floor at the same alignment."""
+        manager = self._manager()
+        manager.addReferenceCandidate(0x1004, 0x2000)
+        manager._buildQueue()
+
+        self.assertIn(0x1004, [candidate.addr for candidate in manager.getNextFunctionStartCandidate()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testLateCandidateProduction.py
+++ b/tests/testLateCandidateProduction.py
@@ -58,7 +58,7 @@ class LateCandidateTestBase:
         self.assertIsNotNone(first)
 
         late_addr = 0x35E0
-        self.manager.addTailcallCandidate(late_addr, reference_source=0x5000)
+        self.manager.addTailcallCandidate(late_addr)
 
         produced = [c.addr for c in gen]
         self.assertIn(
@@ -78,7 +78,7 @@ class LateCandidateTestBase:
         # Another analysis path created the candidate earlier (in candidates only).
         self.manager.ensureCandidate(late_addr)
         # Now addTailcallCandidate fires — should re-add to queue.
-        self.manager.addTailcallCandidate(late_addr, reference_source=0x6000)
+        self.manager.addTailcallCandidate(late_addr)
 
         produced = [c.addr for c in self.manager.getNextFunctionStartCandidate()]
         self.assertIn(
@@ -98,7 +98,7 @@ class LateCandidateTestBase:
 
         late_addr = 0x45E0
         self.manager.ensureCandidate(late_addr)  # candidates only
-        self.manager.addTailcallCandidate(late_addr, reference_source=0x6000)  # re-adds to queue
+        self.manager.addTailcallCandidate(late_addr)  # re-adds to queue
 
         produced = [c.addr for c in gen]
         self.assertIn(
@@ -154,32 +154,33 @@ class LateCandidateTestBase:
 
         late_a = 0x75E0
         late_b = 0x85E0
-        self.manager.addTailcallCandidate(late_a, reference_source=0x8000)
-        self.manager.addTailcallCandidate(late_b, reference_source=0x9000)
+        self.manager.addTailcallCandidate(late_a)
+        self.manager.addTailcallCandidate(late_b)
 
         produced = [c.addr for c in gen]
         self.assertIn(late_a, produced)
         self.assertIn(late_b, produced)
 
     # ------------------------------------------------------------------
-    #   Scenario 7: tailcall with callRef has score > 0 (integration)
+    #   Scenario 7: an aligned tailcall scores above zero on its address alone
     # ------------------------------------------------------------------
-    def test_late_tailcall_with_callref_has_nonzero_score(self):
-        """addCallRef resets _score to None; getScore recalculates > 0."""
+    def test_late_tailcall_scores_on_alignment_alone(self):
+        """The contrast to scenario 5, and the reason a tailcall seed needs no call
+        reference of its own: an aligned address scores 1, which is enough to be produced."""
         late_addr = 0x95E0
-        self.manager.addTailcallCandidate(late_addr, reference_source=0xA000)
+        self.manager.addTailcallCandidate(late_addr)
 
         gen = self.manager.getNextFunctionStartCandidate()
         produced = [c.addr for c in gen]
         self.assertIn(
             late_addr,
             produced,
-            f"Candidate 0x{late_addr:x} with upcoming addCallRef should be produced [queue={self.queue_type}]",
+            f"Candidate 0x{late_addr:x} should be produced on its alignment [queue={self.queue_type}]",
         )
 
-    def test_new_scored_candidate_does_not_rebuild_queue(self):
+    def test_late_tailcall_does_not_rebuild_queue(self):
         with patch.object(self.manager.candidate_queue, "update", wraps=self.manager.candidate_queue.update) as update:
-            self.manager.addTailcallCandidate(0xA5E0, reference_source=0xB000)
+            self.manager.addTailcallCandidate(0xA5E0)
 
         update.assert_not_called()
 
@@ -187,7 +188,7 @@ class LateCandidateTestBase:
         rejected_addr = 0xB5E0
         self.config.MAX_FUNCTION_CANDIDATES = len(self.manager.candidates)
 
-        self.assertFalse(self.manager.addTailcallCandidate(rejected_addr, reference_source=0xC000))
+        self.assertFalse(self.manager.addTailcallCandidate(rejected_addr))
         self.assertNotIn(rejected_addr, self.manager.candidates)
         self.assertNotIn(rejected_addr, self.manager._candidate_offsets)
         if hasattr(self.manager.candidate_queue, "heap"):


### PR DESCRIPTION
Candidate discovery infers an alignment that function starts obey on a given image and refuses a candidate below it. Two things are exempt: an exception record, and an inbound call reference. Both are the image's own evidence that the address is an entry — the comment on that exemption in `common/FunctionCandidateManager.py` says exactly that.

The AArch64 backend seeds a candidate at the target of a backward branch or of a short no-frame stub, and the AArch64 candidate manager recorded the branching instruction as an inbound **call** reference for it.

A branch is not a call. So the seed manufactured the very evidence the alignment floor trusts, and mid-function addresses went through the exemption. That is worse than a stray false positive: on a routine only the gap scan recovers, the smuggled interior address is analysed in the first pass, takes the bytes, and the real start is never reported at all.

The shared implementation in `common/` records no reference. This was an AArch64-only override.

## Fix

Book the candidate; do not record the reference.

```python
-        d.fc_manager.addTailcallCandidate(target, reference_source=i_address)
+        d.fc_manager.addTailcallCandidate(target)
```

The address is still discovered, still queued, still analysed — it just competes on what it actually has (its alignment, its prologue if it has one) instead of on a call that does not exist. With the parameter's only caller gone, the override drops it and the dead `score_changed` bookkeeping with it; what remains over the base class is the queueing the base leaves to its caller.

## Measured

Three corpora, exact-address match, macro means. Ground truth is a compiler's, a linker's, or the Go runtime's — never another disassembler's.

| corpus | n | | PPV | TPR | TP | FP |
|---|---|---|---|---|---|---|
| Go (pclntab) | 47 | before | 94.293 | 99.367 | 165,627 | 10,514 |
| | | after | **94.369** | 99.367 | 165,627 | **10,354** |
| AArch64 ELF (gcc cross, symbol tables) | 72 | before | 80.554 | 95.964 | 54,979 | 7,968 |
| | | after | **80.566** | **95.966** | **54,982** | **7,953** |
| ARM64 Mach-O (`LC_FUNCTION_STARTS`) | 11 | before | 94.220 | 96.711 | 2,532 | 235 |
| | | after | 94.220 | **96.714** | 2,532 | 235 |

**175 false positives removed, 3 functions recovered, no corpus loses recall.**

Two details worth having rather than hiding:

- On the AArch64 ELF set the per-cell picture is not uniformly better — 22 of 72 cells move, 33 false positives go and 18 appear. A candidate analysed later leaves different bytes for the gap scan. **No cell loses a true positive.**
- On Mach-O the totals are flat because one binary gains a function (`LockBit_3e4bbd21756a`) and one loses one (`RustyPages_e98756472404`, at `0x10000548c`). That is the single recall cost anywhere in the three corpora, and it is offset inside the same corpus.

## What the removed addresses actually are

On `netjson_darwin-arm64_default`, 42 addresses stop being functions. All 42 are false positives, and **all 42 sit strictly inside a real function** — interior words, which is what the alignment floor exists to refuse and what the manufactured reference was letting through.

## Two alternatives, both measured and both rejected

**Gate the whole seed behind `RESOLVE_TAILCALLS`**, as the sibling `bl` fall-through site does: removes **339** false positives but costs **26 true positives**, on `RustyPages_e98756472404` (−17), `osx.frostyferret_ef27a525ec0b` (−4) and `osx.poseidonstealer_a494eb0be9d1` (−5). A recall drop is the reject criterion.

**Exempt `is_tailcall` from the alignment floor**, so the removed reference is not what keeps a genuine target eligible:

| | Go PPV | Go FP | Mach-O TP |
|---|---|---|---|
| baseline | 94.293 | 10,514 | 2,532 |
| this branch | **94.369** | **10,354** | 2,532 |
| this branch + the exemption | 94.293 | 10,514 | 2,532 |

It gives back **all 160** Go false positives, per cell exactly, because every candidate this site seeds is a tailcall candidate — so exempting the flag re-admits the whole population. And it does not save the one function it was proposed to save: `RustyPages` is 501 either way. On that image `identified_alignment` is **4** and `0x10000548c` is 4-aligned, so the floor never refused it; that loss is analysis order, not eligibility, and a remedy aimed at the floor cannot reach it.

## Tests

`tests/testAArch64TailcallSeedEvidence.py`, new:

- **End-to-end.** An image with 22 call-referenced 16-aligned leaves, so the floor really does infer 16; one 16-aligned routine only the gap scan can find; and a routine ending in a backward branch into that routine's body at a merely 4-aligned word. Asserts the interior word is not a function *and* that the routine it sits inside is recovered. Before the fix both fail: the interior word is a function and the real start is missing.
- **Unit.** A booked tailcall carries no inbound call reference and the floor then refuses it — with the control that an address something really calls is still exempt at the same alignment, so the exemption is not removed, only stopped from being manufactured.
- **Control.** The branching routine and the driver are recovered either way.

`tests/testLateCandidateProduction.py` stops passing a reference source. Those tests are about late candidates reaching the queue rather than about scoring, and their addresses are 16-aligned so they score above zero without one. The one scenario whose subject really was the call reference is rewritten to assert what now carries it — alignment alone.

## Validation

`ruff check` / `ruff format --check` pass, full suite green on this branch rebased onto current master (1820 passed, 1 skipped, 2584 subtests), diff coverage 100% on the changed lines. No frozen fixture baseline moves and the fixture benchmark gate is green.

## Relationship to #299 and #300

This change is also sitting inside #299 and #300. Both of those were opened from branches that had my fork's master merged into them repeatedly, so their diffs are much wider than their titles suggest and they overlap each other as well.

This PR is the same change on its own, rebased onto current master, so it can be reviewed and measured for what it actually is. If you would rather take it through one of those, close this one; if you take this one, the matching hunks fall out of theirs on rebase.

## The `ty` commit at the tip

The last commit on this branch is #302's fix, cherry-picked unchanged.

Master fails `Code Quality` on its own right now: 572acd7 bumped `ty` to 0.0.74, and its new `unsound-return-statement` / `unsound-assignment` rules become errors under `[tool.ty.rules] all = "error"`. That is 41 errors across 15 files, none of which this PR touches — so every PR opened against master inherits a red check that says nothing about its own diff.

Carrying #302's commit here means this PR's CI reflects only this PR's work. It is the same commit, unmodified, so the moment #302 lands this one is empty and falls out on rebase — there is nothing to untangle later. If you would rather look at this branch without it, merge #302 first and I will drop it.

Checked against `ty` 0.0.74 itself rather than whatever an older local pin resolves to: on master it exits 1 with 41 errors, on this branch it exits 0 with none.
