### PR TITLE
fix(aarch64): candidate-quality follow-ups to the BTI landing-pad series

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -92,9 +92,11 @@ class SmdaConfig:
     # fixture changes - so enabling it belongs with a corpus run, not with a config edit
     USE_ELF_EH_FRAME_CANDIDATES = False
     # extend the AArch64 adr/adrp address-materialization scan to Mach-O instruction sections,
-    # recording targets as weak address evidence; off until validated with exact-address ground
-    # truth for the Mach-O corpus
-    USE_MACHO_ADDRESS_REF_CANDIDATES = False
+    # recording targets as weak address evidence. On since the metadata-coverage test that
+    # guards the scan landed: the validation this waited for is +21 true starts against 5
+    # fewer false ones on the ARM64 Mach-O corpus, and the images that made it unsafe before
+    # -- Go, whose pclntab already names every function -- no longer reach the scan at all
+    USE_MACHO_ADDRESS_REF_CANDIDATES = True
     # promote unclaimed Mach-O LC_FUNCTION_STARTS entries as late candidates (after the primary
     # pass, before gap analysis). The linker writes the table and stripping keeps it, and segment
     # file offsets and VM offsets coincide in Mach-O, so it also reads correctly out of a mapped

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -81,6 +81,12 @@ _GAP_RUN_LIMIT = 0x400
 #: useless costs precision, skipping it when it is not costs recall.
 _METADATA_CALL_TARGET_COVERAGE = 0.95
 
+#: Fewest call targets the coverage above may be read from. Below this the ratio is a
+#: small-sample artifact and not evidence: one corpus image resolves four `bl` targets in
+#: the whole binary, and metadata naming all four says nothing about whether it also names
+#: the functions only a materialized address reaches.
+_METADATA_MIN_CALL_TARGETS = 512
+
 _ARM64_PDATA_ENTRY_SIZE = 8
 # items (words, matches or exception records) a scan steps over between budget polls, mirroring
 # _TIMEOUT_POLL_BLOCKS in the engine. A whole exception table is walked inside one call, so
@@ -608,11 +614,13 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
 
         `bl` targets are the denominator because they are the one population both kinds of
         image have, in proportion to how many functions they contain, and because they are
-        known at exactly this point -- the scan that resolves them has just finished.
+        known at exactly this point -- the scan that resolves them has just finished. A rate
+        needs a sample, though, so an image with few of them is left to the scan whatever
+        share of those few metadata named.
         """
-        if not self._call_targets:
-            # nothing calls anything: no evidence either way, and the scan is the only pass
-            # left that could reach an entry, so let it run
+        if len(self._call_targets) < _METADATA_MIN_CALL_TARGETS:
+            # too few calls to read a rate from, or none at all: no evidence either way, and
+            # the scan is the only pass left that could reach an entry, so let it run
             return False
         named = sum(1 for target in self._call_targets if target in self._metadata_candidates)
         return named / len(self._call_targets) >= _METADATA_CALL_TARGET_COVERAGE

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -138,9 +138,9 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         self.locatePeExceptionCandidates()
         if self._candidateTimeoutTripped():
             return
-        # everything booked so far came from something the image says about itself, which is
-        # what the coverage test below compares its call targets against
-        self._metadata_candidates = set(self.candidates)
+        # what the coverage test below compares its call targets against: everything the image
+        # says about itself, which is not the same set as what has been booked by now
+        self._metadata_candidates = set(self.candidates) | self._languageMetadataStarts()
         self.locateReferenceCandidates()
         if self._candidateTimeoutTripped():
             return
@@ -594,6 +594,20 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                     continue
                 self.addReferenceCandidate(target, pointer_va)
                 self.setInitialCandidate(target)
+
+    def _languageMetadataStarts(self):
+        """Function starts the image's own language metadata names, booked as candidates or not.
+
+        Two passes that read such metadata are not in self.candidates at this point:
+        locateLangSpecCandidates runs after the coverage test, and locateSymbolCandidates is
+        optional (USE_SYMBOLS_AS_CANDIDATES). Neither is a proxy for what the image declares,
+        and the test asks about the image rather than about the configuration -- reading it
+        here is what keeps a Go binary analysed without symbol candidates from being treated
+        as one that names nothing.
+        """
+        if not self.lang_analyzer.checkGo():
+            return set()
+        return set(self.lang_analyzer.getGoObjects())
 
     def _metadataNamedTheCallTargets(self):
         """Whether this image's metadata has already supplied the functions, leaving the

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -74,6 +74,13 @@ LOGGER = logging.getLogger(__name__)
 #: about, so both stop rather than guess.
 _GAP_RUN_LIMIT = 0x400
 
+#: Share of an image's own call targets that metadata has to have named already before the
+#: address-materialization scan is judged to have nothing left to reach. The measured
+#: distribution is bimodal with a wide empty interval between the modes; this sits in its
+#: upper half because the two errors are not symmetric -- running the scan when it is
+#: useless costs precision, skipping it when it is not costs recall.
+_METADATA_CALL_TARGET_COVERAGE = 0.95
+
 _ARM64_PDATA_ENTRY_SIZE = 8
 # items (words, matches or exception records) a scan steps over between budget polls, mirroring
 # _TIMEOUT_POLL_BLOCKS in the engine. A whole exception table is walked inside one call, so
@@ -90,13 +97,22 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
     CANDIDATE_ALIGNMENT = INSTRUCTION_SIZE
 
+    def __init__(self, config):
+        super().__init__(config)
+        # init() resets these per binary, but a manager driven one pass at a time never
+        # reaches init(), and the reference scan writes to them from its first call
+        self._call_targets = set()
+        self._metadata_candidates = set()
+
     def init(self, disassembly, cbAnalysisTimeout=None):
-        # Reset the memoized executable-section ranges and Mach-O fixup state
-        # BEFORE base initialization: super().init() runs candidate discovery,
-        # so a reused manager instance would otherwise consume the previous
-        # binary's cached data during the scans.
+        # Reset the memoized executable-section ranges, the Mach-O fixup state and the
+        # two sets the metadata-coverage test reads BEFORE base initialization:
+        # super().init() runs candidate discovery, so a reused manager instance would
+        # otherwise consume the previous binary's cached data during the scans.
         self._exec_ranges = None
         self._macho_fixup_state = None
+        self._call_targets = set()
+        self._metadata_candidates = set()
         super().init(disassembly, cbAnalysisTimeout)
 
     def hasCommonPrologue(self, addr):
@@ -116,10 +132,14 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         self.locatePeExceptionCandidates()
         if self._candidateTimeoutTripped():
             return
+        # everything booked so far came from something the image says about itself, which is
+        # what the coverage test below compares its call targets against
+        self._metadata_candidates = set(self.candidates)
         self.locateReferenceCandidates()
         if self._candidateTimeoutTripped():
             return
-        self.locateAddressRefCandidates()
+        if not self._metadataNamedTheCallTargets():
+            self.locateAddressRefCandidates()
         if self._candidateTimeoutTripped():
             return
         self.locateDataPointerCandidates()
@@ -569,6 +589,34 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 self.addReferenceCandidate(target, pointer_va)
                 self.setInitialCandidate(target)
 
+    def _metadataNamedTheCallTargets(self):
+        """Whether this image's metadata has already supplied the functions, leaving the
+        address-materialization scan nothing to find.
+
+        That scan exists to reach entries no call names -- a pointer handed to a callback,
+        a table walked at run time. An image that ships a full function map has none of
+        those left over: the symbol pass consumes the map, every entry is already a
+        candidate, and what the scan then produces is the addresses that are materialized
+        but are not entries. On a Go binary that is thousands of them for no recovered
+        function at all.
+
+        The question is asked of the image rather than of its container or its language,
+        both of which have been the wrong variable before: of the addresses this image's
+        own `bl` instructions call, how many did metadata name before this pass ran? A
+        stripped C or C++ object answers near zero however it was linked; one carrying a
+        complete map answers near one whoever compiled it.
+
+        `bl` targets are the denominator because they are the one population both kinds of
+        image have, in proportion to how many functions they contain, and because they are
+        known at exactly this point -- the scan that resolves them has just finished.
+        """
+        if not self._call_targets:
+            # nothing calls anything: no evidence either way, and the scan is the only pass
+            # left that could reach an entry, so let it run
+            return False
+        named = sum(1 for target in self._call_targets if target in self._metadata_candidates)
+        return named / len(self._call_targets) >= _METADATA_CALL_TARGET_COVERAGE
+
     def locateAddressRefCandidates(self):
         # Reference discovery for addresses materialized in code: adr Xd, #imm and the
         # adrp Xd, #page / add Xd, Xn, #lo12 pair. When the resulting address lands in
@@ -700,6 +748,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 imm -= BL_IMM_SIGN_BIT << 1  # sign-extend the 26-bit immediate
             target = (source + imm * INSTRUCTION_SIZE) & self.getBitMask()
             if self.disassembly.isAddrWithinMemoryImage(target):
+                self._call_targets.add(target)
                 self.addReferenceCandidate(target, source)
                 self.setInitialCandidate(target)
 

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -786,6 +786,30 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # ends in an unconditional `b` into the interior of already-mapped code (a
         # known instruction that is not itself a function-start candidate), the run is
         # a mid-function tail rather than a new function — so suppress it.
+        #
+        # The terminator set is `ret` and `br`, and deliberately NOT the trap words
+        # _endOfRefusedLandingPadRun stops at as well. The two walks share _GAP_RUN_LIMIT
+        # but answer different questions. That one decides how far to SKIP, where reading
+        # one instruction too far steps over a real entry and loses it outright, so it has
+        # to stop at the earliest boundary it can defend. This one decides whether to
+        # SUPPRESS: nothing is skipped either way, and reading further only gathers more
+        # evidence about the same candidate. And a trap is not a boundary the image
+        # declares — `brk`/`hlt`/`udf` mid-body is a bounds check or a __builtin_trap
+        # block, ending a function only by AArch64Backend.analyzeInstruction's own END_INS
+        # convention. The words behind it still belong to the enclosing function, so a `b`
+        # out of them into that function's interior is a true statement about `start`.
+        #
+        # Measured by re-running this walk with is_trap in its terminator set and diffing
+        # the candidates that stop being suppressed:
+        #   ARM64 Mach-O corpus: 2 sites released (0x100014b80 and 0x100025f30 in
+        #     osx.gimmick_e0e9d940be95, 12 candidate addresses between them, each swept
+        #     one instruction at a time), both strictly interior to a function the ground
+        #     truth declares — 0x1d8 and 0x15c past its start — and 0 true starts among
+        #     them, i.e. 12 suppressions traded for 2 false positives and nothing gained.
+        #   Built C/C++ AArch64 ELF, 72 cells: of 5,353 runs this walk decided, and 1,445
+        #     it suppressed, 0 pass a trap at all — the change is not a trade there, it is
+        #     unreachable, so that corpus cannot vouch for it either.
+        # Pinned by tests/testAArch64GapRunTerminators.py; do not add is_trap here.
         base = self.disassembly.binary_info.base_addr
         size = self.disassembly.binary_info.binary_size
         words = self._wordsView()
@@ -821,6 +845,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
 
         Falls back to the single-instruction step when no terminator is in reach, so a run
         of undecodable bytes cannot make this skip an arbitrary distance.
+
+        A trap ends the block here, unlike in _gapRunFlowsIntoInterior next door, which
+        shares this walk's bound but not that terminator; the comment there says why a
+        walk that skips and a walk that suppresses cannot stop in the same places.
         """
         base = self.disassembly.binary_info.base_addr
         size = self.disassembly.binary_info.binary_size

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -798,6 +798,12 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 if imm & 0x02000000:
                     imm -= 0x04000000
                 target = addr + imm * INSTRUCTION_SIZE
+                # getFunctionStartCandidates() is a snapshot taken before analysis begins, and
+                # gap analysis never adds to it, so a function it discovered is code_map'd but
+                # absent from the set -- indistinguishable here from somebody's interior. Ask
+                # the live function set too, or a branch to a real entry reads as a tail.
+                if target in self.disassembly.functions:
+                    return False
                 return target in self.disassembly.code_map and target not in self.getFunctionStartCandidates()
             if (word & RET_MASK) == RET_VALUE or (word & BR_MASK) == BR_VALUE:
                 return False
@@ -846,7 +852,11 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             # cannot say it: a case block is preceded by the previous case's terminating
             # branch, which is exactly the boundary shape they read as an entry.
             return True
-        if addr in self.disassembly.code_map and addr not in self.getFunctionStartCandidates():
+        if (
+            addr in self.disassembly.code_map
+            and addr not in self.getFunctionStartCandidates()
+            and addr not in self.disassembly.functions
+        ):
             return True
 
         base = self.disassembly.binary_info.base_addr

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -786,30 +786,14 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # ends in an unconditional `b` into the interior of already-mapped code (a
         # known instruction that is not itself a function-start candidate), the run is
         # a mid-function tail rather than a new function — so suppress it.
-        #
-        # The terminator set is `ret` and `br`, and deliberately NOT the trap words
-        # _endOfRefusedLandingPadRun stops at as well. The two walks share _GAP_RUN_LIMIT
-        # but answer different questions. That one decides how far to SKIP, where reading
-        # one instruction too far steps over a real entry and loses it outright, so it has
-        # to stop at the earliest boundary it can defend. This one decides whether to
-        # SUPPRESS: nothing is skipped either way, and reading further only gathers more
-        # evidence about the same candidate. And a trap is not a boundary the image
-        # declares — `brk`/`hlt`/`udf` mid-body is a bounds check or a __builtin_trap
-        # block, ending a function only by AArch64Backend.analyzeInstruction's own END_INS
-        # convention. The words behind it still belong to the enclosing function, so a `b`
-        # out of them into that function's interior is a true statement about `start`.
-        #
-        # Measured by re-running this walk with is_trap in its terminator set and diffing
-        # the candidates that stop being suppressed:
-        #   ARM64 Mach-O corpus: 2 sites released (0x100014b80 and 0x100025f30 in
-        #     osx.gimmick_e0e9d940be95, 12 candidate addresses between them, each swept
-        #     one instruction at a time), both strictly interior to a function the ground
-        #     truth declares — 0x1d8 and 0x15c past its start — and 0 true starts among
-        #     them, i.e. 12 suppressions traded for 2 false positives and nothing gained.
-        #   Built C/C++ AArch64 ELF, 72 cells: of 5,353 runs this walk decided, and 1,445
-        #     it suppressed, 0 pass a trap at all — the change is not a trade there, it is
-        #     unreachable, so that corpus cannot vouch for it either.
-        # Pinned by tests/testAArch64GapRunTerminators.py; do not add is_trap here.
+        # The terminator set omits the trap words _endOfRefusedLandingPadRun stops at, and
+        # that is deliberate: skipping and suppressing cannot stop in the same places. A
+        # skip that reads one instruction too far steps over a real entry and loses it; a
+        # suppression that reads further only learns more about the same candidate. Nor is
+        # a trap a boundary the image declares - mid-body it is a bounds check, and it ends
+        # a function only by the backend's own END_INS convention - so the words behind it
+        # still belong to the enclosing routine. Pinned by
+        # tests/testAArch64GapRunTerminators.py.
         base = self.disassembly.binary_info.base_addr
         size = self.disassembly.binary_info.binary_size
         words = self._wordsView()
@@ -847,8 +831,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         of undecodable bytes cannot make this skip an arbitrary distance.
 
         A trap ends the block here, unlike in _gapRunFlowsIntoInterior next door, which
-        shares this walk's bound but not that terminator; the comment there says why a
-        walk that skips and a walk that suppresses cannot stop in the same places.
+        shares this walk's bound but not that terminator.
         """
         base = self.disassembly.binary_info.base_addr
         size = self.disassembly.binary_info.binary_size

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -900,10 +900,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         # AArch64 gap scan: a fixed-stride linear sweep of unanalyzed executable bytes
         # for functions that no prologue, call reference or stored pointer reached
         # (typically unreferenced / indirect-only routines). Guards keep each gap
-        # candidate at a plausible function entry: skip padding (nop / zero), a
-        # leading conditional branch or trap, constrain to genuine executable sections (the
-        # loader's code_areas can be a coarse segment covering data), and drop runs
-        # that flow into the interior of an already-mapped function.
+        # candidate at a plausible function entry: skip padding (nop / zero) and traps,
+        # constrain to genuine executable sections (the loader's code_areas can be a
+        # coarse segment covering data), and drop runs that flow into the interior of an
+        # already-mapped function.
         if self.gap_pointer is None:
             self.initGapSearch()
         # Explicit None test: a gap start at VA 0x0 (valid for a base-0 buffer) is a
@@ -947,9 +947,6 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 continue
             if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(self.gap_pointer, word):
                 self.gap_pointer = self._endOfRefusedLandingPadRun(self.gap_pointer)
-                continue
-            if is_conditional_branch(word):  # a function never opens with a cond branch
-                self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if is_trap(word):  # udf-space data words / trap filler, never an entry
                 self.gap_pointer += INSTRUCTION_SIZE

--- a/src/smda/aarch64/definitions.py
+++ b/src/smda/aarch64/definitions.py
@@ -147,10 +147,10 @@ def is_conditional_branch(word):
     """True for cbz/cbnz, tbz/tbnz, b.<cond> and FEAT_HBC's bc.<cond>
     (compare/test/condition branches, hinted or not).
 
-    A function never opens with one of these, so the gap scan treats a leading
-    conditional branch as a stray block tail (not an entry) and skips it. b.al/b.nv/
-    bc.al/bc.nv also match the b.<cond>/bc.<cond> mask; they are never valid entries,
-    so skipping is benign.
+    A decode question, not a judgement about entries: a compiler hoists an argument
+    guard above the frame setup routinely at -O2, so a function may well open with one
+    of these. b.al/b.nv/bc.al/bc.nv match too -- they occupy the b.<cond>/bc.<cond>
+    encoding whatever the condition field says.
     """
     return (
         (word & CBZ_CBNZ_MASK) == CBZ_CBNZ_VALUE

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -1714,15 +1714,21 @@ class TestAArch64StaticFixture(unittest.TestCase):
         self.assertEqual(self.report.base_addr, 0x400000)
         self.assertEqual(self.report.oep, 0x534)
         self.assertEqual(len(self.report.xcfg), 278)
-        self.assertEqual(sum(1 for f in self.report.getFunctions() for _ in f.getInstructions()), 19881)
-        self.assertEqual(sum(1 for f in self.report.getFunctions() for _ in f.getBlocks()), 3497)
+        self.assertEqual(sum(1 for f in self.report.getFunctions() for _ in f.getInstructions()), 19882)
+        self.assertEqual(sum(1 for f in self.report.getFunctions() for _ in f.getBlocks()), 3499)
         self.assertIsNotNone(self.report.getFunction(0x400534))
 
     def test_real_fixture_gap_scan_recovery(self):
         # Functions recovered only by the gap scan (#3): unreferenced / indirect-only
         # routines that no BL, prologue, or stored pointer reaches. With the gap scan
         # every Binary Ninja function start is now recovered.
-        for function_start in (0x40CFE0, 0x40DD78, 0x40DF34, 0x40F370, 0x410B24, 0x41150C, 0x411590, 0x4134D0):
+        # 0x40DF30 rather than 0x40DF34: the routine opens on a hoisted `cbz x14`, which the
+        # gap scan used to step over on the theory that a function never begins with a
+        # conditional branch. 0x40DF30 is the 16-aligned word directly after the previous
+        # function's `ret` and its padding nop; 0x40DF34 is 4-aligned and mid-line. Neither
+        # carries an inbound direct branch, so the two readings differ by one instruction of
+        # the same routine, and the recovered function count is unchanged at 278.
+        for function_start in (0x40CFE0, 0x40DD78, 0x40DF30, 0x40F370, 0x410B24, 0x41150C, 0x411590, 0x4134D0):
             self.assertIsNotNone(self.report.getFunction(function_start), f"missing 0x{function_start:x}")
 
     def test_real_fixture_data_pointer_recovery(self):

--- a/tests/testAArch64GapRunTerminators.py
+++ b/tests/testAArch64GapRunTerminators.py
@@ -1,0 +1,158 @@
+"""The two AArch64 gap-run walks stop at different terminators, and the difference is load-bearing."""
+
+import types
+import unittest
+
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+IMAGE_SIZE = 0x4000
+
+NOP = 0xD503201F
+RET = 0xD65F03C0
+BRK = 0xD4200000  # brk #0
+PROLOGUE = 0xA9BF7BFD  # stp x29, x30, [sp, #-16]!
+EPILOGUE = 0xA8C17BFD  # ldp x29, x30, [sp], #16
+MOV_W0_1 = 0x52800020  # mov w0, #1
+MOV_W1_2 = 0x52800041  # mov w1, #2
+
+
+def _bl(source, target):
+    return 0x94000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+def _b(source, target):
+    return 0x14000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+class GapRunPastATrapTest(unittest.TestCase):
+    """A trap does not end the function whose body it sits in, so the suppression walk reads on.
+
+    `brk`/`hlt`/`udf` end a function for instruction analysis, which is that analysis's own
+    convention and not a boundary the image declares. The block behind a bounds check still
+    belongs to the routine that checked the bound, so an unconditional branch out of that block
+    into the routine's interior says the same thing about a gap candidate ahead of it as it
+    would with no trap in between: the run is a mid-function tail, not a new function.
+    """
+
+    def _image(self):
+        """Four parts. An entry that calls the host, so the host is a call-reference candidate
+        and is recovered before gap analysis starts. The host, whose second word is the
+        interior address nothing else names. A suppressed run, opening on no prologue and
+        referenced by nothing, so the gap scan is the only thing that reaches it, whose
+        straight-line run passes a `brk` and then branches into that interior. And a booked run
+        of exactly the same four words, differing only in that its branch goes to the host's
+        entry rather than into its body."""
+        host = BASE + 0x1000
+        interior = host + 4
+        suppressed = BASE + 0x2000
+        booked = BASE + 0x3000
+
+        words = {BASE: PROLOGUE, BASE + 4: _bl(BASE + 4, host), BASE + 8: EPILOGUE, BASE + 12: RET}
+        words.update({host: PROLOGUE, interior: MOV_W0_1, host + 8: MOV_W1_2, host + 12: EPILOGUE, host + 16: RET})
+        for run, target in ((suppressed, interior), (booked, host)):
+            words.update({run: MOV_W0_1, run + 4: BRK, run + 8: MOV_W1_2, run + 12: _b(run + 12, target)})
+
+        image = bytearray(NOP.to_bytes(4, "little") * (IMAGE_SIZE // 4))
+        for word_address, word in words.items():
+            image[word_address - BASE : word_address - BASE + 4] = word.to_bytes(4, "little")
+        return bytes(image), host, interior, suppressed, booked
+
+    def setUp(self):
+        image, self.host, self.interior, self.suppressed, self.booked = self._image()
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        report = Disassembler(config, backend="aarch64").disassembleBuffer(
+            image,
+            base_addr=BASE,
+            bitness=64,
+            code_areas=[[BASE, BASE + IMAGE_SIZE]],
+            architecture="aarch64",
+        )
+        self.assertEqual(report.status, "ok")
+        self.functions = {function.offset for function in report.getFunctions()}
+
+    def testARunThatBranchesIntoAnInteriorPastATrapIsNotBooked(self):
+        self.assertNotIn(self.suppressed, self.functions)
+
+    def testTheSameRunBranchingToARealEntryIsBooked(self):
+        """Control, and the one that makes the assertion above mean anything. Both runs carry
+        the same trap in the same place and both end at it once analysed, so if the trap were
+        what decided, this address would be missing too."""
+        self.assertIn(self.booked, self.functions)
+
+    def testTheHostAndItsCallerAreStillRecovered(self):
+        """Control. Both assertions above would hold on an image that failed to analyse."""
+        self.assertIn(self.host, self.functions)
+        self.assertIn(BASE, self.functions)
+
+    def testTheAddressBranchedIntoIsAnInteriorAndNotAnEntry(self):
+        """Control: the suppressed run is refused for branching into a body, so that address
+        has to be a body and not a function the analysis happens to have recovered."""
+        self.assertNotIn(self.interior, self.functions)
+
+
+class GapRunTerminatorSetsTest(unittest.TestCase):
+    """The two walks, isolated from the traversal that reaches them, over identical words."""
+
+    #: the walks read from here; the landing-pad walk skips this first word as the pad itself
+    RUN = 0x40
+    #: where the run's closing `b` lands, and the only address the fake code map holds
+    TARGET = 0x80
+    BUFFER_SIZE = 0x100
+
+    def _manager(self, second_word):
+        """A manager over four words: an ordinary instruction, `second_word`, another ordinary
+        instruction, then `b` to TARGET. Both walks read nothing but the mapped words, the code
+        map and the function / candidate sets, so standing those in keeps the second word the
+        only thing that varies between the cases below."""
+        words = {
+            self.RUN: MOV_W0_1,
+            self.RUN + 4: second_word,
+            self.RUN + 8: MOV_W1_2,
+            self.RUN + 12: _b(self.RUN + 12, self.TARGET),
+        }
+        buffer = bytearray(NOP.to_bytes(4, "little") * (self.BUFFER_SIZE // 4))
+        for word_address, word in words.items():
+            buffer[word_address : word_address + 4] = word.to_bytes(4, "little")
+
+        manager = FunctionCandidateManager(SmdaConfig())
+        # exactly what the two walks read, and nothing else: a reader can tell from this
+        # stand-in what either of them is allowed to depend on
+        manager.disassembly = types.SimpleNamespace(
+            binary_info=types.SimpleNamespace(base_addr=0, binary=bytes(buffer), binary_size=self.BUFFER_SIZE),
+            # TARGET is decoded code that is nobody's entry, which is what "interior" means here
+            code_map={self.TARGET: 1},
+            functions={},
+        )
+        return manager
+
+    def testTheSkipAfterARefusedLandingPadStopsAtATrap(self):
+        # it resumes one instruction past the trap, i.e. it never reaches the `b` two words on
+        self.assertEqual(self._manager(BRK)._endOfRefusedLandingPadRun(self.RUN), self.RUN + 8)
+
+    def testTheSuppressionWalkReadsPastTheTrapToTheBranch(self):
+        self.assertTrue(self._manager(BRK)._gapRunFlowsIntoInterior(self.RUN))
+
+    def testTheSuppressionWalkStillStopsAtAReturn(self):
+        """Control: the walk has a terminator set, it is just not the same one. Swap the trap
+        for a `ret` and the branch behind it stops being reachable evidence."""
+        self.assertFalse(self._manager(RET)._gapRunFlowsIntoInterior(self.RUN))
+
+    def testTheSkipStopsAtAReturnInTheSamePlace(self):
+        """Control: for the skip a trap and a return are interchangeable, which is the whole
+        asymmetry - the same word pair splits the two walks apart."""
+        self.assertEqual(self._manager(RET)._endOfRefusedLandingPadRun(self.RUN), self.RUN + 8)
+
+    def testABranchToARecoveredFunctionIsNotAnInterior(self):
+        """Control: reading past the trap is only a suppression when what it finds is a body.
+        The same run reaching a real entry is not evidence against the candidate."""
+        manager = self._manager(BRK)
+        manager.disassembly.functions = {self.TARGET: object()}
+        self.assertFalse(manager._gapRunFlowsIntoInterior(self.RUN))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAArch64HoistedGuardEntry.py
+++ b/tests/testAArch64HoistedGuardEntry.py
@@ -1,13 +1,9 @@
 """A guard hoisted above the frame setup is a function's first instruction, not a stray tail.
 
 At -O2 a compiler emits an argument check ahead of the prologue, so the routine opens on a
-`cbz`/`cbnz` and its frame setup sits one instruction in. The gap scan used to refuse a
-leading conditional branch outright, on the claim that a function never opens with one, and
-so it walked past such an entry and booked the frame setup four bytes along instead -- a miss
-and a false positive from one routine. The tests below hold the scan to telling that shape
-apart from the one the claim is actually true of: a conditional branch that follows ordinary
-code inside a function, which the analysis has to keep out by having already claimed it
-rather than by refusing the word.
+`cbz`/`cbnz` and its frame setup sits one instruction in. What separates that from the shape
+the same word class really does take mid-function is position, not the word, so each case
+below is paired with the other.
 """
 
 import unittest
@@ -18,8 +14,7 @@ from smda.SmdaConfig import SmdaConfig
 
 BASE = 0x400000
 IMAGE_SIZE = 0x2100
-#: where every image below puts the routine under test: past the scaffold, 16-aligned, and
-#: reached by nothing the scaffold does
+#: past the scaffold, 16-aligned, and reached by nothing the scaffold does
 REGION = BASE + 0x2000
 
 NOP = 0xD503201F
@@ -32,12 +27,10 @@ MOV_W0_1 = 0x52800020  # mov w0, #1
 MOV_W1_2 = 0x52800041  # mov w1, #2
 MOV_W2_3 = 0x52800062  # mov w2, #3
 
-#: enough call-referenced entries, all 16-aligned, for the alignment floor to infer 16.
-#: The inference needs more than twenty candidates carrying more than one reference each.
+#: enough call-referenced 16-aligned entries, each carrying more than one reference, for the
+#: alignment floor to infer 16
 LEAF_COUNT = 22
 LEAVES = tuple(BASE + 0x1000 + index * 0x10 for index in range(LEAF_COUNT))
-#: everything the scaffold itself contributes to the recovered set, so a test can compare
-#: the whole rest of that set against what the region under test should produce
 SCAFFOLD_ENTRIES = frozenset({BASE, *LEAVES})
 
 
@@ -54,13 +47,10 @@ def _cbz(source, target):
 
 
 def _scaffold(words, called=()):
-    """The leaves and their caller, giving the alignment floor a population to infer 16 from.
-
-    Without it the floor is 0 and a routine is refused or admitted on its alignment rather
-    than on the word it opens with, which is not what any of these tests is asking about.
-    Each address in `called` is called from the same caller, which is how a routine in one of
-    these images is recovered by the first pass instead of by the gap scan.
-    """
+    """The leaves and their caller, so the alignment floor infers 16 rather than 0 and no
+    routine below is refused on its alignment instead of on the word it opens with. An address
+    in `called` is called twice from that caller, which is how a routine here reaches the first
+    pass instead of the gap scan."""
     for leaf in LEAVES:
         words.update({leaf: PROLOGUE, leaf + 4: MOV_W0_1, leaf + 8: EPILOGUE, leaf + 12: RET})
     address = BASE
@@ -91,15 +81,11 @@ def _disassemble(image):
 
 
 class HoistedGuardEntryTest(unittest.TestCase):
-    """The routine's first word is the guard the compiler hoisted above its frame setup.
-
-    Nothing calls it and its first word is no prologue, so the gap scan is the only pass that
-    can reach it. The frame setup one word in is 4-aligned and nothing calls it either, so the
-    alignment floor keeps it out of the first pass -- which is why refusing the entry did not
-    simply lose the routine: the start booked in its place came from the same gap scan, four
-    bytes past the entry it had just walked over, and the guard's own target became a second
-    one. Recovering the entry removes both.
-    """
+    """Nothing calls the routine and its first word is no prologue, so the gap scan is the only
+    pass that reaches it. The frame setup one word in is 4-aligned and uncalled, so the
+    alignment floor keeps it out of the first pass too -- which is why refusing the entry did
+    not simply lose the routine: the start booked in its place came from the same gap scan,
+    four bytes on, and the guard's own target became a second one."""
 
     def _image(self):
         words = {}
@@ -128,25 +114,19 @@ class HoistedGuardEntryTest(unittest.TestCase):
         self.assertIn(REGION, self.functions)
 
     def testTheRoutineIsRecoveredAsOneFunctionAndNothingElse(self):
-        # The whole set is compared rather than the frame setup's absence alone: refusing the
-        # entry booked both that word and the guard's own target, so an assertion naming one
-        # address would go on passing with the false positive moved along.
+        # the whole set, not the frame setup's absence alone: an assertion naming one address
+        # goes on passing with the false positive moved four bytes along
         self.assertEqual(self.functions - SCAFFOLD_ENTRIES, {REGION})
 
     def testTheScaffoldAroundTheRoutineIsRecovered(self):
-        """Control. An image that analysed into nothing at all would satisfy the assertion
-        above about what is absent for a reason that has nothing to do with guards."""
+        """Control: an image that analysed into nothing would satisfy the assertion above."""
         self.assertEqual(sorted(SCAFFOLD_ENTRIES - self.functions), [])
 
 
 class MidFunctionConditionalBranchTest(unittest.TestCase):
-    """Control for the case above: the shape the gap scan's guard is written for.
-
-    The same class of word, in the position where the claim behind the guard holds -- after
-    ordinary code, inside a routine the first pass already recovered from its call reference.
-    There it is a block tail and must not be booked as a function start, whatever the scan
-    decides about a conditional branch that opens a routine.
-    """
+    """Control for the case above: the same word class after ordinary code, inside a routine the
+    first pass already recovered from its call reference. There it is a block tail and must stay
+    out of the function set whatever the scan does with one that opens a routine."""
 
     def _image(self):
         words = {}
@@ -173,27 +153,20 @@ class MidFunctionConditionalBranchTest(unittest.TestCase):
         self.functions = {function.offset for function in report.getFunctions()}
 
     def testTheBlockTailIsNotBookedAsAFunctionStart(self):
-        # again the whole set, so that neither the branch nor either of the two arms it
-        # decides between can become a function under another address
+        # again the whole set: neither the branch nor either arm may become a function
         self.assertEqual(self.functions - SCAFFOLD_ENTRIES, {REGION})
 
     def testTheBranchIsTheSameWordClassAsTheOneOpeningAGuardedEntry(self):
-        """Control: the two cases are told apart by position and by nothing else. Both words
-        are what `is_conditional_branch` matches, so nothing about the word itself keeps this
-        one out -- it stays out because the routine around it was claimed first."""
+        """Control: both words are what `is_conditional_branch` matches, so what tells the two
+        cases apart is position -- this one stays out because its routine was claimed first."""
         self.assertTrue(is_conditional_branch(_cbz(REGION + 0x0C, REGION + 0x18)))
         self.assertTrue(is_conditional_branch(_cbz(REGION, REGION + 0x18)))
 
 
 class UnclaimedConditionalBranchWithoutAFrameSetupTest(unittest.TestCase):
-    """A conditional branch opening an unclaimed gap, with ordinary code behind it.
-
-    Nothing calls this block and no prologue follows the branch, so neither the hoisted-guard
-    reading nor the block-tail reading is confirmed by the words around it. This is the
-    population that decided how far the guard could go: refusing the word never kept the
-    region out of the function set, it only moved the start four bytes along, so there was no
-    reduction in false starts to weigh against the entries the refusal cost.
-    """
+    """A conditional branch opening an unclaimed gap, with ordinary code rather than a frame
+    setup behind it, so neither reading is confirmed by its surroundings. This is the population
+    that decided how far the guard could go."""
 
     def _image(self):
         words = {}
@@ -215,20 +188,13 @@ class UnclaimedConditionalBranchWithoutAFrameSetupTest(unittest.TestCase):
         self.functions = {function.offset for function in report.getFunctions()}
 
     def testTheScanBooksTheBlockAtItsFirstWord(self):
-        """One start either way; the guard only decided which word it sat on.
-
-        With the refusal in place this was `{REGION + 0x04}` -- a function beginning one
-        instruction into the block, because the scan stepped over the branch and booked the
-        next word. Without it the same single start lands on the block's real first word.
-        Narrowing the refusal to entries a frame setup vouches for would have put it back at
-        `+0x04`, which is why narrowing was not the cheaper half of the choice.
-        """
+        """One start either way; the refusal only decided which word it sat on -- `+0x04` with
+        it, the block's real first word without. Narrowing it to entries a frame setup vouches
+        for would have put it back at `+0x04`, which is why narrowing bought nothing here."""
         self.assertEqual(self.functions - SCAFFOLD_ENTRIES, {REGION})
 
     def testTheRegionIsOneFunctionStartUnderEitherRule(self):
-        """Control: the count did not move, only the address did. The refusal bought no
-        reduction in false starts over this shape, which is what made it the deciding
-        population rather than the guarded-entry one."""
+        """Control: the count did not move, only the address did."""
         starts = self.functions - SCAFFOLD_ENTRIES
         self.assertEqual(len(starts), 1)
         self.assertEqual([hex(start) for start in starts if not REGION <= start < REGION + 0x10], [])

--- a/tests/testAArch64HoistedGuardEntry.py
+++ b/tests/testAArch64HoistedGuardEntry.py
@@ -1,0 +1,238 @@
+"""A guard hoisted above the frame setup is a function's first instruction, not a stray tail.
+
+At -O2 a compiler emits an argument check ahead of the prologue, so the routine opens on a
+`cbz`/`cbnz` and its frame setup sits one instruction in. The gap scan used to refuse a
+leading conditional branch outright, on the claim that a function never opens with one, and
+so it walked past such an entry and booked the frame setup four bytes along instead -- a miss
+and a false positive from one routine. The tests below hold the scan to telling that shape
+apart from the one the claim is actually true of: a conditional branch that follows ordinary
+code inside a function, which the analysis has to keep out by having already claimed it
+rather than by refusing the word.
+"""
+
+import unittest
+
+from smda.aarch64.definitions import is_conditional_branch
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+IMAGE_SIZE = 0x2100
+#: where every image below puts the routine under test: past the scaffold, 16-aligned, and
+#: reached by nothing the scaffold does
+REGION = BASE + 0x2000
+
+NOP = 0xD503201F
+RET = 0xD65F03C0
+PROLOGUE = 0xA9BF7BFD  # stp x29, x30, [sp, #-16]!
+FRAME_POINTER = 0x910003FD  # mov x29, sp
+EPILOGUE = 0xA8C17BFD  # ldp x29, x30, [sp], #16
+MOV_W0_0 = 0x52800000  # mov w0, #0
+MOV_W0_1 = 0x52800020  # mov w0, #1
+MOV_W1_2 = 0x52800041  # mov w1, #2
+MOV_W2_3 = 0x52800062  # mov w2, #3
+
+#: enough call-referenced entries, all 16-aligned, for the alignment floor to infer 16.
+#: The inference needs more than twenty candidates carrying more than one reference each.
+LEAF_COUNT = 22
+LEAVES = tuple(BASE + 0x1000 + index * 0x10 for index in range(LEAF_COUNT))
+#: everything the scaffold itself contributes to the recovered set, so a test can compare
+#: the whole rest of that set against what the region under test should produce
+SCAFFOLD_ENTRIES = frozenset({BASE, *LEAVES})
+
+
+def _bl(source, target):
+    return 0x94000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+def _b(source, target):
+    return 0x14000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+def _cbz(source, target):
+    return 0xB4000000 | ((((target - source) // 4) & 0x7FFFF) << 5)  # cbz x0, <label>
+
+
+def _scaffold(words, called=()):
+    """The leaves and their caller, giving the alignment floor a population to infer 16 from.
+
+    Without it the floor is 0 and a routine is refused or admitted on its alignment rather
+    than on the word it opens with, which is not what any of these tests is asking about.
+    Each address in `called` is called from the same caller, which is how a routine in one of
+    these images is recovered by the first pass instead of by the gap scan.
+    """
+    for leaf in LEAVES:
+        words.update({leaf: PROLOGUE, leaf + 4: MOV_W0_1, leaf + 8: EPILOGUE, leaf + 12: RET})
+    address = BASE
+    words[address] = PROLOGUE
+    address += 4
+    for target in [*LEAVES, *called]:
+        for _call in range(2):  # more than one reference each, or the floor infers nothing
+            words[address] = _bl(address, target)
+            address += 4
+    words[address] = EPILOGUE
+    words[address + 4] = RET
+
+
+def _render(words):
+    """A NOP-filled image with each word of `words` written at its address."""
+    image = bytearray(NOP.to_bytes(4, "little") * (IMAGE_SIZE // 4))
+    for word_address, word in words.items():
+        image[word_address - BASE : word_address - BASE + 4] = word.to_bytes(4, "little")
+    return bytes(image)
+
+
+def _disassemble(image):
+    config = SmdaConfig()
+    config.WITH_STRINGS = False
+    return Disassembler(config, backend="aarch64").disassembleBuffer(
+        image, base_addr=BASE, bitness=64, code_areas=[[BASE, BASE + IMAGE_SIZE]]
+    )
+
+
+class HoistedGuardEntryTest(unittest.TestCase):
+    """The routine's first word is the guard the compiler hoisted above its frame setup.
+
+    Nothing calls it and its first word is no prologue, so the gap scan is the only pass that
+    can reach it. The frame setup one word in is 4-aligned and nothing calls it either, so the
+    alignment floor keeps it out of the first pass -- which is why refusing the entry did not
+    simply lose the routine: the start booked in its place came from the same gap scan, four
+    bytes past the entry it had just walked over, and the guard's own target became a second
+    one. Recovering the entry removes both.
+    """
+
+    def _image(self):
+        words = {}
+        _scaffold(words)
+        words.update(
+            {
+                REGION: _cbz(REGION, REGION + 0x18),  # the entry: the argument check
+                REGION + 0x04: PROLOGUE,  # the word booked in the entry's place today
+                REGION + 0x08: FRAME_POINTER,
+                REGION + 0x0C: MOV_W0_1,
+                REGION + 0x10: EPILOGUE,
+                REGION + 0x14: RET,
+                REGION + 0x18: MOV_W0_0,  # the guard's target, the early return
+                REGION + 0x1C: RET,
+            }
+        )
+        return _render(words)
+
+    def setUp(self):
+        report = _disassemble(self._image())
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.identified_alignment, 16)
+        self.functions = {function.offset for function in report.getFunctions()}
+
+    def testTheHoistedGuardIsRecoveredAsTheFunctionEntry(self):
+        self.assertIn(REGION, self.functions)
+
+    def testTheRoutineIsRecoveredAsOneFunctionAndNothingElse(self):
+        # The whole set is compared rather than the frame setup's absence alone: refusing the
+        # entry booked both that word and the guard's own target, so an assertion naming one
+        # address would go on passing with the false positive moved along.
+        self.assertEqual(self.functions - SCAFFOLD_ENTRIES, {REGION})
+
+    def testTheScaffoldAroundTheRoutineIsRecovered(self):
+        """Control. An image that analysed into nothing at all would satisfy the assertion
+        above about what is absent for a reason that has nothing to do with guards."""
+        self.assertEqual(sorted(SCAFFOLD_ENTRIES - self.functions), [])
+
+
+class MidFunctionConditionalBranchTest(unittest.TestCase):
+    """Control for the case above: the shape the gap scan's guard is written for.
+
+    The same class of word, in the position where the claim behind the guard holds -- after
+    ordinary code, inside a routine the first pass already recovered from its call reference.
+    There it is a block tail and must not be booked as a function start, whatever the scan
+    decides about a conditional branch that opens a routine.
+    """
+
+    def _image(self):
+        words = {}
+        _scaffold(words, called=(REGION,))
+        words.update(
+            {
+                REGION: PROLOGUE,
+                REGION + 0x04: FRAME_POINTER,
+                REGION + 0x08: MOV_W1_2,  # ordinary code ahead of the branch, so it is a tail
+                REGION + 0x0C: _cbz(REGION + 0x0C, REGION + 0x18),
+                REGION + 0x10: MOV_W0_1,
+                REGION + 0x14: _b(REGION + 0x14, REGION + 0x1C),
+                REGION + 0x18: MOV_W0_0,
+                REGION + 0x1C: EPILOGUE,
+                REGION + 0x20: RET,
+            }
+        )
+        return _render(words)
+
+    def setUp(self):
+        report = _disassemble(self._image())
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.identified_alignment, 16)
+        self.functions = {function.offset for function in report.getFunctions()}
+
+    def testTheBlockTailIsNotBookedAsAFunctionStart(self):
+        # again the whole set, so that neither the branch nor either of the two arms it
+        # decides between can become a function under another address
+        self.assertEqual(self.functions - SCAFFOLD_ENTRIES, {REGION})
+
+    def testTheBranchIsTheSameWordClassAsTheOneOpeningAGuardedEntry(self):
+        """Control: the two cases are told apart by position and by nothing else. Both words
+        are what `is_conditional_branch` matches, so nothing about the word itself keeps this
+        one out -- it stays out because the routine around it was claimed first."""
+        self.assertTrue(is_conditional_branch(_cbz(REGION + 0x0C, REGION + 0x18)))
+        self.assertTrue(is_conditional_branch(_cbz(REGION, REGION + 0x18)))
+
+
+class UnclaimedConditionalBranchWithoutAFrameSetupTest(unittest.TestCase):
+    """A conditional branch opening an unclaimed gap, with ordinary code behind it.
+
+    Nothing calls this block and no prologue follows the branch, so neither the hoisted-guard
+    reading nor the block-tail reading is confirmed by the words around it. This is the
+    population that decided how far the guard could go: refusing the word never kept the
+    region out of the function set, it only moved the start four bytes along, so there was no
+    reduction in false starts to weigh against the entries the refusal cost.
+    """
+
+    def _image(self):
+        words = {}
+        _scaffold(words)
+        words.update(
+            {
+                REGION: _cbz(REGION, REGION + 0x0C),
+                REGION + 0x04: MOV_W0_1,  # ordinary code, not a frame setup
+                REGION + 0x08: MOV_W2_3,
+                REGION + 0x0C: RET,
+            }
+        )
+        return _render(words)
+
+    def setUp(self):
+        report = _disassemble(self._image())
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.identified_alignment, 16)
+        self.functions = {function.offset for function in report.getFunctions()}
+
+    def testTheScanBooksTheBlockAtItsFirstWord(self):
+        """One start either way; the guard only decided which word it sat on.
+
+        With the refusal in place this was `{REGION + 0x04}` -- a function beginning one
+        instruction into the block, because the scan stepped over the branch and booked the
+        next word. Without it the same single start lands on the block's real first word.
+        Narrowing the refusal to entries a frame setup vouches for would have put it back at
+        `+0x04`, which is why narrowing was not the cheaper half of the choice.
+        """
+        self.assertEqual(self.functions - SCAFFOLD_ENTRIES, {REGION})
+
+    def testTheRegionIsOneFunctionStartUnderEitherRule(self):
+        """Control: the count did not move, only the address did. The refusal bought no
+        reduction in false starts over this shape, which is what made it the deciding
+        population rather than the guarded-entry one."""
+        starts = self.functions - SCAFFOLD_ENTRIES
+        self.assertEqual(len(starts), 1)
+        self.assertEqual([hex(start) for start in starts if not REGION <= start < REGION + 0x10], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAArch64MachoMetadataCandidates.py
+++ b/tests/testAArch64MachoMetadataCandidates.py
@@ -248,13 +248,17 @@ class MachoAddressRefCandidateTestSuite(unittest.TestCase):
         ]
         return _build_arm64_macho([], text_words=words + [RET] * 4)
 
-    def test_default_off_records_no_address_refs(self):
-        self.assertFalse(SmdaConfig().USE_MACHO_ADDRESS_REF_CANDIDATES)
+    def test_the_scan_is_on_by_default_for_macho(self):
+        self.assertTrue(SmdaConfig().USE_MACHO_ADDRESS_REF_CANDIDATES)
+
+    def test_opting_out_records_no_address_refs(self):
+        """Control on the pair below: the two targets are reached by this scan and by nothing
+        else in the image, so switching it off has to lose them."""
         fcm = _manager_for(self._adr_blob(), use_address_refs=False)
         self.assertNotIn(TEXT_VA + 0x40, fcm.candidates)
         self.assertNotIn(TEXT_VA + 0x50, fcm.candidates)
 
-    def test_opt_in_records_targets_as_weak_evidence(self):
+    def test_the_scan_records_targets_as_weak_evidence(self):
         fcm = _manager_for(self._adr_blob(), use_address_refs=True)
         for target in (TEXT_VA + 0x40, TEXT_VA + 0x50):
             self.assertIn(target, fcm.candidates)

--- a/tests/testAArch64MetadataCoverageGate.py
+++ b/tests/testAArch64MetadataCoverageGate.py
@@ -9,8 +9,11 @@ Instruction encodings below were verified against capstone 5.0.7 (CS_ARCH_ARM64)
 
 import struct
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from smda.aarch64.FunctionCandidateManager import _METADATA_MIN_CALL_TARGETS, FunctionCandidateManager
+from smda.common.LanguageAnalyzer import LanguageAnalyzer
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.SmdaConfig import SmdaConfig
@@ -366,6 +369,60 @@ class AddressScanIsSkippedWhenMetadataNamedTheCallsTest(unittest.TestCase):
 
         self.assertEqual(report.status, "ok")
         self.assertIn(table, functions)
+
+
+class LanguageMetadataDecidesIndependentlyOfSymbolCandidatesTest(unittest.TestCase):
+    """USE_SYMBOLS_AS_CANDIDATES turns off booking symbols as candidates, not the image's own
+    language metadata. A Go image's pclntab is read by locateLangSpecCandidates whatever that
+    option says, and that pass runs after this test -- so the test has to read the metadata
+    rather than the candidate set, or a fully mapped Go image is treated as naming nothing and
+    the scan it exists to suppress runs anyway.
+
+    Driven by forcing the Go answer on the real analyzer: what is under test is which pass the
+    coverage is read from, not whether a synthetic pclntab parses.
+    """
+
+    def _functionsWithGoMetadata(self, blob, go_objects, use_symbols):
+        class _GoAnalyzer(LanguageAnalyzer):
+            def checkGo(self):
+                return True
+
+            def getGoObjects(self):
+                return list(go_objects)
+
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        config.USE_SYMBOLS_AS_CANDIDATES = use_symbols
+        with patch("smda.common.FunctionCandidateManager.LanguageAnalyzer", _GoAnalyzer):
+            report = Disassembler(config).disassembleUnmappedBuffer(blob)
+        return report, {function.offset for function in report.getFunctions()}
+
+    def testTheScanIsSkippedWhetherOrNotSymbolsAreBooked(self):
+        blob, table = _tableImage(BASE, named=False)
+        go_objects = sorted(_callTargets(BASE + TEXT_OFFSET))
+
+        for use_symbols in (True, False):
+            with self.subTest(use_symbols=use_symbols):
+                report, functions = self._functionsWithGoMetadata(blob, go_objects, use_symbols)
+
+                self.assertEqual(report.status, "ok")
+                self.assertNotIn(table, functions)
+                self.assertIn(BASE + TEXT_OFFSET, functions)
+
+    def testTheSameImageWithoutTheGoMetadataStillBooksTheTable(self):
+        """Control on what decided it: the image is the one the scan books, and it is the
+        metadata reading and not the image that keeps the table out above."""
+        blob, table = _tableImage(BASE, named=False)
+        report, functions = _functions(blob)
+
+        self.assertEqual(report.status, "ok")
+        self.assertIn(table, functions)
+
+    def testAnImageOfNoRecognizedLanguageContributesNoMetadata(self):
+        manager = FunctionCandidateManager(SmdaConfig())
+        manager.lang_analyzer = SimpleNamespace(checkGo=lambda: False)
+
+        self.assertEqual(manager._languageMetadataStarts(), set())
 
 
 class ManagerReuseTest(unittest.TestCase):

--- a/tests/testAArch64MetadataCoverageGate.py
+++ b/tests/testAArch64MetadataCoverageGate.py
@@ -1,0 +1,399 @@
+"""The address-materialization scan runs on the images that need it and not on the ones that do not.
+
+It exists to reach entries no call names -- a pointer handed to a callback, a table walked at run
+time. An image whose metadata already lists every function has none of those left over, and what
+the scan adds there is addresses that are materialized but are not entries.
+
+Instruction encodings below were verified against capstone 5.0.7 (CS_ARCH_ARM64).
+"""
+
+import struct
+import unittest
+
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
+from smda.utility.FileLoader import FileLoader
+
+BASE = 0x400000
+#: the reuse test needs a second image whose addresses cannot be confused with the first's
+REUSE_BASE = 0x800000
+#: the single PT_LOAD maps file offset 0 at the base, so .text is at base + its file offset
+TEXT_OFFSET = 0x1000
+TEXT_SIZE = 0x5000
+
+NOP = 0xD503201F
+RET = 0xD65F03C0
+PROLOGUE = 0xA9BF7BFD  # stp x29, x30, [sp, #-16]!
+EPILOGUE = 0xA8C17BFD  # ldp x29, x30, [sp], #16
+MOV_W0_1 = 0x52800020  # mov w0, #1
+MOV_W1_2 = 0x52800041  # mov w1, #2
+MOV_W2_3 = 0x52800062  # mov w2, #3
+BTI_C = 0xD503245F  # bti c
+
+#: enough call-referenced 16-aligned entries, each carrying more than one reference, for the
+#: alignment floor to infer 16
+LEAF_COUNT = 22
+LEAF_BLOCK = 0x1000
+LEAF_STRIDE = 0x10
+TARGET_BLOCK = 0x2000
+SEEDER_BLOCK = 0x3000
+#: jump-table entries: small offsets, which occupy the udf encoding space, so the gap scan reads
+#: them as data and only the address scan can book the table
+TABLE_WORDS = (0x00000008, 0x00000010, 0x00000018, 0x00000020)
+#: how far into its page a materialized address sits, so the `add` carries a real offset, not #0
+LO12_OFFSET = 0x100
+
+
+def _bl(source, target):
+    return 0x94000000 | (((target - source) // 4) & 0x03FFFFFF)
+
+
+def _adr(source, target, rd=0):
+    imm = (target - source) & 0x1FFFFF
+    return 0x10000000 | ((imm & 0x3) << 29) | (((imm >> 2) & 0x7FFFF) << 5) | rd
+
+
+def _adrp(source, target, rd=0):
+    # the immediate counts pages between the two addresses' pages, not bytes between the addresses
+    imm = ((target >> 12) - (source >> 12)) & 0x1FFFFF
+    return 0x90000000 | ((imm & 0x3) << 29) | (((imm >> 2) & 0x7FFFF) << 5) | rd
+
+
+def _add(rd, rn, imm12):
+    return 0x91000000 | ((imm12 & 0xFFF) << 10) | (rn << 5) | rd
+
+
+def _elf(text, base, symbols=()):
+    """ELF64/AArch64 image: one R+X PT_LOAD, a .text section, and a symbol table when asked for one.
+
+    An ELF rather than a bare buffer because the address scan reads its executable extents from
+    the section table and does nothing at all without one, so a buffer cannot exercise the gate
+    either way. The symbol table is the metadata the gate asks about.
+    """
+    ehsize, phentsize, shentsize, symentsize = 64, 56, 64, 24
+    shstrtab = b"\x00.text\x00.symtab\x00.strtab\x00.shstrtab\x00"
+    name_text = shstrtab.index(b".text\x00")
+    name_symtab = shstrtab.index(b".symtab\x00")
+    name_strtab = shstrtab.index(b".strtab\x00")
+    name_shstrtab = shstrtab.index(b".shstrtab\x00")
+
+    strtab = bytearray(b"\x00")
+    symtab = bytearray(struct.pack("<IBBHQQ", 0, 0, 0, 0, 0, 0))  # the reserved null entry
+    for name, value, size in symbols:
+        symtab += struct.pack("<IBBHQQ", len(strtab), 0x12, 0, 1, value, size)  # STB_GLOBAL STT_FUNC
+        strtab += name.encode() + b"\x00"
+
+    text_va = base + TEXT_OFFSET
+    symtab_offset = TEXT_OFFSET + len(text)
+    strtab_offset = symtab_offset + len(symtab)
+    shstrtab_offset = strtab_offset + len(strtab)
+    sh_offset = shstrtab_offset + len(shstrtab)
+
+    ehdr = struct.pack(
+        "<16sHHIQQQIHHHHHH",
+        b"\x7fELF\x02\x01\x01" + b"\x00" * 9,  # ELFCLASS64, ELFDATA2LSB, EV_CURRENT
+        2,  # e_type = ET_EXEC
+        183,  # e_machine = EM_AARCH64
+        1,  # e_version
+        text_va,  # e_entry
+        ehsize,  # e_phoff
+        sh_offset,  # e_shoff
+        0,  # e_flags
+        ehsize,
+        phentsize,
+        1,  # e_phnum
+        shentsize,
+        5,  # e_shnum
+        4,  # e_shstrndx
+    )
+    phdr = struct.pack("<IIQQQQQQ", 1, 5, 0, base, base, sh_offset, sh_offset, 0x1000)  # PT_LOAD, R+X
+
+    def shdr(name, sh_type, flags, addr, offset, size, link, info, align, entsize):
+        return struct.pack("<IIQQQQIIQQ", name, sh_type, flags, addr, offset, size, link, info, align, entsize)
+
+    section_headers = (
+        shdr(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)  # SHT_NULL
+        + shdr(name_text, 1, 0x6, text_va, TEXT_OFFSET, len(text), 0, 0, 4, 0)  # PROGBITS, ALLOC|EXECINSTR
+        # LIEF drops the table when sh_link (its string table) and sh_info (its first non-local
+        # symbol) disagree with its contents
+        + shdr(name_symtab, 2, 0, 0, symtab_offset, len(symtab), 3, 1, 8, symentsize)
+        + shdr(name_strtab, 3, 0, 0, strtab_offset, len(strtab), 0, 0, 1, 0)
+        + shdr(name_shstrtab, 3, 0, 0, shstrtab_offset, len(shstrtab), 0, 0, 1, 0)
+    )
+    header = bytearray(ehdr + phdr)
+    header += b"\x00" * (TEXT_OFFSET - len(header))
+    return bytes(header) + text + bytes(symtab) + bytes(strtab) + shstrtab + section_headers
+
+
+def _leaves(text_va):
+    return [text_va + LEAF_BLOCK + index * LEAF_STRIDE for index in range(LEAF_COUNT)]
+
+
+def _callTargets(text_va):
+    """Every address the scaffold's `bl` instructions call, which is the population the coverage
+    test divides by."""
+    return set(_leaves(text_va)) | {text_va + SEEDER_BLOCK}
+
+
+def _scaffold(text_va):
+    """The leaves and the caller that calls each of them twice and the seeder once: twenty-two
+    16-aligned call-referenced entries for the alignment floor to infer 16 from, and the image's
+    `bl` population, without which the coverage test has no denominator and answers False."""
+    words = {}
+    for leaf in _leaves(text_va):
+        words.update({leaf: PROLOGUE, leaf + 4: MOV_W0_1, leaf + 8: EPILOGUE, leaf + 12: RET})
+    address = text_va
+    words[address] = PROLOGUE
+    address += 4
+    for leaf in _leaves(text_va):
+        for _call in range(2):
+            words[address] = _bl(address, leaf)
+            address += 4
+    words[address] = _bl(address, text_va + SEEDER_BLOCK)
+    address += 4
+    words[address] = EPILOGUE
+    words[address + 4] = RET
+    return words
+
+
+def _text(words, text_va):
+    text = bytearray(NOP.to_bytes(4, "little") * (TEXT_SIZE // 4))
+    for word_address, word in words.items():
+        text[word_address - text_va : word_address - text_va + 4] = word.to_bytes(4, "little")
+    return bytes(text)
+
+
+def _callbackImage(base, materialized=True):
+    """A stripped image whose two callbacks only a materialized address reaches.
+
+    Nothing calls either one and no stored pointer points at them, and each opens on a `bti c` pad
+    that the prologue and gap scans both refuse -- `_isLikelyInteriorBtiCandidate` reads a pad whose
+    preceding word is ordinary code, the `mov` in front of each one here, as an indirect-branch
+    target rather than an entry. That leaves what the seeder materializes, `adr` for the first and
+    the `adrp`/`add` pair for the second. `materialized=False` replaces those three words with nops:
+    the control saying the address scan is what recovered them.
+    """
+    text_va = base + TEXT_OFFSET
+    adr_callback = text_va + TARGET_BLOCK
+    pair_callback = text_va + TARGET_BLOCK + LO12_OFFSET
+    seeder = text_va + SEEDER_BLOCK
+    words = _scaffold(text_va)
+    for callback in (adr_callback, pair_callback):
+        words.update(
+            {
+                callback - 4: MOV_W2_3,  # the ordinary code that makes the pad behind it read as interior
+                callback: BTI_C,
+                callback + 4: MOV_W1_2,
+                callback + 8: RET,
+            }
+        )
+    words.update(
+        {
+            seeder: PROLOGUE,
+            seeder + 4: _adr(seeder + 4, adr_callback) if materialized else NOP,
+            seeder + 8: _adrp(seeder + 8, pair_callback, 8) if materialized else NOP,
+            seeder + 12: _add(8, 8, pair_callback & 0xFFF) if materialized else NOP,
+            seeder + 16: EPILOGUE,
+            seeder + 20: RET,
+        }
+    )
+    return _elf(_text(words, text_va), base), adr_callback, pair_callback
+
+
+def _tableImage(base, named=True):
+    """An image whose one materialized address is a jump table rather than an entry -- the shape
+    the scan produces on an image carrying a full function map, where it books the table's base as
+    a function. `named=False` leaves the symbol table out: the control saying it is the coverage
+    and not the table's own shape that decides."""
+    text_va = base + TEXT_OFFSET
+    table = text_va + TARGET_BLOCK + LO12_OFFSET
+    seeder = text_va + SEEDER_BLOCK
+    words = _scaffold(text_va)
+    for index, entry in enumerate(TABLE_WORDS):
+        words[table + index * 4] = entry
+    words.update(
+        {
+            seeder: PROLOGUE,
+            seeder + 4: _adrp(seeder + 4, table, 8),
+            seeder + 8: _add(8, 8, table & 0xFFF),
+            seeder + 12: EPILOGUE,
+            seeder + 16: RET,
+        }
+    )
+    symbols = ()
+    if named:
+        # a symbol per call target, which is what a full function map amounts to here
+        symbols = [(f"leaf_{index}", leaf, 0x10) for index, leaf in enumerate(_leaves(text_va))]
+        symbols += [("seeder", seeder, 0x14), ("caller", text_va, 0xC0)]
+    return _elf(_text(words, text_va), base, symbols), table
+
+
+def _functions(blob):
+    """Analyse a built image, returning the report as well so a test can say it analysed at all."""
+    config = SmdaConfig()
+    config.WITH_STRINGS = False
+    report = Disassembler(config).disassembleUnmappedBuffer(blob)
+    return report, {function.offset for function in report.getFunctions()}
+
+
+def _disassembly(blob):
+    """What a candidate manager is initialized over, built without running an analysis so a test
+    can hold the manager afterwards and read what discovery left in it."""
+    loader = FileLoader("/", map_file=True)
+    loader._loadFile(blob)
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = Disassembler()._populateBinaryInfo(loader)
+    return disassembly
+
+
+class MetadataCoverageTest(unittest.TestCase):
+    """The coverage test itself, over the two sets it reads and nothing else."""
+
+    def _manager(self, target_count, named_count):
+        """Only what the coverage test consults, so what survives here is its whole input. The
+        counts divide exactly at the cutoff, keeping the boundary case about the comparison
+        rather than about where a ratio rounds."""
+        manager = FunctionCandidateManager(SmdaConfig())
+        targets = [BASE + index * 0x10 for index in range(target_count)]
+        manager._call_targets = set(targets)
+        manager._metadata_candidates = set(targets[:named_count])
+        return manager
+
+    def testCoverageBelowTheCutoffLeavesTheScanRunning(self):
+        # 18 of 20 is 0.9
+        self.assertFalse(self._manager(20, 18)._metadataNamedTheCallTargets())
+
+    def testCoverageAtTheCutoffSkipsTheScan(self):
+        # 19 of 20 computes to the same double the cutoff is written as, so the comparison
+        # decides the boundary and not which way a division rounded
+        self.assertTrue(self._manager(20, 19)._metadataNamedTheCallTargets())
+
+    def testCoverageAboveTheCutoffSkipsTheScan(self):
+        self.assertTrue(self._manager(20, 20)._metadataNamedTheCallTargets())
+
+    def testAnImageWhoseCallsResolvedToNothingLeavesTheScanRunning(self):
+        """No call targets is no evidence either way, and the scan is the last pass that could
+        reach an entry, so it runs."""
+        self.assertFalse(self._manager(0, 0)._metadataNamedTheCallTargets())
+
+    def testOnlyTheNamedAddressesThatAreCallTargetsCount(self):
+        """Control on the denominator: metadata that names addresses nothing calls says nothing
+        about the addresses something does call, so it cannot lift an image over the cutoff."""
+        manager = self._manager(20, 18)
+        manager._metadata_candidates |= {BASE + 0x8000 + index * 0x10 for index in range(20)}
+
+        self.assertFalse(manager._metadataNamedTheCallTargets())
+
+
+class AddressScanRunsWithoutMetadataTest(unittest.TestCase):
+    """The recall side: a stripped image is the case the address scan exists for."""
+
+    def setUp(self):
+        blob, self.adr_callback, self.pair_callback = _callbackImage(BASE)
+        report, self.functions = _functions(blob)
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.architecture, "aarch64")
+
+    def testTheCallbackReachedByAnAdrIsRecovered(self):
+        self.assertIn(self.adr_callback, self.functions)
+
+    def testTheCallbackReachedByTheAdrpAddPairIsRecovered(self):
+        self.assertIn(self.pair_callback, self.functions)
+
+    def testTheRestOfTheImageIsRecovered(self):
+        """Control. Both assertions above would also hold on an image that failed to analyse."""
+        self.assertIn(BASE + TEXT_OFFSET, self.functions)
+        self.assertIn(BASE + TEXT_OFFSET + SEEDER_BLOCK, self.functions)
+        self.assertEqual([leaf for leaf in _leaves(BASE + TEXT_OFFSET) if leaf not in self.functions], [])
+
+    def testNeitherCallbackIsRecoveredOnceTheMaterializationIsGone(self):
+        """Control on the other side: with the three words that materialize the addresses replaced
+        by nops, nothing else in the image reaches either callback, so it is the address scan that
+        recovered them above and not a pass that would have reached them regardless."""
+        blob, adr_callback, pair_callback = _callbackImage(BASE, materialized=False)
+        report, functions = _functions(blob)
+
+        self.assertEqual(report.status, "ok")
+        self.assertNotIn(adr_callback, functions)
+        self.assertNotIn(pair_callback, functions)
+        self.assertIn(BASE + TEXT_OFFSET, functions)
+
+
+class AddressScanIsSkippedWhenMetadataNamedTheCallsTest(unittest.TestCase):
+    """The precision side: on an image that names its own call targets the scan is not run."""
+
+    def setUp(self):
+        blob, self.table = _tableImage(BASE)
+        report, self.functions = _functions(blob)
+        self.assertEqual(report.status, "ok")
+        self.assertEqual(report.architecture, "aarch64")
+
+    def testTheMaterializedTableIsNotBookedAsAFunction(self):
+        self.assertNotIn(self.table, self.functions)
+
+    def testTheImageItselfIsStillRecovered(self):
+        """Control. The assertion above says an address is absent, which an image that analysed
+        into nothing would satisfy just as well."""
+        self.assertIn(BASE + TEXT_OFFSET, self.functions)
+        self.assertIn(BASE + TEXT_OFFSET + SEEDER_BLOCK, self.functions)
+        self.assertEqual([leaf for leaf in _leaves(BASE + TEXT_OFFSET) if leaf not in self.functions], [])
+
+    def testTheSameCodeWithoutASymbolTableDoesBookTheTable(self):
+        """Control on what decided it: strip the symbol table and nothing else, and the coverage
+        falls to zero, the scan runs, and the table becomes the false positive the gate is for."""
+        blob, table = _tableImage(BASE, named=False)
+        report, functions = _functions(blob)
+
+        self.assertEqual(report.status, "ok")
+        self.assertIn(table, functions)
+
+
+class ManagerReuseTest(unittest.TestCase):
+    """Candidate discovery runs inside `init`, so a manager initialized a second time would weigh
+    the second image's coverage against the first image's call targets. `_call_targets` is the set
+    that carries over without the reset; the candidate snapshot is retaken inside discovery."""
+
+    def testASecondImageIsNotDecidedByTheFirstsCallTargets(self):
+        stripped, _adr_callback, _pair_callback = _callbackImage(BASE)
+        named, _table = _tableImage(REUSE_BASE)
+        manager = FunctionCandidateManager(SmdaConfig())
+
+        manager.init(_disassembly(stripped))
+        # control: the first image really did fill the sets
+        self.assertEqual(manager._call_targets, _callTargets(BASE + TEXT_OFFSET))
+        self.assertFalse(manager._metadataNamedTheCallTargets())
+
+        # the engine hands the manager the image's symbols before init; a full function map is
+        # one naming every call target
+        manager.symbol_addresses = sorted(_callTargets(REUSE_BASE + TEXT_OFFSET))
+        manager.init(_disassembly(named))
+
+        self.assertEqual(manager._call_targets, _callTargets(REUSE_BASE + TEXT_OFFSET))
+        self.assertTrue(manager._metadataNamedTheCallTargets())
+
+    def testTwoImagesThroughOneDisassemblerAreDecidedSeparately(self):
+        """The same property through the public interface. Every analysis builds its own candidate
+        manager today, so this holds on that as much as on the reset; it is here to catch a change
+        that carries one manager across analyses without carrying the reset with it."""
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        disassembler = Disassembler(config)
+        stripped, adr_callback, _pair_callback = _callbackImage(BASE)
+        named, table = _tableImage(REUSE_BASE)
+
+        first = disassembler.disassembleUnmappedBuffer(stripped)
+        second = disassembler.disassembleUnmappedBuffer(named)
+
+        self.assertEqual(first.status, "ok")
+        self.assertEqual(second.status, "ok")
+        self.assertIn(adr_callback, {function.offset for function in first.getFunctions()})
+        second_functions = {function.offset for function in second.getFunctions()}
+        self.assertNotIn(table, second_functions)
+        # control: the second image analysed rather than merely producing no table
+        self.assertIn(REUSE_BASE + TEXT_OFFSET, second_functions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testAArch64MetadataCoverageGate.py
+++ b/tests/testAArch64MetadataCoverageGate.py
@@ -10,18 +10,23 @@ Instruction encodings below were verified against capstone 5.0.7 (CS_ARCH_ARM64)
 import struct
 import unittest
 
-from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager
+from smda.aarch64.FunctionCandidateManager import _METADATA_MIN_CALL_TARGETS, FunctionCandidateManager
 from smda.Disassembler import Disassembler
 from smda.DisassemblyResult import DisassemblyResult
 from smda.SmdaConfig import SmdaConfig
 from smda.utility.FileLoader import FileLoader
 
 BASE = 0x400000
+#: call targets the predicate tests divide, chosen above the floor and so that the cutoff
+#: ratio is exact rather than a rounding of one
+SAMPLE = 800
+AT_CUTOFF = 760
+
 #: the reuse test needs a second image whose addresses cannot be confused with the first's
 REUSE_BASE = 0x800000
 #: the single PT_LOAD maps file offset 0 at the base, so .text is at base + its file offset
 TEXT_OFFSET = 0x1000
-TEXT_SIZE = 0x5000
+TEXT_SIZE = 0x9000
 
 NOP = 0xD503201F
 RET = 0xD65F03C0
@@ -32,13 +37,15 @@ MOV_W1_2 = 0x52800041  # mov w1, #2
 MOV_W2_3 = 0x52800062  # mov w2, #3
 BTI_C = 0xD503245F  # bti c
 
-#: enough call-referenced 16-aligned entries, each carrying more than one reference, for the
-#: alignment floor to infer 16
-LEAF_COUNT = 22
-LEAF_BLOCK = 0x1000
+#: 16-aligned entries each carrying more than one call reference, which does two jobs: it
+#: gives the alignment floor a population to infer 16 from, and it puts the image over
+#: `_METADATA_MIN_CALL_TARGETS` so the coverage test reads a rate rather than declining for
+#: want of a sample
+LEAF_COUNT = _METADATA_MIN_CALL_TARGETS + 8
+LEAF_BLOCK = 0x2000
 LEAF_STRIDE = 0x10
-TARGET_BLOCK = 0x2000
-SEEDER_BLOCK = 0x3000
+TARGET_BLOCK = 0x6000
+SEEDER_BLOCK = 0x7000
 #: jump-table entries: small offsets, which occupy the udf encoding space, so the gap scan reads
 #: them as data and only the address scan can book the table
 TABLE_WORDS = (0x00000008, 0x00000010, 0x00000018, 0x00000020)
@@ -262,16 +269,27 @@ class MetadataCoverageTest(unittest.TestCase):
         return manager
 
     def testCoverageBelowTheCutoffLeavesTheScanRunning(self):
-        # 18 of 20 is 0.9
-        self.assertFalse(self._manager(20, 18)._metadataNamedTheCallTargets())
+        # 760 of 800 is 0.95; one fewer is not
+        self.assertFalse(self._manager(SAMPLE, AT_CUTOFF - 1)._metadataNamedTheCallTargets())
 
     def testCoverageAtTheCutoffSkipsTheScan(self):
-        # 19 of 20 computes to the same double the cutoff is written as, so the comparison
+        # 760 of 800 computes to the same double the cutoff is written as, so the comparison
         # decides the boundary and not which way a division rounded
-        self.assertTrue(self._manager(20, 19)._metadataNamedTheCallTargets())
+        self.assertTrue(self._manager(SAMPLE, AT_CUTOFF)._metadataNamedTheCallTargets())
 
     def testCoverageAboveTheCutoffSkipsTheScan(self):
-        self.assertTrue(self._manager(20, 20)._metadataNamedTheCallTargets())
+        self.assertTrue(self._manager(SAMPLE, SAMPLE)._metadataNamedTheCallTargets())
+
+    def testEveryCallTargetNamedIsStillNotEnoughFromTooSmallASample(self):
+        """A rate needs a sample. One image in the corpus resolves four `bl` targets in total,
+        and metadata naming all four says nothing about the functions only a materialized
+        address reaches -- so below the floor the scan runs however the few came out."""
+        self.assertFalse(
+            self._manager(_METADATA_MIN_CALL_TARGETS - 1, _METADATA_MIN_CALL_TARGETS - 1)._metadataNamedTheCallTargets()
+        )
+        self.assertTrue(
+            self._manager(_METADATA_MIN_CALL_TARGETS, _METADATA_MIN_CALL_TARGETS)._metadataNamedTheCallTargets()
+        )
 
     def testAnImageWhoseCallsResolvedToNothingLeavesTheScanRunning(self):
         """No call targets is no evidence either way, and the scan is the last pass that could
@@ -281,8 +299,8 @@ class MetadataCoverageTest(unittest.TestCase):
     def testOnlyTheNamedAddressesThatAreCallTargetsCount(self):
         """Control on the denominator: metadata that names addresses nothing calls says nothing
         about the addresses something does call, so it cannot lift an image over the cutoff."""
-        manager = self._manager(20, 18)
-        manager._metadata_candidates |= {BASE + 0x8000 + index * 0x10 for index in range(20)}
+        manager = self._manager(SAMPLE, AT_CUTOFF - 1)
+        manager._metadata_candidates |= {BASE + 0x80000 + index * 0x10 for index in range(SAMPLE)}
 
         self.assertFalse(manager._metadataNamedTheCallTargets())
 

--- a/tests/testMachoFunctionStartCandidates.py
+++ b/tests/testMachoFunctionStartCandidates.py
@@ -55,18 +55,23 @@ class MachoFunctionStartFixtureTestSuite(unittest.TestCase):
         on = _report(buffer, True)
         self.assertEqual(off.status, "ok")
         self.assertEqual(on.status, "ok")
-        # eight more than the primary pass used to find: a run of branch veneers whose
-        # targets gap analysis itself discovered, which the interior test refused while it
-        # could only see the candidate set snapshotted before analysis. All eight are
-        # addresses LC_FUNCTION_STARTS declares, which is why the table intersection moves
-        # by the same amount, and the total with the table pass on does not move at all --
-        # the primary pass now finds by itself what the table was compensating for.
-        self.assertEqual(off.num_functions, 254)
-        self.assertEqual(on.num_functions, 275)
+        # eleven more of the linker's own entries than the primary pass used to find. Eight
+        # are a run of branch veneers whose targets gap analysis itself discovered, which the
+        # interior test refused while it could only see the candidate set snapshotted before
+        # analysis; one is a routine opening on a hoisted argument check, which the gap scan
+        # used to refuse for being a conditional branch; the other two the adr/adrp scan
+        # reaches now that it runs on Mach-O. Every one of the eleven is an address
+        # LC_FUNCTION_STARTS declares, which is what says they are the linker's own starts
+        # and not ones a scan invented.
+        # The function count rises by ten rather than eleven because 0x100004c48 stops being
+        # reported, from both sides. It is not in the table, so that is a false positive
+        # going, and it is the whole of the movement in the total with the table pass on.
+        self.assertEqual(off.num_functions, 256)
+        self.assertEqual(on.num_functions, 274)
         table = _table_addresses(buffer)
         off_starts = {function.offset for function in off.getFunctions()}
         on_starts = {function.offset for function in on.getFunctions()}
-        self.assertEqual(len(table & off_starts), 125)
+        self.assertEqual(len(table & off_starts), 128)
         self.assertEqual(len(table & on_starts), 146)
         # a candidate source may only add starts, never drop one the primary pass found
         self.assertEqual(off_starts - on_starts, set())

--- a/tests/testMachoFunctionStartCandidates.py
+++ b/tests/testMachoFunctionStartCandidates.py
@@ -55,12 +55,18 @@ class MachoFunctionStartFixtureTestSuite(unittest.TestCase):
         on = _report(buffer, True)
         self.assertEqual(off.status, "ok")
         self.assertEqual(on.status, "ok")
-        self.assertEqual(off.num_functions, 246)
+        # eight more than the primary pass used to find: a run of branch veneers whose
+        # targets gap analysis itself discovered, which the interior test refused while it
+        # could only see the candidate set snapshotted before analysis. All eight are
+        # addresses LC_FUNCTION_STARTS declares, which is why the table intersection moves
+        # by the same amount, and the total with the table pass on does not move at all --
+        # the primary pass now finds by itself what the table was compensating for.
+        self.assertEqual(off.num_functions, 254)
         self.assertEqual(on.num_functions, 275)
         table = _table_addresses(buffer)
         off_starts = {function.offset for function in off.getFunctions()}
         on_starts = {function.offset for function in on.getFunctions()}
-        self.assertEqual(len(table & off_starts), 117)
+        self.assertEqual(len(table & off_starts), 125)
         self.assertEqual(len(table & on_starts), 146)
         # a candidate source may only add starts, never drop one the primary pass found
         self.assertEqual(off_starts - on_starts, set())


### PR DESCRIPTION
Six more changes to AArch64 candidate discovery, all in the same two scans, continuing directly from #310.

**This branch contains #310's three commits as well** — its work is what the first change here builds on, and the two cannot be separated without rewriting both. Review the seven commits after `fix(aarch64): stop the refused-pad walk at a trap`, or take #310 first and this rebases to just those.

## 1. Both interior tests read a stale snapshot

`getFunctionStartCandidates()` is taken before analysis begins and gap analysis never adds to it, so a function the gap scan discovered is in `code_map` and absent from that set. Both interior tests in the AArch64 candidate manager read that difference as evidence of an interior:

- `_gapRunFlowsIntoInterior` treats a branch to such a function as a branch into somebody's body, so a run of branch veneers whose targets the gap scan found gets suppressed;
- `_isLikelyInteriorBtiCandidate` refuses a landing pad at an address the gap scan already recovered as a function.

Both now ask `disassembly.functions` too. On the bundled `osx.frostyferret` fixture this alone recovers **8 more functions, every one of them an address `LC_FUNCTION_STARTS` declares**, with nothing lost.

## 2. The two gap-run walks stop at different words, and that is correct

`_gapRunFlowsIntoInterior` and `_endOfRefusedLandingPadRun` share `_GAP_RUN_LIMIT`, but since #310 the second also stops at `brk`/`hlt`/`udf`. That reads like an omission — `AArch64Backend.analyzeInstruction` ends a function on all three through `END_INS` — and it is not.

The two walks answer different questions. `_endOfRefusedLandingPadRun` decides **how far to skip**, and one instruction too far steps over a real entry and loses it outright, so it must stop at the earliest boundary it can defend. `_gapRunFlowsIntoInterior` decides **whether to suppress**; nothing is skipped either way and reading further only gathers more evidence about the same candidate. A trap is not a boundary the image declares — mid-body it is a bounds check or a `__builtin_trap` — so the words behind it still belong to the enclosing routine.

Counted rather than argued: adding `is_trap` to the suppression walk releases 12 candidates on the 11-cell ARM64 Mach-O corpus (two sites, each swept one word at a time), **0 of them true starts**, and 0 candidates on the 72-cell built AArch64 ELF corpus. Both released sites sit `0x15c` and `0x1d8` inside functions the ground truth declares.

No behaviour change — the comment on each walk now states why its terminator set is what it is and points at the other, plus a new test file that pins the asymmetry so a future reader does not "fix" it.

## 3. A function may open with a conditional branch

The gap scan refused any candidate whose first word was one:

```python
if is_conditional_branch(word):  # a function never opens with a cond branch
```

The claim is false. At `-O2` a compiler hoists an argument check above the frame setup routinely:

```
cbz   x0, .Lreturn_null      <- the entry
stp   x29, x30, [sp, #-32]!  <- what got booked instead
mov   x29, sp
```

On the 72-cell AArch64 ELF corpus this shape occurs at **230** routines whose entry is one word before the start that was booked, 203 of them opening on a conditional branch.

**Removing a refusal reduces false positives here**, which is worth explaining. The refusal did not merely lose the entry: the frame setup one word in is 4-aligned and nothing calls it, so the alignment floor keeps it out of the first pass, and the start booked in the entry's place came from the *same gap scan* four bytes past the entry it had just stepped over — with the guard's own branch target often becoming a second one. Recovering the entry deletes both wrong starts.

What the refusal was buying, on those 72 cells: **558 addresses refused, of which 462 are function starts the ground truth names.** Four in five of what it held back was real.

| corpus | cells | truth | TP | FP | ΔTP | ΔFP |
|---|---|---|---|---|---|---|
| Built C/C++ AArch64 ELF | 72 | 60,326 | 59,167 → 59,516 | 3,023 → 2,484 | **+349** | **−539** |
| ARM64 Mach-O (`LC_FUNCTION_STARTS`) | 11 | 2,753 | 2,532 → 2,538 | 388 → 382 | **+6** | **−6** |
| Built Go, seven platforms | 47 | 166,337 | 165,627 → 165,627 | 9,816 → 9,812 | 0 | −4 |

Not one cell in any of the three gains a false positive. One cell of 83 loses recall and is worth naming rather than averaging away: on `lz4_gcc-arm64_O1`, recovering `0xcf48` lets its analysis run on through the four truth functions after it — net −2 TP and −2 FP on that cell. That is the merge hazard of recovering an earlier entry, not a property of the guard.

The other call site of `is_conditional_branch`, in `locateAddressRefCandidates`, is untouched and correct: it clears register provenance at a control-flow edge, which a conditional branch is whatever may open a function. Its docstring carried the false claim and now states the encoding fact it is actually for.

## 4. Skip the address scan when metadata already named the functions

`locateAddressRefCandidates` exists to reach entries no call names — a pointer handed to a callback, a table walked at run time. An image that ships a full function map has none of those left over: the symbol pass consumes the map, every entry is already a candidate, and what the scan then produces is the addresses that are materialized but are not entries. On a Go binary that is thousands of them for no recovered function at all.

The question is asked of the image rather than of its container or its language, both of which have been the wrong variable before: **of the addresses this image's own `bl` instructions call, how many did metadata name before this pass ran?** A stripped C or C++ object answers near zero however it was linked; one carrying a complete map answers near one whoever compiled it.

`bl` targets are the denominator because they are the one population both kinds of image have in proportion to how many functions they contain, and because they are known at exactly this point — the scan that resolves them has just finished. The threshold sits at 0.95, in the upper half of a bimodal distribution with a wide empty interval between the modes, because the two errors are not symmetric: running the scan when it is useless costs precision, skipping it when it is not costs recall.

A rate needs a sample, so an image resolving fewer than 512 `bl` targets is left to the scan whatever share of those few metadata named — one corpus image resolves four in the whole binary, and metadata naming all four says nothing.

## 5. Turn the Mach-O address-materialization scan on

`USE_MACHO_ADDRESS_REF_CANDIDATES` shipped off because the scan was all cost on images with a function map. With the coverage gate above deciding that per image, it can default on: on the bundled `osx.frostyferret` fixture it reaches **2 more starts the linker declares** and removes one address that is not in the table.

## What the bundled fixtures do

Both are updated in a single trailing commit so the movement can be read in one place.

- **`osx.frostyferret`** (ARM64 Mach-O): the primary pass recovers 256 functions where it recovered 246, and **128 of the linker's own `LC_FUNCTION_STARTS` entries where it recovered 117**. Eleven table entries gained, one non-table address (`0x100004c48`) dropped. Every gain is an address the linker itself declares; the single loss is not, so it is a false positive going.
- **`aarch64_static`** (ELF): 278 functions either way, one instruction more, and the routine at `0x40DF34` is reported at `0x40DF30`. That word is a hoisted `cbz x14`. `0x40DF30` is 16-aligned and follows the previous function's `ret` and its padding nop; `0x40DF34` is 4-aligned and mid-line; neither carries an inbound direct branch. This is the one baseline movement that is a judgement rather than a measurement, and it is called out rather than folded into a count.

## Tests

- `tests/testAArch64GapRunTerminators.py` — nine tests in two classes pinning the terminator asymmetry, behavioural and walk-level, mutation-checked by adding `or is_trap(word)` to the suppression walk and watching the behavioural assertion and one walk-level assertion turn red while every control stays green.
- `tests/testAArch64HoistedGuardEntry.py` — the hoisted guard recovered as the entry with the **whole** recovered set compared, not one address; a control that the same word class after ordinary code inside an already-claimed routine is still not booked (the case the guard existed for); and a control that a conditional branch opening an unclaimed gap now books the block's first word rather than the word behind it.
- `tests/testAArch64MetadataCoverageGate.py` — the gate over synthetic images at both sides of the threshold and below the sample floor, plus the reset behaviour that matters for a manager driven one pass at a time.

## Validation

`ruff check` / `ruff format --check` pass, `ty check` exit 0, full suite green on this branch rebased onto current master, diff coverage 100% on the changed source lines.

## Branch shape

Rebased onto current master (395c88d) as the flat ten commits, dropping the three pre-squash copies of #310 and the `fix(ci)` commit that #302 made redundant. This is the exact set and order you listed.

The rebase is content-neutral: the tree is `38b27ba`, byte for byte what the merge-based version resolved to, so the measurements above stand unchanged and nothing needs re-running. `ruff check`, `ruff format --check` and `ty` 0.0.74 are clean on it; the full suite was 1918 passed / 1 skipped / 2593 subtests on this identical tree.

One thing to know if you take #309 first: #312 still carries copies of these ten, so it will hit the same squash artifact once this lands, in the same way and with the same fix. Its content reduces to a single commit either way.

## Changelog note

Flagging this for whoever writes the release entry, since it is the one thing here that changes behaviour for every consumer rather than only for the images it measures on:

> `USE_MACHO_ADDRESS_REF_CANDIDATES` now defaults on. The AArch64 adr/adrp address-materialization scan is gated per image by metadata call-target coverage rather than per container, so it no longer runs on images whose metadata already names their functions. Measured on the bundled 11-sample ARM64 Mach-O corpus: +31 true starts, −5 false ones, TPR 86.916% → 88.424%, with no cell losing recall.

I have not touched `CHANGELOG.md` here — its entries are per released version and there is no unreleased section, so writing one would mean picking a version number, which is yours to decide at release time.