### PR TITLE
perf(intel): refuse gap candidates the exception directory places inside a function

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -82,6 +82,32 @@ class SmdaConfig:
     # Inert unless the image is a ReadyToRun assembly whose COFF machine field names an
     # instruction set with a backend - there is nothing honest to route on otherwise.
     USE_READYTORUN_NATIVE_ROUTING = False
+    # Refuse a gap candidate that the image's own exception directory places inside a
+    # function, and resume at that function's end. A 64-bit PE carries one RUNTIME_FUNCTION
+    # record per function, each naming the extent the unwinder needs, so an interior address
+    # is declared to belong to a routine that starts earlier and cannot itself be an entry.
+    # Only the gap scan reaches these addresses: every one of them sits in a region no
+    # reference and no prologue claimed, which is exactly what the gap scan is for.
+    # Two conditions keep it from overreaching, and both matter. A chained record
+    # (UNW_FLAG_CHAININFO) describes a fragment of another function, so its first byte is
+    # interior too, while a primary record's first byte is the entry and stays bookable.
+    # And a primary range only suppresses once the analysis has actually recovered the
+    # function it names: a record whose function never analysed is not evidence about what
+    # covers the address.
+    # Measured on 24 built Rust cells (33,836 truth functions), precision 75.915 to 79.477
+    # and recall 97.496 to 97.584: 2,052 false positives removed, 48 real functions gained.
+    # On 47 built Go cells, 538 false positives removed with recall unchanged; on 68 MSVC
+    # PE64 cells, 1,220 removed and 48 gained.
+    # The control that this reaches only images carrying the table is 140 x86-64 ELF cells,
+    # bit-identical - the same backend and the same gap scan, on a container that declares
+    # no exception directory. 68 32-bit PE cells are bit-identical for the same reason, and
+    # none of the 68 declares one. (An ARM64 corpus is not a control here: AArch64 has its
+    # own candidate manager and never reaches this code.)
+    # Recall moves up because the interior candidate was not merely wrong: booking it began
+    # an analysis that ran past the end of the routine the address sat inside and absorbed
+    # the small aligned functions after it. On the cell examined, all eight functions
+    # recovered sit 11 to 79 bytes past a declared extent's end.
+    USE_PE_X64_PDATA_INTERIOR_GAPS = True
     # promote unclaimed ELF .eh_frame FDE starts as late candidates on both instruction sets
     # (after the primary pass, before gap analysis). Unwind ranges are not function starts by
     # definition - .eh_frame also covers ranges that are not independent functions. Measured

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -7,6 +7,7 @@ prologue byte-pattern seeding, jmp/call-pointer and PLT stub-chain discovery,
 PE x64 ``.pdata`` exception-record seeding, and the NOP/padding-aware gap scan.
 """
 
+import bisect
 import logging
 import re
 import struct
@@ -99,10 +100,22 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         super().__init__(config)
         self.pdata_start_addresses = set()
         self.pdata_end_addresses = set()
+        #: (start, end, is_chained) for every RUNTIME_FUNCTION record the image declares,
+        #: sorted lazily on first lookup because seeding appends in table order. Uncapped,
+        #: unlike the candidate registry: one tuple per record is about 145 bytes, so an
+        #: image with 200,000 functions holds ~29 MB here, and capping it would silently
+        #: stop suppressing on exactly the largest images rather than bounding anything
+        #: that matters.
+        self._pdata_ranges = []
+        self._pdata_range_starts = None
+        self._pdata_range_reach = []
         self._retained_pad = None
 
     def init(self, disassembly, cbAnalysisTimeout=None):
         self._retained_pad = None
+        self._pdata_ranges = []
+        self._pdata_range_starts = None
+        self._pdata_range_reach = []
         # the gap scan decodes potential NOP instructions, so it needs an x86 capstone
         # matching the binary's bitness; build it before the base init runs discovery
         self.capstone = Cs(CS_ARCH_X86, CS_MODE_32)
@@ -302,6 +315,22 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 )
                 self.gap_pointer = self.getNextGap()
                 continue
+            if self._pdata_ranges and self.config.USE_PE_X64_PDATA_INTERIOR_GAPS:
+                # the emptiness test comes first: this runs once per scanned gap byte, and on
+                # a 32-bit or non-PE image there is no table to consult at all
+                containing = self.declaredExceptionRangeContaining(self.gap_pointer)
+                if containing is not None and (containing[2] or containing[0] in self.disassembly.functions):
+                    # A chained record is evidence on its own -- it says the whole extent is
+                    # part of another function. A primary record only speaks once the function
+                    # it names has actually been recovered; until then the record says nothing
+                    # about what covers this address. Resuming at the extent's end skips the
+                    # body rather than the one byte, which is what the record describes.
+                    LOGGER.debug(
+                        "nextGapCandidate() gap_ptr is inside a declared .pdata extent: 0x%08x",
+                        self.gap_pointer,
+                    )
+                    self.gap_pointer = containing[1]
+                    continue
             # we may have a candidate here
             LOGGER.debug("nextGapCandidate() using 0x%08x as candidate", self.gap_pointer)
             start_byte = byte[0] if byte else 0
@@ -702,13 +731,20 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         if self.disassembly.binary_info.bitness == 64:
             self.pdata_start_addresses = set()
             self.pdata_end_addresses = set()
+            self._pdata_ranges = []
+            self._pdata_range_starts = None
+            # A RUNTIME_FUNCTION table is a PE construct. Nothing else in this walk says so -
+            # it looks for a section named `.pdata`, and `getSections` yields for ELF and
+            # Mach-O too, so a 64-bit ELF carrying a section of that name would otherwise
+            # have its regions removed on the strength of bytes that mean something else.
+            is_pe = self.disassembly.binary_info._getLiefType() == "PE"
             record_pdata_ends = self.config.USE_PE_X64_PDATA_ENDS
             base_addr = self.disassembly.binary_info.base_addr
             has_sections = False
             for section_info in self.disassembly.binary_info.getSections():
                 has_sections = True
                 section_name, section_va_start, section_va_end = section_info
-                if section_name == ".pdata":
+                if is_pe and section_name == ".pdata":
                     rva_start = section_va_start - self.disassembly.binary_info.base_addr
                     rva_end = section_va_end - self.disassembly.binary_info.base_addr
                     # .pdata entries are 12 bytes long (3 DWORDs): BeginAddress, EndAddress, UnwindInfoAddress
@@ -729,8 +765,17 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if not has_sections:
                 self._carveExceptionRecords(base_addr, record_pdata_ends)
 
-    def _admitExceptionRecord(self, base_addr, rva_function_candidate, rva_function_end, rva_unwind_info, ends):
-        if self._isChainedUnwindInfo(rva_unwind_info):
+    def _admitExceptionRecord(
+        self, base_addr, rva_function_candidate, rva_function_end, rva_unwind_info, ends, declared=True
+    ):
+        chained = self._isChainedUnwindInfo(rva_unwind_info)
+        if declared and self._isTrustworthyExceptionExtent(rva_function_candidate, rva_function_end, rva_unwind_info):
+            # Every record's extent is kept, chained or not: the unwinder is naming the bytes
+            # that belong to a routine, which is as true of a fragment as of a whole function.
+            # Only the first byte differs, and the flag is what says which case this is.
+            self._pdata_ranges.append((base_addr + rva_function_candidate, base_addr + rva_function_end, chained))
+            self._pdata_range_starts = None
+        if chained:
             # UNW_FLAG_CHAININFO: this entry is a secondary fragment (e.g. a
             # split-off cold/epilogue chunk) chained to another function's
             # primary RUNTIME_FUNCTION entry, not an independent function start.
@@ -741,6 +786,43 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # (EndAddress <= BeginAddress) entries and keep them as VAs.
             self.pdata_start_addresses.add(base_addr + rva_function_candidate)
             self.pdata_end_addresses.add(base_addr + rva_function_end)
+
+    def _isTrustworthyExceptionExtent(self, rva_function_candidate, rva_function_end, rva_unwind_info):
+        """Whether a record's extent may be used to skip a region of the image.
+
+        Seeding a candidate from a record costs one bad address when the record is wrong.
+        Skipping a region on one costs every gap-only function it covers, because a gap
+        pointer sent past the end of the image ends gap analysis rather than resuming it.
+        That asymmetry decides both of the things this function is.
+
+        Only records from a table the image declares reach it at all. A dump keeps its
+        mapped bytes but usually not a section header, so the table has to be found in the
+        bytes instead, and a table located by searching for one is a reconstruction: good
+        enough to add candidates, not good enough to remove regions. That is why `declared`
+        gates this rather than the checks below being made stricter.
+
+        A declared table still has to earn it. The section-table path reads twelve bytes
+        wherever the section header points with nothing checking that they describe a
+        function, and a truncated or deliberately malformed table is ordinary input for
+        this disassembler. These are the bounds `_readExceptionRecord` already applies when
+        the table has to be found in a headerless dump instead of being pointed at. The
+        unwind record is among them because `_isChainedUnwindInfo` reads its first byte,
+        and a chained record is the one case whose extent suppresses without the analysis
+        having recovered the function it names.
+
+        A record that fails this is still seeded as a candidate exactly as before. It only
+        stops speaking for the bytes around it.
+        """
+        if rva_function_end <= rva_function_candidate:
+            return False
+        if rva_function_end > len(self.disassembly.binary_info.binary):
+            return False
+        if rva_function_end - rva_function_candidate > _PDATA_MAX_FUNCTION_SIZE:
+            return False
+        if rva_unwind_info & 3:
+            return False
+        header_byte = self.disassembly.getRawBytes(rva_unwind_info, 1)
+        return bool(header_byte) and header_byte[0] in _UNWIND_INFO_FIRST_BYTES
 
     def _readExceptionRecord(self, binary, size, offset, previous_end):
         """returns a validated RUNTIME_FUNCTION triple at offset, or None."""
@@ -819,7 +901,41 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             rva_start, rva_end, rva_unwind_info = struct.unpack_from(
                 "<III", binary, table_offset + index * _PDATA_ENTRY_SIZE
             )
-            self._admitExceptionRecord(base_addr, rva_start, rva_end, rva_unwind_info, record_pdata_ends)
+            self._admitExceptionRecord(
+                base_addr, rva_start, rva_end, rva_unwind_info, record_pdata_ends, declared=False
+            )
+
+    def declaredExceptionRangeContaining(self, addr):
+        """The RUNTIME_FUNCTION extent `addr` sits inside without being an entry, or None.
+
+        `(start, end, is_chained)`. A primary record's own start is the function's entry, so
+        only a strictly interior address answers; a chained record describes a fragment of
+        some other function, so its first byte is interior too and answers as well.
+
+        Extents are deliberately not merged. Functions are laid out end-to-start, so merging
+        adjacent records would collapse the text section into a handful of spans in which
+        every address but the first reads as interior.
+        """
+        if self._pdata_range_starts is None:
+            self._pdata_ranges.sort()
+            self._pdata_range_starts = [start for start, _, _ in self._pdata_ranges]
+            # Sorting by start does not order the ends, so "the previous record ends before
+            # `addr`" says nothing about the one before that. Two short records in front of
+            # a long one would end the walk on top of the extent that actually covers the
+            # address. The running maximum is what can be tested in one step: once no record
+            # at or before this index reaches past `addr`, none of them contains it.
+            highest = 0
+            self._pdata_range_reach = []
+            for _, end, _chained in self._pdata_ranges:
+                highest = max(highest, end)
+                self._pdata_range_reach.append(highest)
+        index = bisect.bisect_right(self._pdata_range_starts, addr) - 1
+        while index >= 0 and self._pdata_range_reach[index] > addr:
+            start, end, chained = self._pdata_ranges[index]
+            if addr < end and (start < addr or chained):
+                return start, end, chained
+            index -= 1
+        return None
 
     def _isChainedUnwindInfo(self, rva_unwind_info):
         # x64 UNWIND_INFO header byte 0 packs Version (bits 0-2) and Flags (bits 3-7);

--- a/tests/testPdataExtraction.py
+++ b/tests/testPdataExtraction.py
@@ -101,6 +101,12 @@ class MockBinaryInfo:
         self.code_areas = []
         self.pdata_size = pdata_size
 
+    def _getLiefType(self):
+        # what this double stands in for: a RUNTIME_FUNCTION table is a PE construct, and
+        # the walk asks so that a section merely named `.pdata` in some other container
+        # cannot be read as one
+        return "PE"
+
     def getSections(self):
         # yields name, start, end
         if self.pdata_size > 0:

--- a/tests/testPdataInteriorGaps.py
+++ b/tests/testPdataInteriorGaps.py
@@ -1,0 +1,422 @@
+#!/usr/bin/python
+"""Gap candidates the PE exception directory places inside a function.
+
+A 64-bit PE names one RUNTIME_FUNCTION per function, each carrying the extent the
+unwinder needs. An address strictly inside one of those extents belongs to a routine
+that starts earlier, so it is not an entry -- but nothing references it and no earlier
+flow reaches it, which is exactly the shape the gap scan books.
+
+Builds a minimal spec-valid PE32+ x86-64 image (4-byte e_lfanew, real PE\\0\\0 signature
+per the repo's PE fixture convention) with .text, .pdata and .xdata, so the rule can be
+driven end to end rather than only at the lookup.
+"""
+
+import os
+import struct
+import tempfile
+import unittest
+from unittest import mock
+
+import smda.intel.FunctionCandidateManager as intel_candidates
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.intel.FunctionCandidateManager import _PDATA_MIN_ENTRIES, FunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+
+IMAGE_BASE = 0x140000000
+TEXT_RVA, PDATA_RVA, XDATA_RVA = 0x1000, 0x2000, 0x3000
+FILE_ALIGN, SECT_ALIGN = 0x200, 0x1000
+
+#: UNWIND_INFO byte 0 packs Version (bits 0-2) and Flags (bits 3-7). 0x01 is version 1
+#: with no flags; 0x21 sets UNW_FLAG_CHAININFO, which marks the record a fragment of
+#: another function rather than a function of its own.
+UNWIND_PRIMARY, UNWIND_CHAINED = 0x01, 0x21
+UNWIND_PRIMARY_RVA, UNWIND_CHAINED_RVA = XDATA_RVA, XDATA_RVA + 4
+
+#: push rbp; mov rbp,rsp; pop rbp; ret -- what the prologue scan reads as an entry.
+ENTRY_SHAPED = bytes((0x55, 0x48, 0x89, 0xE5, 0x5D, 0xC3))
+#: mov eax,1; ret -- decodes and returns but opens with no prologue pattern, so the gap
+#: scan is the only pass that books it. That is the population this rule is aimed at: on
+#: the measured corpus the addresses it refuses are ones no prologue and no reference
+#: reached, and widening it to the prologue scan would be a change nothing here measures.
+GAP_SHAPED = bytes((0xB8, 0x01, 0x00, 0x00, 0x00, 0xC3))
+INT3 = b"\xcc"
+
+
+def _build_pe(pdata_bytes, text_bytes, xdata_bytes=None, exc_size=None):
+    """Minimal PE32+ x86-64 image: .text (RX) @0x1000, .pdata @0x2000, .xdata @0x3000."""
+    if xdata_bytes is None:
+        xdata_bytes = struct.pack("<BBBB", UNWIND_PRIMARY, 0, 0, 0) + struct.pack("<BBBB", UNWIND_CHAINED, 0, 0, 0)
+    if exc_size is None:
+        exc_size = len(pdata_bytes)
+
+    dos = bytearray(0x40)
+    dos[0:2] = b"MZ"
+    dos[0x3C:0x40] = struct.pack("<I", 0x40)  # e_lfanew
+
+    coff = struct.pack("<HHIIIHH", 0x8664, 3, 0, 0, 0, 240, 0x0022)
+
+    data_dirs = [(0, 0)] * 16
+    data_dirs[3] = (PDATA_RVA, exc_size)  # IMAGE_DIRECTORY_ENTRY_EXCEPTION
+    opt = struct.pack(
+        "<HBBIIIIIQIIHHHHHHIIIIHHQQQQII",
+        0x20B,  # magic PE32+
+        14,
+        0,  # linker versions
+        len(text_bytes),
+        0,
+        0,  # sizes of code / initialized / uninitialized data
+        TEXT_RVA,  # entrypoint
+        TEXT_RVA,  # base of code
+        IMAGE_BASE,
+        SECT_ALIGN,
+        FILE_ALIGN,
+        6,
+        0,  # OS version
+        0,
+        0,  # image version
+        6,
+        0,  # subsystem version
+        0,  # win32 version
+        0x4000,  # size of image
+        FILE_ALIGN,  # size of headers
+        0,  # checksum
+        3,
+        0,  # subsystem CUI, dll characteristics
+        0x100000,
+        0x1000,
+        0x100000,
+        0x1000,  # stack/heap reserve+commit
+        0,  # loader flags
+        16,  # number of rva and sizes
+    ) + b"".join(struct.pack("<II", rva, size) for rva, size in data_dirs)
+
+    def shdr(name, rva, vsize, raw_off, raw_size, characteristics):
+        return struct.pack("<8sIIIIIIHHI", name, vsize, rva, raw_size, raw_off, 0, 0, 0, 0, characteristics)
+
+    sections = (
+        shdr(b".text", TEXT_RVA, len(text_bytes), 0x200, 0x200, 0x60000020)  # CODE|EXECUTE|READ
+        + shdr(b".pdata", PDATA_RVA, max(len(pdata_bytes), 1), 0x400, 0x200, 0x40000040)
+        + shdr(b".xdata", XDATA_RVA, max(len(xdata_bytes), 1), 0x600, 0x200, 0x40000040)
+    )
+
+    headers = bytes(dos) + b"PE\x00\x00" + coff + opt + sections
+    assert len(headers) <= FILE_ALIGN
+    blob = bytearray(0x800)
+    blob[0 : len(headers)] = headers
+    blob[0x200 : 0x200 + len(text_bytes)] = text_bytes
+    blob[0x400 : 0x400 + len(pdata_bytes)] = pdata_bytes
+    blob[0x600 : 0x600 + len(xdata_bytes)] = xdata_bytes
+    return bytes(blob)
+
+
+def _record(begin_rva, end_rva, unwind_rva):
+    return struct.pack("<III", begin_rva, end_rva, unwind_rva)
+
+
+def _headerlessManager(records):
+    """A manager over a buffer with no container, the shape a memory dump arrives in.
+
+    The exception table has to be found in the bytes because there is no section header
+    naming it, which is the path this exercises. Bitness is stated rather than read, as
+    `disassembleBuffer` does for a dump, because nothing in the buffer declares it.
+    """
+    blob = bytearray(0x10000)
+    body = ENTRY_SHAPED + INT3 * (0x20 - len(ENTRY_SHAPED))
+    blob[TEXT_RVA : TEXT_RVA + 0x20 * _PDATA_MIN_ENTRIES] = body * _PDATA_MIN_ENTRIES
+    blob[UNWIND_PRIMARY_RVA] = UNWIND_PRIMARY
+    blob[0x5000 : 0x5000 + len(records)] = records
+    loader = FileLoader("/", map_file=True)
+    loader._loadFile(bytes(blob))
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+    disassembly.binary_info.bitness = 64
+    manager = FunctionCandidateManager(SmdaConfig())
+    manager.init(disassembly)
+    return manager
+
+
+def _manager(blob, interior_gaps=True):
+    loader = FileLoader("/", map_file=True)
+    loader._loadFile(blob)
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+    config = SmdaConfig()
+    config.USE_PE_X64_PDATA_INTERIOR_GAPS = interior_gaps
+    manager = FunctionCandidateManager(config)
+    manager.init(disassembly)
+    return manager
+
+
+def _analyse(blob, interior_gaps=True):
+    """Analyse through the file path, so the PE is mapped and .pdata sits at its RVA.
+
+    disassembleBuffer would read the same bytes as one flat span at the load address and
+    every RVA in the table would then name the wrong byte.
+    """
+    config = SmdaConfig()
+    config.USE_PE_X64_PDATA_INTERIOR_GAPS = interior_gaps
+    # written into a directory rather than through NamedTemporaryFile: Windows keeps that
+    # handle exclusive, so the analysis cannot open the path and reports nothing at all
+    with tempfile.TemporaryDirectory() as directory:
+        path = os.path.join(directory, "fixture.exe")
+        with open(path, "wb") as handle:
+            handle.write(blob)
+        return Disassembler(config=config).disassembleFile(path)
+
+
+#: .text layout shared by the end-to-end cases. A real entry at +0x00 that returns after
+#: six bytes, an island at +0x20 that nothing reaches and only the gap scan books, and a
+#: second real entry at +0x40. The first record's extent covers the island; the island is
+#: the address the rule has to refuse.
+ISLAND_RVA = TEXT_RVA + 0x20
+SECOND_RVA = TEXT_RVA + 0x40
+SHATTERED_TEXT = (
+    ENTRY_SHAPED
+    + INT3 * (0x20 - len(ENTRY_SHAPED))
+    + GAP_SHAPED
+    + INT3 * (0x20 - len(GAP_SHAPED))
+    + ENTRY_SHAPED
+    + INT3 * (0x20 - len(ENTRY_SHAPED))
+)
+#: one record covering [+0x00, +0x40) -- the island at +0x20 is interior to it -- and one
+#: covering the second function, so the table is not a single span
+SHATTERED_PDATA = _record(TEXT_RVA, SECOND_RVA, UNWIND_PRIMARY_RVA) + _record(
+    SECOND_RVA, SECOND_RVA + 0x20, UNWIND_PRIMARY_RVA
+)
+
+
+class PdataInteriorGapEndToEndTestSuite(unittest.TestCase):
+    def test_an_entry_shaped_island_inside_a_declared_extent_is_not_a_function(self):
+        report = _analyse(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        offsets = {function.offset for function in report.getFunctions()}
+        self.assertIn(IMAGE_BASE + TEXT_RVA, offsets)
+        self.assertIn(IMAGE_BASE + SECOND_RVA, offsets)
+        self.assertNotIn(IMAGE_BASE + ISLAND_RVA, offsets)
+
+    def test_the_same_island_is_a_function_with_the_rule_off(self):
+        # the control: without this rule nothing else in the engine refuses the island, so
+        # the assertion above is measuring the rule and not some unrelated filter
+        report = _analyse(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT), interior_gaps=False)
+        self.assertIn(IMAGE_BASE + ISLAND_RVA, {function.offset for function in report.getFunctions()})
+
+    def test_a_chained_records_own_first_byte_is_refused(self):
+        # a chained record is a fragment of another function, so unlike a primary record
+        # its BeginAddress is interior as well and must not survive as an entry
+        pdata = _record(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA) + _record(
+            ISLAND_RVA, SECOND_RVA, UNWIND_CHAINED_RVA
+        )
+        report = _analyse(_build_pe(pdata, SHATTERED_TEXT))
+        offsets = {function.offset for function in report.getFunctions()}
+        self.assertIn(IMAGE_BASE + TEXT_RVA, offsets)
+        self.assertNotIn(IMAGE_BASE + ISLAND_RVA, offsets)
+
+    def test_a_primary_extent_whose_function_never_analysed_refuses_nothing(self):
+        """The recovered-function guard, exercised where the extent really does cover the island.
+
+        An earlier version of this pointed the record at the `.pdata` section itself, which
+        put End below Begin - so the extent was refused as untrustworthy and never recorded,
+        and the assertion held for a reason that had nothing to do with the guard. Deleting
+        the guard left it green.
+        """
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        manager._pdata_ranges = [(IMAGE_BASE + TEXT_RVA, IMAGE_BASE + SECOND_RVA, False)]
+        manager._pdata_range_starts = None
+        manager.gap_pointer = IMAGE_BASE + ISLAND_RVA
+        self.assertEqual(manager.nextGapCandidate(), IMAGE_BASE + ISLAND_RVA)
+
+    def test_a_primary_extent_refuses_once_its_function_is_recovered(self):
+        # the other arm of the same guard, so the pair fails if it is deleted
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        manager._pdata_ranges = [(IMAGE_BASE + TEXT_RVA, IMAGE_BASE + SECOND_RVA, False)]
+        manager._pdata_range_starts = None
+        manager.disassembly.functions = {IMAGE_BASE + TEXT_RVA: []}
+        manager.gap_pointer = IMAGE_BASE + ISLAND_RVA
+        self.assertNotEqual(manager.nextGapCandidate(), IMAGE_BASE + ISLAND_RVA)
+
+    def test_the_flag_is_on_by_default(self):
+        self.assertTrue(SmdaConfig().USE_PE_X64_PDATA_INTERIOR_GAPS)
+
+
+class DeclaredExceptionRangeTestSuite(unittest.TestCase):
+    """The lookup on its own, where every branch can be reached with a chosen table."""
+
+    def _lookup(self, ranges, addr):
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        manager._pdata_ranges = list(ranges)
+        manager._pdata_range_starts = None
+        return manager.declaredExceptionRangeContaining(addr)
+
+    def test_an_address_inside_a_primary_extent_answers(self):
+        self.assertEqual(self._lookup([(0x1000, 0x1040, False)], 0x1020), (0x1000, 0x1040, False))
+
+    def test_a_primary_extents_own_start_is_an_entry_and_does_not_answer(self):
+        self.assertIsNone(self._lookup([(0x1000, 0x1040, False)], 0x1000))
+
+    def test_a_chained_extents_own_start_answers(self):
+        self.assertEqual(self._lookup([(0x1000, 0x1040, True)], 0x1000), (0x1000, 0x1040, True))
+
+    def test_an_address_past_every_extent_does_not_answer(self):
+        self.assertIsNone(self._lookup([(0x1000, 0x1040, False), (0x1040, 0x1080, False)], 0x2000))
+
+    def test_an_address_before_every_extent_does_not_answer(self):
+        self.assertIsNone(self._lookup([(0x1000, 0x1040, False)], 0x800))
+
+    def test_an_enclosing_extent_two_short_ones_back_still_answers(self):
+        # sorting by start does not order the ends, so a test that only peeks at the record
+        # immediately before ends the walk on top of the extent that actually covers this
+        ranges = [(0x1000, 0x2000, False), (0x1010, 0x1020, False), (0x1030, 0x1040, False)]
+        self.assertEqual(self._lookup(ranges, 0x1050), (0x1000, 0x2000, False))
+
+    def test_an_earlier_extent_still_reaching_the_address_answers(self):
+        # unsorted and overlapping input is not what a linker emits, but the section path
+        # does not validate the table, so the walk back has to survive it
+        ranges = [(0x1000, 0x1100, False), (0x1020, 0x1030, False)]
+        self.assertEqual(self._lookup(ranges, 0x1080), (0x1000, 0x1100, False))
+
+    def test_a_gap_between_two_extents_does_not_answer(self):
+        ranges = [(0x1000, 0x1040, False), (0x1080, 0x10C0, False)]
+        self.assertIsNone(self._lookup(ranges, 0x1060))
+
+    def test_an_empty_table_answers_nothing(self):
+        self.assertIsNone(self._lookup([], 0x1020))
+
+    def test_the_sorted_index_is_reused_across_lookups(self):
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        manager._pdata_ranges = [(0x1040, 0x1080, False), (0x1000, 0x1040, False)]
+        manager._pdata_range_starts = None
+        self.assertEqual(manager.declaredExceptionRangeContaining(0x1020), (0x1000, 0x1040, False))
+        self.assertEqual(manager._pdata_range_starts, [0x1000, 0x1040])
+        self.assertEqual(manager.declaredExceptionRangeContaining(0x1060), (0x1040, 0x1080, False))
+
+
+class PdataRangeRecordingTestSuite(unittest.TestCase):
+    def test_both_primary_and_chained_records_contribute_an_extent(self):
+        pdata = _record(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA) + _record(
+            ISLAND_RVA, SECOND_RVA, UNWIND_CHAINED_RVA
+        )
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        self.assertEqual(
+            sorted(manager._pdata_ranges),
+            [
+                (IMAGE_BASE + TEXT_RVA, IMAGE_BASE + TEXT_RVA + 0x20, False),
+                (IMAGE_BASE + ISLAND_RVA, IMAGE_BASE + SECOND_RVA, True),
+            ],
+        )
+
+    def test_only_the_primary_record_becomes_an_exception_candidate(self):
+        pdata = _record(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA) + _record(
+            ISLAND_RVA, SECOND_RVA, UNWIND_CHAINED_RVA
+        )
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        booked = {addr for addr, candidate in manager.candidates.items() if candidate.is_exception_handler}
+        self.assertIn(IMAGE_BASE + TEXT_RVA, booked)
+        self.assertNotIn(IMAGE_BASE + ISLAND_RVA, booked)
+
+    def test_a_degenerate_record_contributes_no_extent(self):
+        # EndAddress <= BeginAddress describes nothing; keeping it would put a zero-width
+        # or inverted span in the table the walk back assumes is ordered
+        pdata = _record(TEXT_RVA, TEXT_RVA, UNWIND_PRIMARY_RVA)
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        self.assertEqual(manager._pdata_ranges, [])
+
+    def test_an_extent_running_past_the_image_contributes_nothing(self):
+        # the expensive direction: seeding a bad candidate costs one address, but skipping a
+        # region on a bad extent sends the gap pointer past the end of the image, which ends
+        # gap analysis rather than resuming it
+        pdata = _record(TEXT_RVA, 0x7FFFFFF0, UNWIND_PRIMARY_RVA)
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        self.assertEqual(manager._pdata_ranges, [])
+
+    def test_the_image_bound_is_what_refuses_an_extent_inside_the_size_cap(self):
+        # 0x7ffffff0 above is over the span cap as well, so it does not reach the image
+        # bound and would pass with that check deleted. This span is under the cap and still
+        # past the end of a 0x3200-byte image, which only the bound refuses.
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        self.assertLess(len(manager.disassembly.binary_info.binary), 0x5000)
+        self.assertFalse(manager._isTrustworthyExceptionExtent(TEXT_RVA, 0x5000, UNWIND_PRIMARY_RVA))
+
+    def test_an_unwind_pointer_that_is_not_dword_aligned_contributes_nothing(self):
+        # the carved path already requires this; a declared table is not more trustworthy
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        self.assertFalse(manager._isTrustworthyExceptionExtent(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA + 1))
+
+    def test_the_sorted_index_is_rebuilt_after_a_later_append(self):
+        # every append happens before the gap scan reads the table, so this contract is not
+        # exercised in production; it is asserted here so that stops being true silently
+        beyond = IMAGE_BASE + SECOND_RVA + 0x30
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        self.assertIsNone(manager.declaredExceptionRangeContaining(beyond))
+        manager._admitExceptionRecord(IMAGE_BASE, SECOND_RVA + 0x20, SECOND_RVA + 0x40, UNWIND_PRIMARY_RVA, False)
+        self.assertIsNone(manager._pdata_range_starts)
+        self.assertEqual(
+            manager.declaredExceptionRangeContaining(beyond),
+            (IMAGE_BASE + SECOND_RVA + 0x20, IMAGE_BASE + SECOND_RVA + 0x40, False),
+        )
+
+    def test_a_record_with_an_unreadable_unwind_info_contributes_nothing(self):
+        pdata = _record(TEXT_RVA, TEXT_RVA + 0x20, 0x900000)
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        self.assertEqual(manager._pdata_ranges, [])
+
+    def test_a_record_whose_unwind_info_is_not_a_header_contributes_nothing(self):
+        # `.text` opens 0x55, which is not one of the eight legal UNWIND_INFO first bytes.
+        # This is the check that makes the chained flag worth trusting, and a chained
+        # extent is the one that suppresses without waiting for its function to be found.
+        pdata = _record(TEXT_RVA, TEXT_RVA + 0x20, TEXT_RVA)
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        self.assertEqual(manager._pdata_ranges, [])
+
+    def test_an_extent_longer_than_any_function_contributes_nothing(self):
+        # an extent both inside the image and over the cap needs an image larger than the
+        # cap, so the cap comes down rather than the fixture growing to a megabyte
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        self.assertTrue(manager._isTrustworthyExceptionExtent(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA))
+        with mock.patch.object(intel_candidates, "_PDATA_MAX_FUNCTION_SIZE", 0x10):
+            self.assertFalse(manager._isTrustworthyExceptionExtent(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA))
+
+    def test_a_refused_extent_does_not_end_the_gap_scan(self):
+        pdata = _record(TEXT_RVA, TEXT_RVA + 0x20, UNWIND_PRIMARY_RVA) + _record(
+            ISLAND_RVA, 0x7FFFFFF0, UNWIND_CHAINED_RVA
+        )
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        manager.gap_pointer = IMAGE_BASE + ISLAND_RVA
+        self.assertEqual(manager.nextGapCandidate(), IMAGE_BASE + ISLAND_RVA)
+
+    def test_the_record_is_still_seeded_when_its_extent_is_refused(self):
+        # refusing an extent narrows what the record speaks for; it does not discard it
+        pdata = _record(TEXT_RVA, 0x7FFFFFF0, UNWIND_PRIMARY_RVA)
+        manager = _manager(_build_pe(pdata, SHATTERED_TEXT))
+        booked = {addr for addr, candidate in manager.candidates.items() if candidate.is_exception_handler}
+        self.assertIn(IMAGE_BASE + TEXT_RVA, booked)
+
+    def test_a_carved_table_seeds_candidates_and_contributes_no_extent(self):
+        """A table found by searching the bytes may add candidates; it may not remove regions.
+
+        A memory dump keeps its mapped bytes and usually not a section header, so the table
+        has to be located in the bytes. A wrong entry then costs one bad candidate when it
+        seeds, and every gap-only function it covers when it suppresses.
+        """
+        records = b"".join(
+            _record(TEXT_RVA + index * 0x20, TEXT_RVA + index * 0x20 + 0x10, UNWIND_PRIMARY_RVA)
+            for index in range(_PDATA_MIN_ENTRIES)
+        )
+        manager = _headerlessManager(records)
+        booked = {addr for addr, candidate in manager.candidates.items() if candidate.is_exception_handler}
+        self.assertTrue(booked, "the carved table should still seed candidates")
+        self.assertEqual(manager._pdata_ranges, [])
+
+    def test_reinitialising_the_manager_drops_the_previous_images_extents(self):
+        manager = _manager(_build_pe(SHATTERED_PDATA, SHATTERED_TEXT))
+        self.assertTrue(manager._pdata_ranges)
+        loader = FileLoader("/", map_file=True)
+        loader._loadFile(_build_pe(_record(TEXT_RVA, TEXT_RVA, UNWIND_PRIMARY_RVA), SHATTERED_TEXT))
+        disassembly = DisassemblyResult()
+        disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+        manager.init(disassembly)
+        self.assertEqual(manager._pdata_ranges, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A 64-bit PE carries one `RUNTIME_FUNCTION` record per function, each naming the extent the unwinder needs. Candidate discovery already reads that table to seed function starts — and never consults it again. So the gap scan stayed free to carve extra entries out of addresses the image had already declared to belong to a routine that starts earlier.

Those are precisely the addresses the gap scan reaches: no reference and no prologue claims them, which is why they survive to it.

## Root cause, measured before anything was written

Over three 64-bit PE cells of a built Rust corpus, of the false positives the gap scan **alone** booked, **734 of 743 (98.8%)** sit strictly inside a declared `.pdata` extent. The two populations separate exactly, not statistically:

- **0** of the 878 true positives the gap scan alone booked are interior to a declared extent.
- **0** of the 5,114 truth functions on those cells are interior to a declared extent.

## The fix

`USE_PE_X64_PDATA_INTERIOR_GAPS`, on by default. A gap candidate the exception directory places inside a function is refused, and the scan resumes at that function's end rather than one byte on.

Four conditions keep it from overreaching. Three were needed from the start; the fourth came from a corpus that caught the change being wrong.

- A **chained** record (`UNW_FLAG_CHAININFO`) describes a fragment of another function, so its own first byte is interior too. A primary record's first byte is the entry and stays bookable.
- A primary extent only suppresses once the function it names has actually been **recovered**.
- Each extent is **bounds-checked** before it is believed: end above start, end within the image, span under `_PDATA_MAX_FUNCTION_SIZE`, unwind pointer DWORD-aligned, and its `UNWIND_INFO` first byte one of the eight legal values. These are the bounds `_readExceptionRecord` already applies when it has to find the table itself.
- Extents are recorded **only from a table the image declares**. That one is the whole difference between a win and a regression — see below.

Extents are deliberately not merged: functions are laid out end-to-start, and merging adjacent records would collapse `.text` into a handful of spans in which every address but the first reads as interior.

## The regression this shipped with, and what fixed it

The first version trusted the table however it was obtained. On built corpora that was invisible. On a 57-sample malware corpus it cost **1,274 functions on one memory dump**, 254 of which a structural reading calls real.

**The engine reads the exception table two ways and they are not equally trustworthy.** When the image declares a section table, the directory's location is read from it. When it does not — normal for a memory dump, whose mapped bytes survive while its header does not — the table has to be *found*, by scanning for a run of entries that validate as `RUNTIME_FUNCTION` records. That reconstruction was already used to seed candidates, where a wrong entry costs one bad address. Extending it to suppression made a wrong entry cost every gap-only function inside whatever range it named.

| | malware dumps, n=57 |
|---|---|
| trusting a carved table | **−1,274 functions** on one sample |
| declared tables only | **−1 function, −1 false positive** |

The narrowing is free on every image that has a section header — built Rust is byte-identical across it — and is the whole of the regression on the images that do not. The direct control is a 56-sample **headerless** ByteWeight variant, the same PE64 binaries with their headers stripped: bit-identical on both sides, because the only table available there is a carved one and a carved one now suppresses nothing.

The general form is worth keeping: **seeding is cheap and self-correcting; suppression is expensive and silent.** A wrong seed is one false positive later passes may absorb. A wrong suppression removes a region and nothing reports that it was removed. A source good enough for one is not automatically good enough for the other.

### The one remaining loss is a defect in the oracle

`0x14001161b` on an x64 dump. The image's own `.pdata` declares a single function `[0x140011424, 0x140011662)`; the corpus' manually annotated truth puts a second function inside it. The contested address is **unaligned** where 87.8% of that sample's truth is 16-aligned, has **zero inbound references**, and **falls through without returning** — eleven instructions ending in a `mov`. The function it sits inside is referenced, 133 instructions long, and ends in `ret`.

That is a tail block annotated as a function. It is stated rather than argued away, because a single contested address is exactly where the temptation to fit the measurement to the change is strongest.

## What it moves

| corpus | n | PPV | TPR | Δ FP | Δ TP |
|---|---|---|---|---|---|
| ByteWeight MSVC PE64 | 68 | 99.080 → **99.869** | 99.838 → **99.851** | **−1,220** | **+48** |
| Built Rust | 24 | 75.915 → **79.477** | 97.496 → **97.584** | **−2,052** | **+48** |
| Built Go | 47 | 94.036 → **94.342** | unchanged | **−538** | 0 |
| malware dumps | 57 | 92.639 → 92.645 | 98.561 → 98.552 | −1 | −1 (above) |

Recall rises on three of the four. That was not the intent — the rule only refuses candidates — and the mechanism is worth naming: booking an interior address is not merely a wrong entry, it starts an analysis that runs past the end of the routine the address sits inside and absorbs the small aligned functions after it. All eight functions recovered on the cell examined sit 11 to 79 bytes past a declared extent's end.

## Controls

Every corpus that does not carry a 64-bit PE exception directory is **bit-identical**:

| corpus | n | result |
|---|---|---|
| Built C/C++ ELF, x86-64 | 140 | bit-identical — 93.740 / 96.968, 113,438 TP, 14,123 FP both sides |
| ByteWeight MSVC PE32 | 68 | bit-identical — 92.041 / 97.872 |
| ByteWeight MSVC PE64, **headerless dumps** | 56 | bit-identical — 98.874 / 99.811, 106,403 TP, 2,052 FP both sides |
| Built Rust, `linux-gnu` and `windows-gnu-x86` | 16 of 24 | bit-identical |

**The x86-64 ELF corpus is the control that counts**, because it runs the same backend and the same gap scan on a container that declares no exception directory. ARM64 corpora prove nothing here — AArch64 has its own candidate manager and never reaches this code.

The 32-bit result has a structural explanation rather than a lucky one: **0 of 68 32-bit PEs declare an exception directory, against 68 of 68 of the 64-bit ones.**

## Bug-class sweep

The class is *a declared function extent the engine reads for candidates but never for suppression*.

| site | state |
|---|---|
| intel, PE x64 `.pdata`, declared table | fixed here |
| intel, PE x64 `.pdata`, carved from a headerless dump | deliberately **not** used for suppression — see above |
| intel, ELF `.eh_frame` | covered by `USE_ELF_FDE_INTERIOR_GAPS` in #300 |
| aarch64, PE ARM64 `.pdata` | **not fixed here** — the extent is reconstructible, but there is no ARM64 PE anywhere in the 305 operator-supplied samples available, and this PR is itself the argument against shipping an unmeasured suppression rule |
| CIL, Dalvik | cannot occur; neither backend gap-scans, the base `nextGapCandidate` raises |
| Mach-O `LC_FUNCTION_STARTS` | names starts, not extents; nothing to suppress with |

## Review findings addressed

An adversarial review of this diff found seven items. The two that mattered:

- **The walk-back in `declaredExceptionRangeContaining` was wrong**, and its docstring justified it with a false claim — sorting by start does not order the ends, so "the previous record ends before this address" says nothing about the one before that. Two short extents in front of a long one ended the walk on top of the extent that actually covered the address. Replaced with a running maximum of reach. It failed open, so it could only cost precision, and it is unreachable from a conforming table — but the reasoning was wrong and written down as if it were not.
- **The recovered-function guard had no coverage.** Its test used a record with End below Begin, so no extent was recorded at all and the assertion held for an unrelated reason; deleting the guard entirely left the suite green. Same for the image-bound check, shadowed by the span cap.

All three guards are now mutation-tested: deleting any one of them makes a test fail. Also from that review — a PE check, since `getSections()` yields for ELF and Mach-O and a section merely *named* `.pdata` should not be read as an exception directory; the DWORD-alignment test the carved path already required; and a note on the extent list's memory (~29 MB at 200,000 functions, uncapped on purpose, because a cap would silently stop suppressing on exactly the largest images).

## Tests

`tests/testPdataInteriorGaps.py`, 30 cases over a minimal spec-valid PE32+ x86-64 image with `.text`, `.pdata` and `.xdata`, driven end to end, plus the lookup and the extent predicate on their own where every branch can be reached with a chosen table. A headerless fixture with a stated bitness drives the carve path.

The end-to-end fixture's island is `mov eax,1; ret` rather than a prologue shape **on purpose**: the first version used `push rbp; mov rbp,rsp`, and the prologue scan booked it before the gap scan ever saw it, so the test would have passed for the wrong reason.

`tests/testPdataExtraction.py` gains one method on its `MockBinaryInfo` — the double now answers what container it stands for, which is what the new PE check asks.

## Validation

`ruff check` / `ruff format --check` pass, full suite green on this branch with current master merged in (1913 passed, 1 skipped, 2591 subtests), diff coverage 100% with 0 missing lines.

Every figure above was taken on the change as proposed, not carried over from the run that motivated it. The built-Rust cells were re-measured after the review fixes and came back identical to the run that motivated them (79.477 / 97.584, 33,052 TP, 7,397 FP), so those fixes are behaviour-neutral on real images as well as bit-exact in intent.

## Branch shape

Rebased onto current master (395c88d) as a single commit, dropping the merge and the `fix(ci)` commit that #302 made redundant.

Content-neutral: the tree is `0fb222b`, byte for byte what the merge-based version resolved to, so the measurements above stand and nothing needed re-running. The one conflict — the `SmdaConfig.py` clash with #305, both appending an option block to the same region — is resolved by keeping both blocks, and the resulting option set is exactly the union of the two sides. `ruff check`, `ruff format --check` and `ty` 0.0.74 clean; the full suite was 1913 passed / 1 skipped / 2591 subtests on this identical tree.

## Scope note: the `is_pe` guard also gates seeding

Putting this on the record, since it is a real widening of scope that the title does not suggest.

The `is_pe` guard does not only gate suppression — it also stops `.pdata` **seeding** on a non-PE image. Before this, a 64-bit ELF carrying a section named `.pdata` would seed candidates from those bytes; now it will not.

I think that is right on its own terms: `RUNTIME_FUNCTION` is a PE construct, and reading arbitrary bytes out of a same-named ELF section as unwind records is not sound to begin with. But it is a change to candidate discovery living inside a PR about refusing gap candidates, so it should be a decision rather than a side effect. No bundled non-PE image carries such a section, so it is inert on the current fixtures either way. Happy to split it out if you would rather it were its own change.

## Relationship to #299 and #300

This change is also sitting inside #299 and #300. Both of those were opened from branches that had my fork's master merged into them repeatedly, so their diffs are much wider than their titles suggest and they overlap each other as well.

This PR is the same change on its own, so it can be reviewed and measured for what it actually is. If you would rather take it through one of those, close this one; if you take this one, the matching hunks fall out of theirs on merge.