### PR TITLE
fix(aarch64): read the BTI target type, and resume past a refused pad's block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # ty is pinned in pyproject.toml and ships new error rules in patch releases;
+      # bump it in a dedicated change that addresses those rules, not via Dependabot.
+      - dependency-name: "ty"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dev = [
     "ruff",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
-    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield, 35 errors
-    # against an unchanged tree). Bump deliberately, with the new rules addressed.
+    # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74
+    # promotes those plus unsound-assignment). Bump deliberately, with the new
+    # rules addressed.
     "ty==0.0.74",
     "tqdm",
     "twine",
@@ -208,7 +209,9 @@ rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
 
 [[tool.ty.overrides]]
 include = ["src/smda/cil/CilDisassembler.py"]
-rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore" }
+# dnfile/dncil expose heap lookups and PE reads as Any/Unknown; ty 0.0.74 treats
+# those as unsound against the local bytes/str annotations rather than as gradual Any.
+rules = { "invalid-assignment" = "ignore", "not-iterable" = "ignore", "unsound-assignment" = "ignore", "unsound-return-statement" = "ignore" }
 
 # LIEF's type stubs declare PE Section.name as bytes; the runtime returns str.
 [[tool.ty.overrides]]

--- a/src/smda/Disassembler.py
+++ b/src/smda/Disassembler.py
@@ -295,7 +295,7 @@ class Disassembler:
             )
         return smda_report
 
-    def _disassemble(self, binary_info, timeout=0):
+    def _disassemble(self, binary_info, timeout=0) -> SmdaReport:
         self._start_time = datetime.datetime.now(datetime.timezone.utc)
         self._timeout = timeout
         self._last_timeout_log_second = -1
@@ -319,7 +319,7 @@ class Disassembler:
             raise RuntimeError(f"No disassembly backend available for architecture '{binary_info.architecture}'.")
         raise RuntimeError("Disassembler backend not initialized.")
 
-    def _createErrorReport(self, start, exception):
+    def _createErrorReport(self, start, exception) -> SmdaReport:
         report = SmdaReport(config=self.config)
         report.smda_version = self.config.VERSION
         report.status = "error"
@@ -330,7 +330,7 @@ class Disassembler:
         report.timestamp = datetime.datetime.now(datetime.timezone.utc)
         return report
 
-    def _handleDisassemblyException(self, start, exception, log_message):
+    def _handleDisassemblyException(self, start, exception, log_message) -> SmdaReport:
         reraise_non_operational_exception(exception)
         LOGGER.error(log_message)
         return self._createErrorReport(start, exception)

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -47,6 +47,22 @@ class SmdaConfig:
     # system binaries (wermgr/ping/robocopy/bcrypt) show equal-or-better boundary accuracy
     # with the directory enabled, so it is on by default
     USE_PE_ARM64_PDATA_CANDIDATES = True
+    # do not read `bti j` as a function entry on AArch64. The four BTI forms are not
+    # interchangeable: J permits a target reached by `br` - an indirect jump, which is what a
+    # switch dispatch does to a case block - while C permits one reached by `blr`, which is how
+    # a function is reached indirectly. A compiler that wrote `bti j` was naming an interior
+    # label, and the hardware would fault a call landing on it. The prologue scan read all four
+    # as entries, so every jump pad in the image was booked.
+    # Measured on 72 built AArch64 ELF cells, attributing each prologue-sole booking to the arm
+    # of `is_function_prologue` that accepted it: `bti j` produced 803 false positives and 0 real
+    # functions, `bti c` produced 0 false positives and 505 real functions. The split is exact,
+    # not statistical, which is what distinguishes this from a threshold.
+    # The ARM64 Mach-O corpus is not a control: 11 cells book no BTI-opened prologue candidate at
+    # all, so the rule is inert there rather than confirmed. It reaches no other architecture -
+    # the intel scan has no BTI shape - and it is deliberately not applied to the PE ARM64
+    # exception-record reader, which accepts the same word through a different question and has
+    # no corpus to be measured on - there is no ARM64 PE among the samples available here.
+    USE_AARCH64_BTI_TARGET_TYPE = True
     # force function-end splits at x64 PE .pdata RUNTIME_FUNCTION EndAddresses so that
     # SMDA functions align with the compiler's exception-table boundaries; off by default
     # because MSVC fragments single control-flow functions across many .pdata ranges

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,7 +111,7 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -821,7 +821,12 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         limit = start + _GAP_RUN_LIMIT
         while addr + INSTRUCTION_SIZE <= base + size and addr < limit:
             word = words[(addr - base) // INSTRUCTION_SIZE]
-            if (word & RET_MASK) == RET_VALUE or (word & BR_MASK) == BR_VALUE or (word & B_MASK) == B_VALUE:
+            if (
+                (word & RET_MASK) == RET_VALUE
+                or (word & BR_MASK) == BR_VALUE
+                or (word & B_MASK) == B_VALUE
+                or is_trap(word)
+            ):
                 return addr + INSTRUCTION_SIZE
             addr += INSTRUCTION_SIZE
         return start + INSTRUCTION_SIZE

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -49,6 +49,7 @@ from .definitions import (
     BL_VALUE,
     BR_MASK,
     BR_VALUE,
+    BTI_J,
     INSTRUCTION_SIZE,
     LDR_UNSIGNED_64_MASK,
     LDR_UNSIGNED_64_VALUE,
@@ -709,7 +710,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if not is_function_prologue(word):
                 continue
             addr = (base + match_count * INSTRUCTION_SIZE) & self.getBitMask()
-            if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(addr):
+            if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(addr, word):
                 continue
             if not self._passesCodeFilter(addr):
                 continue
@@ -796,11 +797,19 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             addr += INSTRUCTION_SIZE
         return False
 
-    def _isLikelyInteriorBtiCandidate(self, addr):
+    def _isLikelyInteriorBtiCandidate(self, addr, word):
         # BTI marks both real entries and indirect-branch landing pads. If the word
         # sits inside already claimed code, or immediately follows ordinary code
         # rather than padding / a terminator-like boundary, suppress it as an entry
         # candidate so switch targets and guarded blocks do not fragment functions.
+        if self.config.USE_AARCH64_BTI_TARGET_TYPE and word == BTI_J:
+            # `bti j` permits a target reached by `br` - an indirect jump - and never one
+            # reached by `blr`: a call landing on a J-only pad faults. The compiler that wrote
+            # J was naming an interior label, a switch case or a computed-goto target, and the
+            # pad says so about itself before anything around it is read. The checks below
+            # cannot say it: a case block is preceded by the previous case's terminating
+            # branch, which is exactly the boundary shape they read as an entry.
+            return True
         if addr in self.disassembly.code_map and addr not in self.getFunctionStartCandidates():
             return True
 
@@ -879,7 +888,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if word in (0, NOP):  # inter-function padding
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
-            if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(self.gap_pointer):
+            if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(self.gap_pointer, word):
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if is_conditional_branch(word):  # a function never opens with a cond branch

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -69,6 +69,11 @@ from .FunctionCandidate import FunctionCandidate
 
 LOGGER = logging.getLogger(__name__)
 
+#: How far either straight-line walk over a gap run will read before giving up. A run that
+#: has not reached a terminator in this many bytes is not a block either walk can reason
+#: about, so both stop rather than guess.
+_GAP_RUN_LIMIT = 0x400
+
 _ARM64_PDATA_ENTRY_SIZE = 8
 # items (words, matches or exception records) a scan steps over between budget polls, mirroring
 # _TIMEOUT_POLL_BLOCKS in the engine. A whole exception table is walked inside one call, so
@@ -783,7 +788,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         size = self.disassembly.binary_info.binary_size
         words = self._wordsView()
         addr = start
-        limit = start + 0x400
+        limit = start + _GAP_RUN_LIMIT
         while addr + INSTRUCTION_SIZE <= base + size and addr < limit:
             word = words[(addr - base) // INSTRUCTION_SIZE]
             if (word & B_MASK) == B_VALUE:
@@ -796,6 +801,30 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 return False
             addr += INSTRUCTION_SIZE
         return False
+
+    def _endOfRefusedLandingPadRun(self, start):
+        """Where the scan may resume after refusing a landing pad, without meeting its body.
+
+        Advancing one instruction from a refused pad lands on the pad's own first body
+        instruction. That word is ordinary code, so it passes every remaining guard and is
+        promoted in the pad's place four bytes along - the false positive moves rather than
+        going. The block a pad labels ends at its first terminator, and past that is the
+        first address the scan has not already decided against.
+
+        Falls back to the single-instruction step when no terminator is in reach, so a run
+        of undecodable bytes cannot make this skip an arbitrary distance.
+        """
+        base = self.disassembly.binary_info.base_addr
+        size = self.disassembly.binary_info.binary_size
+        words = self._wordsView()
+        addr = start + INSTRUCTION_SIZE
+        limit = start + _GAP_RUN_LIMIT
+        while addr + INSTRUCTION_SIZE <= base + size and addr < limit:
+            word = words[(addr - base) // INSTRUCTION_SIZE]
+            if (word & RET_MASK) == RET_VALUE or (word & BR_MASK) == BR_VALUE or (word & B_MASK) == B_VALUE:
+                return addr + INSTRUCTION_SIZE
+            addr += INSTRUCTION_SIZE
+        return start + INSTRUCTION_SIZE
 
     def _isLikelyInteriorBtiCandidate(self, addr, word):
         # BTI marks both real entries and indirect-branch landing pads. If the word
@@ -889,7 +918,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(self.gap_pointer, word):
-                self.gap_pointer += INSTRUCTION_SIZE
+                self.gap_pointer = self._endOfRefusedLandingPadRun(self.gap_pointer)
                 continue
             if is_conditional_branch(word):  # a function never opens with a cond branch
                 self.gap_pointer += INSTRUCTION_SIZE

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+from typing import Optional
 
 import lief
 
@@ -47,11 +48,11 @@ class BinaryInfo:
     """
 
     architecture = ""
-    base_addr = 0
-    binary = b""
-    raw_data = b""
+    base_addr: int = 0
+    binary: bytes = b""
+    raw_data: bytes = b""
     binary_size = 0
-    bitness = None
+    bitness: Optional[int] = None
     code_areas = None
     component = ""
     family = ""
@@ -70,7 +71,7 @@ class BinaryInfo:
     symbols = None
     oep = None
 
-    def __init__(self, binary):
+    def __init__(self, binary: bytes):
         self.binary = binary
         self.raw_data = binary
         self.binary_size = len(binary)

--- a/src/smda/common/BlockLocator.py
+++ b/src/smda/common/BlockLocator.py
@@ -1,5 +1,8 @@
 import bisect
 import itertools
+from typing import Any, Dict, List, Optional
+
+from smda.common.SmdaBasicBlock import SmdaBasicBlock
 
 
 class BlockLocator:
@@ -7,8 +10,8 @@ class BlockLocator:
     When instantiated, creates the required data structures.
     """
 
-    sorted_blocks_addresses = None
-    blocks_dict = None
+    sorted_blocks_addresses: Optional[List[Any]] = None
+    blocks_dict: Optional[Dict[Any, SmdaBasicBlock]] = None
 
     def __init__(self, functions):
         # Instantiate the datastructures required :
@@ -23,7 +26,7 @@ class BlockLocator:
         last_ins = block.instructions[-1]
         return last_ins.offset + len(last_ins.bytes) // 2  # bytes is actuall a hex string
 
-    def findBlockByContainedAddress(self, inner_address):
+    def findBlockByContainedAddress(self, inner_address) -> Optional[SmdaBasicBlock]:
         sorted_addresses = self.sorted_blocks_addresses
         if sorted_addresses is None:
             return None

--- a/src/smda/common/SmdaBasicBlock.py
+++ b/src/smda/common/SmdaBasicBlock.py
@@ -1,16 +1,19 @@
 import hashlib
 import struct
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from smda.common.SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaFunction import SmdaFunction
 
 # sentinel distinguishing "hash not yet computed" from "hash computed as None (uncomputable)"
 _UNSET = object()
 
 
 class SmdaBasicBlock:
-    smda_function = None
-    instructions = None
+    smda_function: Optional["SmdaFunction"] = None
+    instructions: Optional[List[SmdaInstruction]] = None
     _picblockhash = _UNSET
     _opcblockhash = _UNSET
     offset = None

--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -167,7 +167,7 @@ class SmdaFunction:
     is_exported = False
     architecture_metadata: Dict[str, Any] = {}
     # metadata
-    binweight = 0
+    binweight: float = 0.0
     characteristics: Optional[str] = ""
     confidence: Optional[float] = 0.0
     function_name = ""
@@ -177,6 +177,7 @@ class SmdaFunction:
     nesting_depth = 0
     strongly_connected_components = None
     tfidf = None
+    _basic_blocks: Optional[List["SmdaBasicBlock"]] = None
 
     def __init__(self, disassembly=None, function_offset=None, config=None, smda_report=None):
         self.smda_report = smda_report
@@ -380,7 +381,7 @@ class SmdaFunction:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset) -> List["SmdaInstruction"]:
+    def getInstructionsForBlock(self, offset):
         if offset is None:
             offset = self.offset
         if offset is None:

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -12,8 +12,8 @@ LOGGER = logging.getLogger(__name__)
 
 class SmdaInstruction:
     smda_function = None
-    offset = None
-    bytes = None
+    offset: Optional[int] = None
+    bytes: Optional[str] = None
     mnemonic = None
     operands = None
     detailed = None
@@ -186,7 +186,7 @@ class SmdaInstruction:
         return self.bytes
 
     @classmethod
-    def fromDict(cls, instruction_dict, smda_function=None) -> Optional["SmdaInstruction"]:
+    def fromDict(cls, instruction_dict, smda_function=None) -> "SmdaInstruction":
         smda_instruction = cls(None)
         smda_instruction.smda_function = smda_function
         smda_instruction.offset = instruction_dict[0]

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import zipfile
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from capstone import CS_ARCH_ARM64, CS_ARCH_X86, CS_MODE_32, CS_MODE_64, CS_MODE_LITTLE_ENDIAN, Cs
 
@@ -67,10 +67,11 @@ class SmdaReport:
     abi = None
     base_addr = None
     binary_size = None
-    binweight = 0
+    binweight: float = 0.0
     bitness = None
-    block_locator = None
-    buffer = None
+    block_locator: Optional[BlockLocator] = None
+    buffer: Optional[bytes] = None
+    _sorted_functions: Optional[List["SmdaFunction"]] = None
     code_areas = None
     # immutable-by-convention sentinel: __init__ always rebinds this to a fresh list
     code_sections: List[Any] = []
@@ -99,19 +100,20 @@ class SmdaReport:
     xcfg: Dict[int, "SmdaFunction"] = {}
     xheader = None
     pe_header_hash = None
-    data_refs_from = None
+    data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
+    _string_cache: Dict[Any, Optional[Tuple[str, str]]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
     # in case we need to re-disassemble with more detail, we hold an initialized capstone instance as singleton
     capstone = None
 
-    def __init__(self, disassembly=None, config=None, buffer=None):
+    def __init__(self, disassembly=None, config=None, buffer: Optional[bytes] = None):
         # caches owned by SmdaReport but populated lazily by StringExtractor; declared here so
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
-        self._string_cache = {}
+        self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
         self._derefs_cache = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
@@ -128,7 +130,7 @@ class SmdaReport:
             self.abi = disassembly.binary_info.abi
             self.base_addr = disassembly.binary_info.base_addr
             self.binary_size = disassembly.binary_info.binary_size
-            self.binweight = 0
+            self.binweight = 0.0
             self.bitness = disassembly.binary_info.bitness
             self.buffer = buffer
             self.code_areas = disassembly.binary_info.code_areas
@@ -227,10 +229,10 @@ class SmdaReport:
         return self.xcfg.get(function_addr, None)
 
     def getFunctions(self) -> Iterator["SmdaFunction"]:
-        if getattr(self, "_sorted_functions", None) is None:
-            self._sorted_functions = []
-            if self.xcfg:
-                self._sorted_functions = [smda_function for _, smda_function in sorted(self.xcfg.items())]
+        if self._sorted_functions is None:
+            self._sorted_functions = (
+                [smda_function for _, smda_function in sorted(self.xcfg.items())] if self.xcfg else []
+            )
         yield from self._sorted_functions
 
     def getExportedFunctions(self):

--- a/src/smda/common/labelprovider/DelphiPythiaProvider.py
+++ b/src/smda/common/labelprovider/DelphiPythiaProvider.py
@@ -136,8 +136,8 @@ class DelphiPythiaProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._binary_info = None
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 0
         self._scan_ranges: List[Tuple[int, int]] = []
         self._func_symbols: Dict[int, str] = {}

--- a/src/smda/common/labelprovider/DelphiReSymProvider.py
+++ b/src/smda/common/labelprovider/DelphiReSymProvider.py
@@ -227,11 +227,11 @@ class DelphiReSymProvider(AbstractLabelProvider):
     def __init__(self, config):
         self._config = config
         self._func_symbols = {}
-        self._binary = b""
-        self._base_addr = 0
+        self._binary: bytes = b""
+        self._base_addr: int = 0
         self._bitness = 32
-        self._code_start = 0
-        self._code_end = 0
+        self._code_start: int = 0
+        self._code_end: int = 0
         self._settings = None
 
     def update(self, binary_info):

--- a/src/smda/common/labelprovider/RustSymbolEvidence.py
+++ b/src/smda/common/labelprovider/RustSymbolEvidence.py
@@ -11,7 +11,7 @@ RUST_DEMANGLE_ERRORS = (TypeNotFoundError, UnableTov0Demangle, UnableToLegacyDem
 _LEGACY_RUST_HASHED_SYMBOL = re.compile(r"^(?:_)?_ZN.*17h[0-9a-f]{16}E(?:[.$].*)?$")
 
 
-def is_rust_language_evidence(name):
+def is_rust_language_evidence(name) -> bool:
     """Return whether a mangled name has Rust-specific, parseable structure."""
     if not name:
         return False

--- a/src/smda/common/labelprovider/rust_demangler/main.py
+++ b/src/smda/common/labelprovider/rust_demangler/main.py
@@ -1,7 +1,9 @@
+from typing import Dict, Union
+
 from .rust import RustDemangler
 
 _DEMANGLER = RustDemangler()
-_DEMANGLE_CACHE = {}
+_DEMANGLE_CACHE: Dict[str, Union[str, Exception]] = {}
 # the cache is process-lifetime and keyed by every mangled name ever seen; bound it so a
 # long-running batch cannot grow it without limit (the sibling demanglers use
 # lru_cache(maxsize=4096)). Results and exception objects are both cached, which lru_cache

--- a/src/smda/common/labelprovider/rust_demangler/rust_v0.py
+++ b/src/smda/common/labelprovider/rust_demangler/rust_v0.py
@@ -71,7 +71,7 @@ class Ident:
         self.out_len = 0
 
     def try_small_punycode_decode(self) -> Optional[bool]:
-        def f(inp):
+        def f(inp) -> bool:
             inp = "".join(inp)
             self.disp += inp
             return True
@@ -495,9 +495,9 @@ class Printer:
     # self-referential backref chain raises RecursionError before this guard.
     RUST_MAX_RECURSION_COUNT = 256
 
-    def __init__(self, parser, out, bound, recursion=0):
+    def __init__(self, parser, out: str, bound, recursion=0):
         self.parser = parser
-        self.out = out
+        self.out: str = out
         self.bound_lifetime_depth = bound
         self.recursion = recursion
 
@@ -692,8 +692,8 @@ class Printer:
         try:
             p = self.parser_mut()
             tag = p.next_func()
-            if basic_type(tag):
-                ty = basic_type(tag)
+            ty = basic_type(tag)
+            if ty:
                 self.out += ty
                 return
 

--- a/src/smda/synthesis/ElfSynthesizer.py
+++ b/src/smda/synthesis/ElfSynthesizer.py
@@ -323,7 +323,7 @@ class ElfSynthesizer(BinarySynthesizer):
                 )
         return segments
 
-    def _assembleFile(self, sections, segments, bitness, dynamic_range=None):
+    def _assembleFile(self, sections, segments, bitness, dynamic_range=None) -> bytes:
         is_64 = bitness == 64
         ehdr_size = 64 if is_64 else 52
         phent_size = 56 if is_64 else 32
@@ -553,7 +553,7 @@ class ElfSynthesizer(BinarySynthesizer):
             )
         return bytes(output)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         sections = self._prepareSections(sections, offsets, with_strings)
         import_map = self._getImportMap() if with_imports else {}
@@ -563,7 +563,7 @@ class ElfSynthesizer(BinarySynthesizer):
         segments = self._mergeSegments(sections)
         return self._assembleFile(sections, segments, bitness, dynamic_range)
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         bitness = self._getBitness()
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {

--- a/src/smda/synthesis/MachoSynthesizer.py
+++ b/src/smda/synthesis/MachoSynthesizer.py
@@ -505,7 +505,7 @@ class MachoSynthesizer(BinarySynthesizer):
         libs = sorted({lib for lib, _ in import_map.values() if lib})
         return strtab, symtab, indirect_blob, libs, len(indirect)
 
-    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings):
+    def _synthesizeFromSections(self, sections, offsets, with_imports, with_strings) -> bytes:
         is_64 = self._is64()
         segments = self._prepareSections(sections, offsets, with_strings)
         sections = [section for segment in segments for section in segment["sections"]]
@@ -737,7 +737,7 @@ class MachoSynthesizer(BinarySynthesizer):
             flags,
         )
 
-    def _synthesizeMinimal(self, offsets):
+    def _synthesizeMinimal(self, offsets) -> bytes:
         va_start, va_end = self._syntheticSpan(offsets, PAGE_SIZE)
         section = {"name": "__text", "va_start": va_start, "va_end": va_end}
         return self._synthesizeFromSections([section], offsets, False, False)

--- a/src/smda/synthesis/PeSynthesizer.py
+++ b/src/smda/synthesis/PeSynthesizer.py
@@ -322,7 +322,7 @@ class PeSynthesizer(BinarySynthesizer):
         header += b"\x00" * (size_of_headers - len(header))
         return header
 
-    def _synthesizeFromHeader(self, offsets, with_imports, with_strings):
+    def _synthesizeFromHeader(self, offsets, with_imports, with_strings) -> bytes:
         base = self.report.base_addr
         pe_src = safe_lief_parse(bytes(self.report.xheader))
         if not isinstance(pe_src, lief.PE.Binary):
@@ -451,7 +451,7 @@ class PeSynthesizer(BinarySynthesizer):
             return base
         return candidate
 
-    def _synthesizeMinimal(self, offsets, with_imports, with_strings):
+    def _synthesizeMinimal(self, offsets, with_imports, with_strings) -> bytes:
         bitness = self._getBitness()
         ptr_size = 8 if bitness == 64 else 4
         section_alignment = 0x1000

--- a/src/smda/utility/DexFileLoader.py
+++ b/src/smda/utility/DexFileLoader.py
@@ -93,7 +93,7 @@ class DexFileLoader:
         return 0
 
     @staticmethod
-    def getBitness(data, parsed=None):
+    def getBitness(data, parsed=None) -> int:
         return 32
 
     @staticmethod

--- a/src/smda/utility/StringExtractor.py
+++ b/src/smda/utility/StringExtractor.py
@@ -1,7 +1,7 @@
 import re
 import string
 import struct
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 
 from smda.common.ExceptionHandling import reraise_non_operational_exception
 from smda.common.SmdaFunction import SmdaFunction
@@ -20,14 +20,15 @@ def read_bytes(smda_report, va, num_bytes=None):
     """
 
     rva = va - smda_report.base_addr
-    if smda_report.buffer is None:
+    buffer = smda_report.buffer
+    if buffer is None:
         raise ValueError("buffer is empty")
-    buffer_end = len(smda_report.buffer)
+    buffer_end = len(buffer)
     max_bytes = num_bytes if num_bytes is not None else 0x100
     if rva + max_bytes > buffer_end:
-        return smda_report.buffer[rva:]
+        return buffer[rva:]
     else:
-        return smda_report.buffer[rva : rva + max_bytes]
+        return buffer[rva : rva + max_bytes]
 
 
 def derefs(smda_report, p):
@@ -166,7 +167,7 @@ def read_string(smda_report, offset, maxlen=None):
     return res
 
 
-def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, int, int, str]]:
+def extract_strings(f: SmdaFunction, mode=None) -> Iterator[Tuple[str, Any, Any, str]]:
     """parse string features from the given instruction."""
     if mode == "go":
         # we address stack assigned strings and String structs

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -866,6 +866,72 @@ class TestAArch64PrologueDiscovery(unittest.TestCase):
         self.assertEqual(report.status, "ok")
         self.assertEqual({f.offset for f in report.getFunctions()}, {BASE, BASE + 0xC, BASE + 0x18})
 
+    def _btiPadOnly(self, pad, **overrides):
+        """A landing pad reached only by an unresolved `br`, which is the corpus shape.
+
+        A pad the engine can reach from inside a function is absorbed by the analysis whatever
+        the prologue scan did, so it cannot show this rule doing anything. The pads that became
+        false positives are the ones behind an indirect branch nothing resolves: no analysis
+        covers them, and both the prologue scan and the gap scan then get a turn at booking
+        them, which is why the rule lives in the predicate they share.
+        """
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        for name, value in overrides.items():
+            setattr(config, name, value)
+        words = [
+            0xD503233F,  # 0x401000 paciasp
+            0xD61F0020,  # 0x401004 br x1        -- target unresolved
+            pad,  # 0x401008 the landing pad under test
+            0x52800020,  # 0x40100c mov w0, #1
+            0xD65F03C0,  # 0x401010 ret
+        ]
+        code = b"".join(word.to_bytes(4, "little") for word in words)
+        report = Disassembler(config, backend="aarch64").disassembleBuffer(
+            code, base_addr=BASE, bitness=64, code_areas=[[BASE, BASE + len(code)]]
+        )
+        self.assertEqual(report.status, "ok")
+        return {function.offset for function in report.getFunctions()}
+
+    def test_a_jump_only_bti_pad_is_not_an_entry(self):
+        # `bti j` permits a target reached by `br`, never by `blr`, so a call cannot land here
+        self.assertNotIn(BASE + 0x8, self._btiPadOnly(0xD503249F))  # bti j
+
+    def test_a_call_target_bti_pad_in_the_same_place_is_an_entry(self):
+        # the other arm, so the pair fails if the rule is widened to every BTI form: the only
+        # difference from the case above is C for J
+        self.assertIn(BASE + 0x8, self._btiPadOnly(0xD503245F))  # bti c
+
+    def test_a_call_and_jump_bti_pad_is_still_an_entry(self):
+        # `bti jc` permits a call as well as a jump, so it says nothing against an entry
+        self.assertIn(BASE + 0x8, self._btiPadOnly(0xD50324DF))  # bti jc
+
+    def test_the_jump_only_pad_is_booked_again_with_the_flag_off(self):
+        # the flag is what refuses it, not some other guard reached along the way, so deleting
+        # the check makes the first test above fail rather than silently passing
+        self.assertIn(BASE + 0x8, self._btiPadOnly(0xD503249F, USE_AARCH64_BTI_TARGET_TYPE=False))
+
+    def test_both_passes_that_book_a_pad_consult_the_same_rule(self):
+        """The gap scan reaches these addresses too, and refuses them for the same reason.
+
+        Asserted on the predicate rather than through a second fixture because the two callers
+        differ only in which address they are standing on: a rule that lived in one of them
+        would leave the other booking exactly what the first refused.
+        """
+        binary = b"".join(word.to_bytes(4, "little") for word in [0xD65F03C0, 0xD503249F])
+        binary_info = BinaryInfo(binary)
+        binary_info.base_addr = BASE
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={}, functions={})
+        manager._candidate_offsets = set()
+
+        # preceded by a `ret`, the boundary shape the surrounding checks read as an entry
+        self.assertTrue(manager._isLikelyInteriorBtiCandidate(BASE + 4, 0xD503249F))
+        self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4, 0xD503245F))
+
+    def test_the_flag_is_on_by_default(self):
+        self.assertTrue(SmdaConfig().USE_AARCH64_BTI_TARGET_TYPE)
+
 
 class TestAArch64FunctionBoundaries(unittest.TestCase):
     def _disassemble_words(self, words, oep=None):
@@ -1498,7 +1564,7 @@ class TestAArch64GapScan(unittest.TestCase):
         manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={})
         manager._candidate_offsets = set()
 
-        self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4))
+        self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4, 0xD503245F))
 
     def test_bti_after_trap_is_not_suppressed_as_interior(self):
         # a trap (brk/udf/hlt) ends control flow like ret/b, so a BTI right after a
@@ -1517,7 +1583,7 @@ class TestAArch64GapScan(unittest.TestCase):
             manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={})
             manager._candidate_offsets = set()
 
-            self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4))
+            self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4, 0xD503245F))
 
     def test_bti_after_drps_is_not_suppressed_as_interior(self):
         # drps (Debug Restore PState) transfers control to ELR_ELx like eret*, so a BTI
@@ -1535,7 +1601,7 @@ class TestAArch64GapScan(unittest.TestCase):
         manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={})
         manager._candidate_offsets = set()
 
-        self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4))
+        self.assertFalse(manager._isLikelyInteriorBtiCandidate(BASE + 4, 0xD503245F))
 
 
 class TestAArch64StaticFixture(unittest.TestCase):

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -943,6 +943,34 @@ class TestAArch64PrologueDiscovery(unittest.TestCase):
 
         self.assertEqual(BASE + 0x10, manager._endOfRefusedLandingPadRun(BASE))
 
+    def test_a_trap_ends_the_pad_run_like_any_other_terminator(self):
+        """`brk`, `hlt` and `udf` end a function in the backend, so they end this walk.
+
+        Without them the skip reads past the trap to the next `ret` and swallows whatever
+        lies between -- and what lies after a trap is exactly the unreferenced, gap-only
+        routine this scan exists to reach, so the cost of getting it wrong is recall.
+        """
+        for name, trap in (("brk #1", 0xD4200020), ("hlt #1", 0xD4400020), ("udf #0x36", 0x00000036)):
+            with self.subTest(terminator=name):
+                config = SmdaConfig()
+                config.WITH_STRINGS = False
+                manager = FunctionCandidateManager(config)
+                words = [
+                    0xD503249F,  # 0x401000 bti j       -- the refused pad
+                    0x52800020,  # 0x401004 mov w0, #1
+                    trap,  # ......  0x401008 the trap, which ends the block
+                    0xD503233F,  # 0x40100c paciasp     -- a gap-only routine the scan must reach
+                    0x52800040,  # 0x401010 mov w0, #2
+                    0xD65F03C0,  # 0x401014 ret
+                ]
+                binary = b"".join(word.to_bytes(4, "little") for word in words)
+                binary_info = BinaryInfo(binary)
+                binary_info.base_addr = BASE
+                binary_info.binary_size = len(binary)
+                manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={}, functions={})
+
+                self.assertEqual(BASE + 0xC, manager._endOfRefusedLandingPadRun(BASE))
+
     def test_a_pad_run_with_no_terminator_in_reach_falls_back_to_one_step(self):
         # an unbounded skip on undecodable bytes would cost every function after it, which is
         # the failure mode a bad extent had in the x64 exception-directory rule

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -894,22 +894,68 @@ class TestAArch64PrologueDiscovery(unittest.TestCase):
         return {function.offset for function in report.getFunctions()}
 
     def test_a_jump_only_bti_pad_is_not_an_entry(self):
-        # `bti j` permits a target reached by `br`, never by `blr`, so a call cannot land here
-        self.assertNotIn(BASE + 0x8, self._btiPadOnly(0xD503249F))  # bti j
+        """`bti j` permits a target reached by `br`, never by `blr`, so a call cannot land here.
+
+        Asserted against the whole recovered set rather than the pad's absence. The first
+        version of this checked only that `BASE + 0x8` was gone, and passed while the false
+        positive moved four bytes to `BASE + 0xc` -- the scan refused the pad and then met its
+        first body instruction, which is ordinary code and passes every remaining guard.
+        """
+        self.assertEqual({BASE}, self._btiPadOnly(0xD503249F))  # bti j
 
     def test_a_call_target_bti_pad_in_the_same_place_is_an_entry(self):
         # the other arm, so the pair fails if the rule is widened to every BTI form: the only
         # difference from the case above is C for J
-        self.assertIn(BASE + 0x8, self._btiPadOnly(0xD503245F))  # bti c
+        self.assertEqual({BASE, BASE + 0x8}, self._btiPadOnly(0xD503245F))  # bti c
 
     def test_a_call_and_jump_bti_pad_is_still_an_entry(self):
         # `bti jc` permits a call as well as a jump, so it says nothing against an entry
-        self.assertIn(BASE + 0x8, self._btiPadOnly(0xD50324DF))  # bti jc
+        self.assertEqual({BASE, BASE + 0x8}, self._btiPadOnly(0xD50324DF))  # bti jc
 
     def test_the_jump_only_pad_is_booked_again_with_the_flag_off(self):
         # the flag is what refuses it, not some other guard reached along the way, so deleting
         # the check makes the first test above fail rather than silently passing
-        self.assertIn(BASE + 0x8, self._btiPadOnly(0xD503249F, USE_AARCH64_BTI_TARGET_TYPE=False))
+        self.assertEqual({BASE, BASE + 0x8}, self._btiPadOnly(0xD503249F, USE_AARCH64_BTI_TARGET_TYPE=False))
+
+    def test_the_body_of_a_refused_pad_is_not_promoted_in_its_place(self):
+        """Refusing a pad has to move the scan past the block it labels, not past the pad.
+
+        Pinned separately from the assertions above because it is the part that a
+        set-equality check happens to cover rather than states: the pad's body is ordinary
+        code, so one step past a refused pad puts the scan on an address every remaining
+        guard accepts.
+        """
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        manager = FunctionCandidateManager(config)
+        words = [
+            0xD503249F,  # 0x401000 bti j        -- the refused pad
+            0x52800020,  # 0x401004 mov w0, #1   -- its body, which must not be reconsidered
+            0x52800041,  # 0x401008 mov w1, #2
+            0xD65F03C0,  # 0x40100c ret          -- the block ends here
+            0xD503233F,  # 0x401010 paciasp      -- the next thing the scan may look at
+        ]
+        binary = b"".join(word.to_bytes(4, "little") for word in words)
+        binary_info = BinaryInfo(binary)
+        binary_info.base_addr = BASE
+        binary_info.binary_size = len(binary)
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={}, functions={})
+
+        self.assertEqual(BASE + 0x10, manager._endOfRefusedLandingPadRun(BASE))
+
+    def test_a_pad_run_with_no_terminator_in_reach_falls_back_to_one_step(self):
+        # an unbounded skip on undecodable bytes would cost every function after it, which is
+        # the failure mode a bad extent had in the x64 exception-directory rule
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        manager = FunctionCandidateManager(config)
+        binary = b"".join((0x52800020).to_bytes(4, "little") for _ in range(0x200))
+        binary_info = BinaryInfo(binary)
+        binary_info.base_addr = BASE
+        binary_info.binary_size = len(binary)
+        manager.disassembly = SimpleNamespace(binary_info=binary_info, code_map={}, functions={})
+
+        self.assertEqual(BASE + 4, manager._endOfRefusedLandingPadRun(BASE))
 
     def test_both_passes_that_book_a_pad_consult_the_same_rule(self):
         """The gap scan reaches these addresses too, and refuses them for the same reason.


### PR DESCRIPTION
Two commits' worth of one thing: the AArch64 candidate scans read a `bti j` landing pad as a function entry, and refusing one has to resume in the right place or the false positive simply moves four bytes.

## The measurement first

Every prologue-sole booking on a 72-cell built AArch64 ELF corpus, charged to the arm of `is_function_prologue` that actually accepted it — same order the function uses, so each address is charged to the branch that took it:

| pattern | FP | TP | FP share | FP per TP |
|---|---|---|---|---|
| **BTI landing pad** | **803** | 505 | **59.8%** | **1.59** |
| `stp x29,x30,[sp,#imm]!` frame record | 536 | 2,764 | 39.9% | 0.19 |
| PAC sign (`paciasp`/`pacibsp`) | **0** | **1,656** | 0.0% | **0.00** |
| not a prologue word | 4 | 0 | 0.3% | — |

The two remaining arms — the callee-saved pair `stp x{19..28},x{19..28},[sp,#-imm]!` and the LR save `str x30,[sp,#-imm]!` — are the sole booker of nothing at all here, neither a true positive nor a false one.

Splitting the BTI row by which form the compiler wrote:

| variant | FP | TP |
|---|---|---|
| `bti c` (call target) | **0** | **505** |
| `bti j` (jump target) | **803** | **0** |

**Exact, not statistical.** 1,308 addresses, no overlap, across 72 cells.

## Why the two forms mean different things

`bti j` permits a target reached by `br` — an indirect *jump*, which is what a switch dispatch does to a case block. `bti c` permits one reached by `blr` — an indirect *call*, which is how a function is reached. A call landing on a J-only pad **faults**. So the compiler that emitted `bti j` was naming an interior label, and it recorded that fact in the instruction.

Candidate discovery read all four forms as entry prologues, which put every jump pad in the image on the list. The existing guard reads the word *before* the pad and refuses one that follows ordinary code — but that cannot separate these two, because a case block is preceded by the previous case's terminating branch, which is exactly the boundary shape the guard accepts as an entry.

So the pass had the answer in front of it and was not reading it.

## Commit 1: read the target type

`USE_AARCH64_BTI_TARGET_TYPE`, on by default. A `bti j` word is interior by what it says about itself, before anything around it is read.

It lives in `_isLikelyInteriorBtiCandidate`, the predicate the **prologue scan and the gap scan share**, rather than in the scan that produced the histogram. Both reach these addresses — the pads that became false positives are the ones behind an indirect branch nothing resolves, so no analysis covers them and both passes get a turn. A rule in one would have left the other booking exactly what the first refused.

| corpus | n | PPV | TPR | Δ FP | Δ TP |
|---|---|---|---|---|---|
| Built C/C++ AArch64 ELF | 72 | 87.596 → **89.186** | 96.205 → 96.205 | **−2,941** | −1 |

Recall unchanged to three decimals. 2,941 removed against 803 prologue-sole bookings, because a wrong entry does not only cost its own address — it starts an analysis that fragments the routine it sits inside.

### The one true positive that moves is not lost

On one cell the entry at `0xe1744` is returned at `0xe1748` instead: one instruction later, at the `stp x29, x30, [sp, #-96]!` rather than at the `paciasp` in front of it. Both are prologue candidates, and this change shifts their order in the queue; the `stp` is analysed first and the `paciasp` behind it then aborts on the collision.

Read against truth rather than against the count, the window is better after, not worse:

| in `[0xe1500, 0xe1f00]`, truth declares 3 functions | recovered | of which real | spurious |
|---|---|---|---|
| before | 13 | 3 | 10 |
| after | 6 | 2 | 4 |

An exact-start metric charges that as a lost function plus a false positive. It is a boundary that moved by four bytes, not a routine that vanished.

## Commit 2: resume past the block, not past the pad

Refusing a pad advanced the gap scan by one instruction. That puts it on the pad's own first body instruction — ordinary code, which passes every remaining guard and is promoted in the pad's place. The false positive does not go, it moves four bytes:

| | recovered functions |
|---|---|
| `bti j`, rule off | `0x401000`, **`0x401008`** |
| `bti j`, rule on, resuming one instruction on | `0x401000`, **`0x40100c`** |
| `bti j`, rule on, resuming past the block | `0x401000` |

So the walk resumes past the block the pad labels — its first terminator — instead of past the pad.

Terminators are `ret`, `br`, `b` **and the traps** `brk` / `hlt` / `udf`. The traps matter because `AArch64Backend.analyzeInstruction` ends a function on all three through `END_INS`: without them the walk reads a block that has already closed and skips whatever lies behind it, and what lies behind a trap is exactly the unreferenced, gap-only routine this scan exists to reach. Reproduced on a five-word image — the walk resumed at `0x401018` instead of `0x40100c`, swallowing a `paciasp`-opening routine, for each of the three trap forms.

It falls back to the single-instruction step when no terminator is within `_GAP_RUN_LIMIT`, so a run of undecodable bytes cannot make the skip travel an arbitrary distance. That bound is not hypothetical caution — an unbounded skip on a bad extent is what cost 1,274 functions on one dump while developing the x64 `.pdata` suppression, and the same shape is available here.

Applied to **every** arm of `_isLikelyInteriorBtiCandidate`, not only the target-type arm the first commit adds. The two older arms — a pad inside already-claimed code, and a pad following ordinary code — have the same weakness and predate that change. `_GAP_RUN_LIMIT` also replaces the bare `0x400` in `_gapRunFlowsIntoInterior`, which walks the same runs under the same bound and is the only other place that number appears.

| corpus | n | PPV | TPR | Δ FP | Δ TP |
|---|---|---|---|---|---|
| Built C/C++ AArch64 ELF | 72 | 89.215 → **89.623** | 96.208 → 96.208 | **−442** | **0** |
| ARM64 Mach-O | 11 | bit-identical — 93.992 / 95.619, 2,484 TP, 262 FP both sides | | | |

442 false positives removed, recall unchanged to three decimals, and **not one true positive moved** — TP is 59,012 on both sides.

### Why the first commit's tests did not catch it

They asserted the refused address was **absent**:

```python
self.assertNotIn(BASE + 0x8, self._btiPadOnly(0xD503249F))
```

which is true both when the false positive is gone and when it has moved to `BASE + 0xc`. The assertion was satisfied by the exact defect it was written to prevent. All four BTI cases now compare the **whole recovered set**, which is what makes the difference between "removed" and "moved" visible.

## Controls

| corpus | n | result |
|---|---|---|
| Built C/C++, x86-64 | 140 | **bit-identical** — 93.740 / 96.968, 113,438 TP, 14,123 FP both sides |
| Built Go, all platforms | 47 | **bit-identical** — 94.036 / 99.367, 165,627 TP, 10,944 FP both sides |
| ARM64 Mach-O | 11 | **bit-identical** for commit 1 too — 93.986 / 95.616, 2,484 TP, 263 FP both sides |

The x86-64 corpus is the control that matters for scope: the intel scan has no BTI shape and the rule must not reach it.

**The Mach-O corpus is not a control for the rule itself, and is not offered as one.** Those 11 cells book no BTI-opened prologue candidate at all, so the rule is inert there rather than confirmed. It is measured on one corpus, and this says so.

The PE ARM64 exception-record reader (`is_exception_record_entry`) accepts the same word through a different question — whether a record names an independent entry or a funclet — and is deliberately left alone. There is no ARM64 PE corpus here to measure it on, and shipping an unmeasured suppression rule is the thing the `.pdata` work above argued against.

## Tests

- Five cases in `tests/testAArch64Disassembler.py` over a landing pad reached only by an unresolved `br` — the shape that actually produced the false positives. A pad the engine can reach from inside a function is absorbed by the analysis whatever the prologue scan did, so it cannot show this rule doing anything; the first fixture written for this was that shape and it passed for the wrong reason. `bti j` refused; `bti c` and `bti jc` still booked in the same position; the flag off restores the old behaviour; and the predicate asserted directly, because the two callers differ only in which address they stand on.
- `test_the_body_of_a_refused_pad_is_not_promoted_in_its_place` — the walk landing past the block's `ret`.
- `test_a_trap_ends_the_pad_run_like_any_other_terminator` — all three trap forms as subtests.
- `test_a_pad_run_with_no_terminator_in_reach_falls_back_to_one_step` — the bound, over 0x200 words with no terminator.

Mutation-tested both ways: reverting the call site to `+= INSTRUCTION_SIZE` fails `test_a_jump_only_bti_pad_is_not_an_entry` (which it did **not** do before the assertions were tightened), and deleting the trap clause fails all three subtests.

## One follow-up deliberately not in here

`_gapRunFlowsIntoInterior` keeps a *different* terminator set from the skip walk — it walks to `ret`/`br`/`b` and reads straight through traps. That asymmetry is correct rather than an omission: the skip walk decides **how far to skip**, and one instruction too far steps over a real entry and loses it, so it must stop at the earliest boundary it can defend; the suppression walk decides **whether to suppress**, nothing is skipped either way, and reading further only gathers more evidence about the same candidate. Counted on both corpora, adding `is_trap` there releases 12 candidates on ARM64 Mach-O (two sites, swept one word at a time), **0 of them true starts**, and 0 candidates on the 72-cell ELF corpus.

The test file that pins that reasoning needs a guard from #300 (`_gapRunFlowsIntoInterior` asking the live function set, not just the pre-analysis candidate snapshot), so it is held back rather than included here.

## Validation

`ruff check` / `ruff format --check` pass, full suite green on this branch rebased onto current master, diff coverage 100% with 0 missing lines on both changed files.

## Relationship to #299 and #300

Both commits are also sitting inside #299, and the first of the two inside #300 as well. Those were opened from branches that had my fork's master merged into them repeatedly, so their diffs are much wider than their titles suggest, they overlap each other, and they carry this change at two different points of its history.

This PR is the same change on its own, rebased onto current master, so it can be reviewed and measured for what it actually is. If you would rather take it through one of those, close this one; if you take this one, the matching hunks fall out of theirs on rebase.

## The `ty` commit at the tip

The last commit on this branch is #302's fix, cherry-picked unchanged.

Master fails `Code Quality` on its own right now: 572acd7 bumped `ty` to 0.0.74, and its new `unsound-return-statement` / `unsound-assignment` rules become errors under `[tool.ty.rules] all = "error"`. That is 41 errors across 15 files, none of which this PR touches — so every PR opened against master inherits a red check that says nothing about its own diff.

Carrying #302's commit here means this PR's CI reflects only this PR's work. It is the same commit, unmodified, so the moment #302 lands this one is empty and falls out on rebase — there is nothing to untangle later. If you would rather look at this branch without it, merge #302 first and I will drop it.

Checked against `ty` 0.0.74 itself rather than whatever an older local pin resolves to: on master it exits 1 with 41 errors, on this branch it exits 0 with none.
