### PR TITLE
docs(docs): say which address space a report's offsets are in

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # ty is pinned in pyproject.toml and ships new error rules in patch releases;
+      # bump it in a dedicated change that addresses those rules, not via Dependabot.
+      - dependency-name: "ty"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ There is also a demo script:
 
 * analyze.py -- example usage: perform disassembly on a file or memory dump and optionally store results in JSON to a given output path.
 
+#### What an offset in a report means
+
+`SmdaFunction.offset`, the basic-block keys and `SmdaInstruction.offset` are **virtual addresses** on
+every backend but one. The .NET/CIL backend reports **file offsets**: a managed method is addressed
+by where its body sits in the file, not by `base_addr` plus its RVA.
+
+So a managed report's offsets do not line up with a native one's, and correlating the two - or either
+with another tool's output - compares two different address spaces. A report names the backend that
+produced it in two places, `report.architecture` and `metadata.language` in `toDict()`, so a consumer
+can tell which rule applies before treating an offset as an address.
+
+This asymmetry is recorded rather than corrected: the offsets are a public compatibility surface that
+downstream consumers index on, so changing which space they are in is a deliberate decision and not a
+bug fix.
+
 #### Raw buffers and the instruction set
 
 `disassembleFile` reads the instruction set from the container header. `disassembleBuffer` has no

--- a/README.md
+++ b/README.md
@@ -52,15 +52,24 @@ There is also a demo script:
 #### What an offset in a report means
 
 `SmdaFunction.offset`, the basic-block keys and `SmdaInstruction.offset` are **virtual addresses** on
-every backend but one. The .NET/CIL backend reports **file offsets**: a managed method is addressed
-by where its body sits in the file, not by `base_addr` plus its RVA.
+the native backends, `intel` and `aarch64`. On the two managed ones they are **file offsets**:
 
-So a managed report's offsets do not line up with a native one's, and correlating the two - or either
-with another tool's output - compares two different address spaces. A report names the backend that
-produced it in two places, `report.architecture` and `metadata.language` in `toDict()`, so a consumer
-can tell which rule applies before treating an offset as an address.
+| `report.architecture` | what an offset is |
+|---|---|
+| `intel`, `aarch64` | a virtual address - `base_addr` plus an RVA |
+| `cil` | the offset of the method body in the assembly file |
+| `dalvik` | the offset of the code item in the DEX file |
 
-This asymmetry is recorded rather than corrected: the offsets are a public compatibility surface that
+The two are not the same kind of number, so correlating a managed report with a native one - or
+either with another tool's output - compares two different address spaces. A report names the backend
+that produced it in two places, `report.architecture` and `metadata.language` in `toDict()`, so a
+consumer can tell which rule applies before treating an offset as an address.
+
+The two managed cases differ in why. A CIL method has an RVA, and reporting the file offset instead
+is a choice; a DEX carries no load address at all, so the file offset is the only address there is.
+Either way, adding `base_addr` to one of them produces a number that means nothing.
+
+This is recorded rather than corrected: the offsets are a public compatibility surface that
 downstream consumers index on, so changing which space they are in is a deliberate decision and not a
 bug fix.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dev = [
     "ruff",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
-    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield, 35 errors
-    # against an unchanged tree). Bump deliberately, with the new rules addressed.
+    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74
+    # promotes those plus unsound-assignment). Bump deliberately, with the new
+    # rules addressed.
     "ty==0.0.74",
     "tqdm",
     "twine",
@@ -208,7 +209,9 @@ rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
 
 [[tool.ty.overrides]]
 include = ["src/smda/cil/CilDisassembler.py"]
-rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
+# dnfile/dncil expose heap lookups and PE reads as Any/Unknown; ty 0.0.74 treats
+# those as unsound against the local bytes/str annotations rather than as gradual Any.
+rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore", "unsound-assignment" = "ignore", "unsound-return-statement" = "ignore" }
 
 # LIEF's type stubs declare PE Section.name as bytes; the runtime returns str.
 [[tool.ty.overrides]]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -295,7 +295,7 @@ class Disassembler:
             )
         return smda_report
 
-    def _disassemble(self, binary_info, timeout=0):
+    def _disassemble(self, binary_info, timeout=0) -> SmdaReport:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
@@ -319,7 +319,7 @@ class Disassembler:
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
-    def _createErrorReport(self, start, exception):
+    def _createErrorReport(self, start, exception) -> SmdaReport:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
@@ -330,7 +330,7 @@ class Disassembler:
         report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         return report
 
-    def _handleDisassemblyException(self, start, exception, log_message):
+    def _handleDisassemblyException(self, start, exception, log_message) -> SmdaReport:
         reraise_non_operational_exception(exception)
         LOGGER.error(log_message)
         return self._createErrorReport(start, exception)

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,7 +111,7 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -140,6 +140,16 @@ class DnfileMethodBodyReader(CilMethodBodyReaderBase):
 
 
 class CilDisassembler:
+    """Recover managed method bodies from a .NET assembly.
+
+    Every address in the report this produces is a **file offset**, not a virtual address: a
+    method body is located through `get_offset_from_rva`, and the instruction offsets dncil
+    reports are relative to the file as well. Every other backend reports virtual addresses,
+    so these do not line up with `base_addr` plus an RVA and are not comparable with a native
+    report's. The report names the backend that produced it, in `architecture` and in the
+    language score map, which is what lets a consumer tell which rule applies.
+    """
+
     def __init__(self, config):
         self.config = config
         self._tfidf = None

--- a/src/smda/cil/CilDisassembler.py
+++ b/src/smda/cil/CilDisassembler.py
@@ -144,10 +144,12 @@ class CilDisassembler:
 
     Every address in the report this produces is a **file offset**, not a virtual address: a
     method body is located through `get_offset_from_rva`, and the instruction offsets dncil
-    reports are relative to the file as well. Every other backend reports virtual addresses,
-    so these do not line up with `base_addr` plus an RVA and are not comparable with a native
-    report's. The report names the backend that produced it, in `architecture` and in the
-    language score map, which is what lets a consumer tell which rule applies.
+    reports are relative to the file as well. The native backends report virtual addresses, so
+    these do not line up with `base_addr` plus an RVA and are not comparable with a native
+    report's. The Dalvik backend addresses by file offset too, for a different reason - a DEX
+    carries no load address, where a CIL method has an RVA this declines to use. The report
+    names the backend that produced it, in `architecture` and in the language score map, which
+    is what lets a consumer tell which rule applies.
     """
 
     def __init__(self, config):

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from typing import Optional
 
 import lief
 
@@ -47,11 +48,11 @@ class BinaryInfo:
     """
 
     architecture = ""
-    base_addr = 0
-    binary = b""
-    raw_data = b""
+    base_addr: int = 0
+    binary: bytes = b""
+    raw_data: bytes = b""
     binary_size = 0
-    bitness = None
+    bitness: Optional[int] = None
     code_areas = None
     component = ""
     family = ""
@@ -70,7 +71,7 @@ class BinaryInfo:
     symbols = None
     oep = None
 
-    def __init__(self, binary):
+    def __init__(self, binary: bytes):
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)

--- a/src/smda/common/BlockLocator.py
+++ b/src/smda/common/BlockLocator.py
@@ -1,5 +1,8 @@
 import bisect
 import itertools
+from typing import Any, Dict, List, Optional
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 
 
 class BlockLocator:
@@ -7,8 +10,8 @@ class BlockLocator:
     When instantiated, creates the required data structures.
     """
 
-    sorted_blocks_addresses = None
-    blocks_dict = None
+    sorted_blocks_addresses: Optional[List[Any]] = None
+    blocks_dict: Optional[Dict[Any, SmdaBasicBlock]] = None
 
     def __init__(self, functions):
         # Instantiate the datastructures required :
@@ -23,7 +26,7 @@ class BlockLocator:
         last_ins = block.instructions[-1]
         return last_ins.offset + len(last_ins.bytes) // 2  # bytes is actuall a hex string
 
-    def findBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address) -> Optional[SmdaBasicBlock]:
         sorted_addresses = self.sorted_blocks_addresses
         if sorted_addresses is None:
             return None

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -1,16 +1,19 @@
 import hashlib
 import struct
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from smda.common.SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaFunction import SmdaFunction
 
 # sentinel distinguishing "hash not yet computed" from "hash computed as None (uncomputable)"
 _UNSET = object()
 
 
 class SmdaBasicBlock:
-    smda_function = None
-    instructions = None
+    smda_function: Optional["SmdaFunction"] = None
+    instructions: Optional[List[SmdaInstruction]] = None
     _picblockhash = _UNSET
     _opcblockhash = _UNSET
     offset = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -167,7 +167,7 @@ class SmdaFunction:
     is_exported = False
     architecture_metadata: Dict[str, Any] = {}
     # metadata
-    binweight = 0
+    binweight: float = 0.0
     characteristics: Optional[str] = ""
     confidence: Optional[float] = 0.0
     function_name = ""
@@ -177,6 +177,7 @@ class SmdaFunction:
     nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
+    _basic_blocks: Optional[List["SmdaBasicBlock"]] = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
@@ -380,7 +381,7 @@ class SmdaFunction:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset) -> List["SmdaInstruction"]:
+    def getInstructionsForBlock(self, offset):
         if offset is None:
             offset = self.offset
         if offset is None:

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -12,8 +12,8 @@ LOGGER = logging.getLogger(__name__)
 
 class SmdaInstruction:
     smda_function = None
-    offset = None
-    bytes = None
+    offset: Optional[int] = None
+    bytes: Optional[str] = None
     mnemonic = None
     operands = None
     detailed = None
@@ -186,7 +186,7 @@ class SmdaInstruction:
         return self.bytes
 
     @classmethod
-    def fromDict(cls, instruction_dict, smda_function=None) -> Optional["SmdaInstruction"]:
+    def fromDict(cls, instruction_dict, smda_function=None) -> "SmdaInstruction":
         smda_instruction = cls(None)
         smda_instruction.smda_function = smda_function
         smda_instruction.offset = instruction_dict[0]

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import zipfile
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from capstone import CS_ARCH_ARM64, CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_MODE_LITTLE_ENDIAN, Cs
 
@@ -67,10 +67,11 @@ class SmdaReport:
     abi = None
     base_addr = None
     binary_size = None
-    binweight = 0
+    binweight: float = 0.0
     bitness = None
-    block_locator = None
-    buffer = None
+    block_locator: Optional[BlockLocator] = None
+    buffer: Optional[bytes] = None
+    _sorted_functions: Optional[List["SmdaFunction"]] = None
     code_areas = None
     # immutable-by-convention sentinel: __init__ always rebinds this to a fresh list
     code_sections: List[Any] = []
@@ -99,19 +100,20 @@ class SmdaReport:
     xcfg: Dict[int, "SmdaFunction"] = {}
     xheader = None
     pe_header_hash = None
-    data_refs_from = None
+    data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
+    _string_cache: Dict[Any, Optional[Tuple[str, str]]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
     # in case we need to re-disassemble with more detail, we hold an initialized capstone instance as singleton
     capstone = None
 
-    def __init__(self, disassembly=None, config=None, buffer=None):
+    def __init__(self, disassembly=None, config=None, buffer: Optional[bytes] = None):
         # caches owned by SmdaReport but populated lazily by StringExtractor; declared here so
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
-        self._string_cache = {}
+        self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
         self._derefs_cache = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
@@ -128,7 +130,7 @@ class SmdaReport:
             self.abi = disassembly.binary_info.abi
             self.base_addr = disassembly.binary_info.base_addr
             self.binary_size = disassembly.binary_info.binary_size
-            self.binweight = 0
+            self.binweight = 0.0
             self.bitness = disassembly.binary_info.bitness
             self.buffer = buffer
             self.code_areas = disassembly.binary_info.code_areas
@@ -227,10 +229,10 @@ class SmdaReport:
         return self.xcfg.get(function_addr, None)
 
     def getFunctions(self) -> Iterator["SmdaFunction"]:
-        if getattr(self, "_sorted_functions", None) is None:
-            self._sorted_functions = []
-            if self.xcfg:
-                self._sorted_functions = [smda_function for _, smda_function in sorted(self.xcfg.items())]
+        if self._sorted_functions is None:
+            self._sorted_functions = (
+                [smda_function for _, smda_function in sorted(self.xcfg.items())] if self.xcfg else []
+            )
         yield from self._sorted_functions
 
     def getExportedFunctions(self):

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -136,8 +136,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._binary_info = None
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 0
         self._scan_ranges: List[Tuple[int, int]] = []
         self._func_symbols: Dict[int, str] = {}

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -227,11 +227,11 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._func_symbols = {}
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 32
-        self._code_start = 0
-        self._code_end = 0
+        self._code_start: int = 0
+        self._code_end: int = 0
         self._settings = None
 
     def update(self, binary_info):

--- a/src/smda/common/labelprovider/RustSymbolEvidence.py
+++ b/src/smda/common/labelprovider/RustSymbolEvidence.py
@@ -11,7 +11,7 @@ RUST_DEMANGLE_ERRORS = (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDem
 _LEGACY_RUST_HASHED_SYMBOL = re.compile(r"^(?:_)?_ZN.*17h[0-9a-f]{16}E(?:[.$].*)?$")
 
 
-def is_rust_language_evidence(name):
+def is_rust_language_evidence(name) -> bool:
     """Return whether a mangled name has Rust-specific, parseable structure."""
     if not name:
         return False

--- a/src/smda/common/labelprovider/rust_demangler/main.py
+++ b/src/smda/common/labelprovider/rust_demangler/main.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from .rust import RustDemangler
 
 _DEMANGLER = RustDemangler()
-_DEMANGLE_CACHE = {}
+_DEMANGLE_CACHE: Dict[str, Union[str, Exception]] = {}
 # the cache is process-lifetime and keyed by every mangled name ever seen; bound it so a
 # long-running batch cannot grow it without limit (the sibling demanglers use
 # lru_cache(maxsize=4096)). Results and exception objects are both cached, which lru_cache

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -71,7 +71,7 @@ class Ident:
         self.out_len = 0
 
     def try_small_punycode_decode(self) -> Optional[bool]:
-        def f(inp):
+        def f(inp) -> bool:
             inp = "".join(inp)
             self.disp += inp
             return True
@@ -495,9 +495,9 @@ class Printer:
     # self-referential backref chain raises RecursionError before this guard.
     RUST_MAX_RECURSION_COUNT = 256
 
-    def __init__(self, parser, out, bound, recursion=0):
+    def __init__(self, parser, out: str, bound, recursion=0):
         self.parser = parser
-        self.out = out
+        self.out: str = out
         self.bound_lifetime_depth = bound
         self.recursion = recursion
 
@@ -692,8 +692,8 @@ class Printer:
         try:
             p = self.parser_mut()
             tag = p.next_func()
-            if basic_type(tag):
-                ty = basic_type(tag)
+            ty = basic_type(tag)
+            if ty:
                 self.out += ty
                 return
 

--- a/src/smda/dalvik/DalvikDisassembler.py
+++ b/src/smda/dalvik/DalvikDisassembler.py
@@ -588,6 +588,15 @@ class DexReferenceResolver:
 
 
 class DalvikDisassembler:
+    """Recover method bodies from a raw DEX.
+
+    Every address in the report this produces is an **offset into the DEX file**: a method
+    starts at its code item's offset and each instruction address is that plus its position in
+    the bytecode. A DEX carries no load address, so there is no virtual address to report -
+    but the native backends do report one, and adding `base_addr` to an offset from here
+    produces a number that means nothing.
+    """
+
     MAX_SWITCH_TARGETS_FOR_HEURISTIC = 32
 
     def __init__(self, config):

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -323,7 +323,7 @@ class ElfSynthesizer(BinarySynthesizer):
                 )
         return segments
 
-    def _assembleFile(self, sections, segments, bitness, dynamic_range=None):
+    def _assembleFile(self, sections, segments, bitness, dynamic_range=None) -> bytes:
         is_64 = bitness == 64
         ehdr_size = 64 if is_64 else 52
         phent_size = 56 if is_64 else 32
@@ -553,7 +553,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
         return bytes(output)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         sections = self._prepareSections(sections, offsets, with_strings)
         import_map = self._getImportMap() if with_imports else {}
@@ -563,7 +563,7 @@ class ElfSynthesizer(BinarySynthesizer):
         segments = self._mergeSegments(sections)
         return self._assembleFile(sections, segments, bitness, dynamic_range)
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         bitness = self._getBitness()
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -505,7 +505,7 @@ class MachoSynthesizer(BinarySynthesizer):
         libs = sorted({lib for lib, _ in import_map.values() if lib})
         return strtab, symtab, indirect_blob, libs, len(indirect)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         is_64 = self._is64()
         segments = self._prepareSections(sections, offsets, with_strings)
         sections = [section for segment in segments for section in segment["sections"]]
@@ -737,7 +737,7 @@ class MachoSynthesizer(BinarySynthesizer):
             flags,
         )
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {"name": "__text", "va_start": va_start, "va_end": va_end}
         return self._synthesizeFromSections([section], offsets, False, False)

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -322,7 +322,7 @@ class PeSynthesizer(BinarySynthesizer):
         header += b"\x00" * (size_of_headers - len(header))
         return header
 
-    def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
+    def _synthesizeFromHeader(self, offsets, with_imports, with_strings) -> bytes:
         base = self.report.base_addr
         pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
@@ -451,7 +451,7 @@ class PeSynthesizer(BinarySynthesizer):
             return base
         return candidate
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000

--- a/src/smda/utility/DexFileLoader.py
+++ b/src/smda/utility/DexFileLoader.py
@@ -93,7 +93,7 @@ class DexFileLoader:
         return 0
 
     @staticmethod
-    def getBitness(data, parsed=None):
+    def getBitness(data, parsed=None) -> int:
         return 32
 
     @staticmethod

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -1,7 +1,7 @@
 import re
 import string
 import struct
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaFunction import SmdaFunction
@@ -20,14 +20,15 @@ def read_bytes(smda_report, va, num_bytes=None):
     """
 
     rva = va - smda_report.base_addr
-    if smda_report.buffer is None:
+    buffer = smda_report.buffer
+    if buffer is None:
         raise ValueError("buffer is empty")
-    buffer_end = len(smda_report.buffer)
+    buffer_end = len(buffer)
     max_bytes = num_bytes if num_bytes is not None else 0x100
     if rva + max_bytes > buffer_end:
-        return smda_report.buffer[rva:]
+        return buffer[rva:]
     else:
-        return smda_report.buffer[rva : rva + max_bytes]
+        return buffer[rva : rva + max_bytes]
 
 
 def derefs(smda_report, p):
@@ -166,7 +167,7 @@ def read_string(smda_report, offset, maxlen=None):
     return res
 
 
-def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int, int, str]]:
+def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, Any, Any, str]]:
     """parse string features from the given instruction."""
     if mode == "go":
         # we address stack assigned strings and String structs

--- a/tests/testCilAddressSpace.py
+++ b/tests/testCilAddressSpace.py
@@ -1,0 +1,57 @@
+import os
+import unittest
+
+import dnfile
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+
+def _decode(name):
+    config = SmdaConfig()
+    with open(os.path.join(config.PROJECT_ROOT, "tests", name), "rb") as fixture:
+        raw = fixture.read()
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(raw))
+
+
+class CilOffsetsAreFileOffsetsTest(unittest.TestCase):
+    """The managed backend addresses a method by where its body sits in the file, where every
+    other backend reports a virtual address. Pinned rather than fixed: the offsets are a public
+    compatibility surface, so which space they are in is a deliberate decision. What a test can
+    do is stop it changing by accident and stop the README describing it wrongly."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.binary = _decode("njrat_xored")
+        cls.report = Disassembler(SmdaConfig(), backend="cil").disassembleUnmappedBuffer(cls.binary)
+        cls.recovered = {function.offset for function in cls.report.getFunctions()}
+
+    def testEveryRecoveredMethodIsAtItsBodysFileOffset(self):
+        parsed = dnfile.dnPE(data=self.binary)
+        declared = set()
+        for row in parsed.net.mdtables.MethodDef.rows:
+            if row.Rva:
+                declared.add(parsed.get_offset_from_rva(row.Rva))
+        self.assertTrue(declared)
+        self.assertTrue(self.recovered)
+        self.assertEqual(self.recovered - declared, set())
+
+    def testNoneOfThemIsTheVirtualAddressOfTheSameMethod(self):
+        """The control that makes the assertion above mean something. On this image the two
+        spaces are far enough apart that a report in either one satisfies the first test alone
+        only if it is in the file's."""
+        parsed = dnfile.dnPE(data=self.binary)
+        image_base = parsed.OPTIONAL_HEADER.ImageBase
+        virtual = {image_base + row.Rva for row in parsed.net.mdtables.MethodDef.rows if row.Rva}
+        self.assertTrue(virtual)
+        self.assertEqual(self.recovered & virtual, set())
+
+    def testTheReportSaysWhichBackendProducedIt(self):
+        """A consumer can only apply the rule if the report identifies itself. Two fields do:
+        the architecture, and the language score map."""
+        self.assertEqual(self.report.architecture, "cil")
+        self.assertIn(".net", self.report.toDict()["metadata"]["language"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testCilAddressSpace.py
+++ b/tests/testCilAddressSpace.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import dnfile
+import lief
 
 from smda.Disassembler import Disassembler
 from smda.SmdaConfig import SmdaConfig
@@ -51,6 +52,39 @@ class CilOffsetsAreFileOffsetsTest(unittest.TestCase):
         the architecture, and the language score map."""
         self.assertEqual(self.report.architecture, "cil")
         self.assertIn(".net", self.report.toDict()["metadata"]["language"])
+
+
+class DalvikOffsetsAreFileOffsetsTest(unittest.TestCase):
+    """The other managed backend, for a different reason: a DEX carries no load address, so a
+    code item's offset in the file is the only address there is. Pinned alongside CIL because
+    documenting one and not the other tells a consumer to read these as virtual addresses."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.binary = _decode("blockblast_classes_xored")
+        cls.report = Disassembler(SmdaConfig(), backend="dalvik").disassembleUnmappedBuffer(cls.binary)
+        cls.recovered = {function.offset for function in cls.report.getFunctions()}
+
+    def testEveryRecoveredMethodIsAtItsCodeItemsFileOffset(self):
+        """Cross-checked against a second parser rather than against the file's length -- with
+        `base_addr` at 0 an address inside the image proves nothing about which space it is
+        in, but matching the code-item offsets LIEF reads out of the DEX does."""
+        parsed = lief.DEX.parse(list(self.binary), "fixture.dex")
+        declared = {method.code_offset for method in parsed.methods if method.code_offset}
+
+        self.assertTrue(declared)
+        self.assertTrue(self.recovered)
+        self.assertEqual(self.recovered - declared, set())
+
+    def testEveryInstructionAddressIsAFileOffsetToo(self):
+        addresses = [
+            instruction.offset for function in self.report.getFunctions() for instruction in function.getInstructions()
+        ]
+        self.assertTrue(addresses)
+        self.assertLess(max(addresses), len(self.binary))
+
+    def testTheReportSaysWhichBackendProducedIt(self):
+        self.assertEqual(self.report.architecture, "dalvik")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A managed report's function and instruction offsets are **file offsets**. The native backends report **virtual addresses**. Nothing in the repository said so, so a consumer correlating a managed report with a native one — or with `base_addr` plus an RVA, or with any other tool's output — was silently comparing two different address spaces.

Two backends are affected, not one:

| `report.architecture` | what an offset is |
|---|---|
| `intel`, `aarch64` | a virtual address — `base_addr` plus an RVA |
| `cil` | the offset of the method body in the assembly file |
| `dalvik` | the offset of the code item in the DEX file |

The two managed cases differ in *why*, which is worth recording. A CIL method **has** an RVA and `CilDisassembler` reports the file offset instead — that is a choice. A DEX carries no load address at all, so for Dalvik the file offset is the only address there is. The consequence for a consumer is identical either way: adding `base_addr` to one of them produces a number that means nothing.

## The decision: document it, do not move it

The offsets are a public compatibility surface that downstream consumers index on. Converting them would change every stored managed report's addresses; carrying both would change the report schema. Either is a deliberate decision about the format rather than a bug fix, and neither belongs in a change that can be made without the people who consume it. What was actually missing is the statement.

The second half of the statement matters as much as the first: a report **already names the backend that produced it**, twice — `report.architecture`, and `metadata.language` in `toDict()`. So a consumer has what it needs to apply the right rule, once it knows there are two.

## What changed

- A `README` subsection under Usage, beside the raw-buffer section that covers the other thing about a report you cannot infer from it.
- Class docstrings on `CilDisassembler` and `DalvikDisassembler`, at the places the conversion is actually made.
- `tests/testCilAddressSpace.py`.

No behaviour change. The only edits under `src/smda/**` are docstrings.

## The tests

Both halves pin the contract against a **second parser**, not against the file's length — with `base_addr` at 0 an address inside the image proves nothing about which space it is in, and that weaker assertion would pass on a report that had been converted to virtual addresses.

- **CIL**, via dnfile: every recovered method sits at its body's file offset (`MethodDef.Rva` through `get_offset_from_rva`), and **none** sits at the virtual address of the same method (`ImageBase + Rva`). The second is the control that makes the first mean something.
- **Dalvik**, via LIEF: all 2,219 recovered offsets on the bundled DEX fixture are `code_offset` values LIEF independently reports for the same file.
- A third asserts the fields a consumer would branch on are actually populated, since the README now tells people to read them.

The Dalvik half is a correction to the first draft of this, which said offsets are virtual addresses on "every backend but one". That was wrong in the direction that matters: documenting only CIL would have told a consumer to read Dalvik offsets as addresses, the exact error the section exists to prevent.

## Validation

`ruff check` / `ruff format --check` pass, full suite green on this branch rebased onto current master (1820 passed, 1 skipped, 2584 subtests). Diff coverage reports no measurable lines, because the only `src/smda/**` lines are docstrings.

## Relationship to #299 and #300

This change is also sitting inside #299 and #300. Both of those were opened from branches that had my fork's master merged into them repeatedly, so their diffs are much wider than their titles suggest and they overlap each other as well.

This PR is the same change on its own, rebased onto current master, so it can be reviewed and measured for what it actually is. If you would rather take it through one of those, close this one; if you take this one, the matching hunks fall out of theirs on rebase.

## The `ty` commit at the tip

The last commit on this branch is #302's fix, cherry-picked unchanged.

Master fails `Code Quality` on its own right now: 572acd7 bumped `ty` to 0.0.74, and its new `unsound-return-statement` / `unsound-assignment` rules become errors under `[tool.ty.rules] all = "error"`. That is 41 errors across 15 files, none of which this PR touches — so every PR opened against master inherits a red check that says nothing about its own diff.

Carrying #302's commit here means this PR's CI reflects only this PR's work. It is the same commit, unmodified, so the moment #302 lands this one is empty and falls out on rebase — there is nothing to untangle later. If you would rather look at this branch without it, merge #302 first and I will drop it.

Checked against `ty` 0.0.74 itself rather than whatever an older local pin resolves to: on master it exits 1 with 41 errors, on this branch it exits 0 with none.
