### PR TITLE
perf(aarch64): refuse a gap candidate the ARM64 PE unwind data places inside a routine

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -43,9 +43,19 @@ class SmdaConfig:
     USE_ALIGNMENT = True
     USE_SYMBOLS_AS_CANDIDATES = True
     # seed AArch64 function candidates from the PE ARM64 exception directory (classic 0xAA64
-    # images only); funclet/fragment records are filtered at seeding, and IDA-labeled ARM64
+    # images only); packed fragment records are dropped at seeding, and IDA-labeled ARM64
     # system binaries (wermgr/ping/robocopy/bcrypt) show equal-or-better boundary accuracy
-    # with the directory enabled, so it is on by default
+    # with the directory enabled, so it is on by default.
+    #
+    # What survives seeding is not only whole functions. An MSVC-built image gives a separated
+    # chunk of a routine its own record, and the chunk sets up its own frame, so the entry-shape
+    # filter reads it as an entry: on ping/robocopy/bcrypt that is 78 seeded starts inside a
+    # function IDA labels, 73 beginning exactly where another record's extent ends with nothing
+    # referencing them. Microsoft's own public PDBs name 88.5% of the addresses IDA calls
+    # functions but only 6.4% of those 78, so they are chunks rather than entries and this seeding
+    # over-reports on such images. Refusing them by that shape costs 13 addresses the PDBs do name;
+    # the exact test is whether the parent's .xdata scope table points at the address, which is
+    # not parsed yet. clang/llvm-mingw does not split them, so a from-source ARM64 PE is unaffected.
     USE_PE_ARM64_PDATA_CANDIDATES = True
     # do not read `bti j` as a function entry on AArch64. The four BTI forms are not
     # interchangeable: J permits a target reached by `br` - an indirect jump, which is what a

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -53,9 +53,12 @@ class SmdaConfig:
     # function IDA labels, 73 beginning exactly where another record's extent ends with nothing
     # referencing them. Microsoft's own public PDBs name 88.5% of the addresses IDA calls
     # functions but only 6.4% of those 78, so they are chunks rather than entries and this seeding
-    # over-reports on such images. Refusing them by that shape costs 13 addresses the PDBs do name;
-    # the exact test is whether the parent's .xdata scope table points at the address, which is
-    # not parsed yet. clang/llvm-mingw does not split them, so a from-source ARM64 PE is unaffected.
+    # over-reports on such images. Refusing them by that shape costs 13 addresses the PDBs do name,
+    # and no exact test is in reach: the parent's .xdata handler data names its exception funclets,
+    # but only 25 of the 145 chunks here have a parent carrying any -- the other 120 continue a
+    # record with the X bit clear or no .xdata at all, so they are not exception funclets and
+    # nothing in the unwind data distinguishes them. clang/llvm-mingw emits one record per function
+    # symbol and does not split them, so a from-source ARM64 PE is unaffected either way.
     USE_PE_ARM64_PDATA_CANDIDATES = True
     # do not read `bti j` as a function entry on AArch64. The four BTI forms are not
     # interchangeable: J permits a target reached by `br` - an indirect jump, which is what a

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -108,6 +108,11 @@ class SmdaConfig:
     # the small aligned functions after it. On the cell examined, all eight functions
     # recovered sit 11 to 79 bytes past a declared extent's end.
     USE_PE_X64_PDATA_INTERIOR_GAPS = True
+    # Refuse a gap candidate that an ARM64 PE image's own exception directory places inside a
+    # routine. The same evidence and the same rule as the x64 flag above, reached differently:
+    # an ARM64 RUNTIME_FUNCTION has no EndAddress, so the extent is reconstructed from packed
+    # unwind data or from the .xdata record it points at.
+    USE_PE_ARM64_PDATA_INTERIOR_GAPS = True
     # promote unclaimed ELF .eh_frame FDE starts as late candidates on both instruction sets
     # (after the primary pass, before gap analysis). Unwind ranges are not function starts by
     # definition - .eh_frame also covers ranges that are not independent functions. Measured

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -185,16 +185,22 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 ranges.append((section_start, section_start + section_size))
         return ranges
 
-    def _isValidArm64UnwindInfo(self, xdata_rva):
+    def _arm64UnwindHeaderWord(self, xdata_rva):
+        """First word of the .xdata record at `xdata_rva`, or None when it cannot be read.
+
+        It carries both the validity of the record and the length of the function it
+        describes, so the callers that need either read it through here rather than twice.
+        """
         # ARM64 .xdata header word: FunctionLength[17:0] (in words, must be nonzero),
         # Vers[19:18] (only version 0 is defined), X[20], E[21], EpilogCount[26:22],
-        # CodeWords[31:27]. Records are 4-byte aligned and must lie inside the image.
-        if xdata_rva == 0 or xdata_rva % 4 != 0:
-            return False
-        header = self.disassembly.getRawBytes(xdata_rva, 4)
-        if header is None or len(header) < 4:
-            return False
-        return self._isValidArm64UnwindHeader(int.from_bytes(header, "little"))
+        # CodeWords[31:27]. The pointer needs no alignment test: it is only read when the
+        # flag in its own low two bits is zero, which is what makes it word-aligned.
+        if not xdata_rva:
+            return None
+        header = self.disassembly.getRawBytes(xdata_rva, INSTRUCTION_SIZE)
+        if header is None or len(header) < INSTRUCTION_SIZE:
+            return None
+        return int.from_bytes(header, "little")
 
     @staticmethod
     def _isValidArm64UnwindHeader(header_word):
@@ -249,17 +255,33 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if begin_rva == 0:
                 break
             flag = unwind_data & 0x3
-            if flag == 0:
-                # UnwindData is the RVA of a full .xdata record; validate its header
-                if not self._isValidArm64UnwindInfo(unwind_data):
-                    continue
-            elif flag != 1:
-                # flag 2: packed fragment of another function's body; flag 3: reserved
+            if flag == 3:  # reserved
                 continue
             if begin_rva % INSTRUCTION_SIZE != 0:
                 continue
             addr = base_addr + begin_rva
             if not any(start <= addr < end for start, end in exec_ranges):
+                continue
+            # An ARM64 RUNTIME_FUNCTION carries no EndAddress, unlike its x64 counterpart. A
+            # packed record spells the length in bits 2-12 of UnwindData; a full record puts
+            # it in bits 0-17 of the .xdata header, the same word that says whether the record
+            # is valid at all. Both count instructions, so both scale by the word size.
+            if flag == 0:
+                header_word = self._arm64UnwindHeaderWord(unwind_data)
+                if header_word is None or not self._isValidArm64UnwindHeader(header_word):
+                    continue
+                length = (header_word & 0x3FFFF) * INSTRUCTION_SIZE
+            else:
+                length = ((unwind_data >> 2) & 0x7FF) * INSTRUCTION_SIZE
+            # the extent is recorded for every accepted record, fragments included: what the
+            # unwinder names is the bytes belonging to a routine, and that is as true of a
+            # fragment as of a whole function
+            if length:
+                self._pdata_ranges.append((addr, addr + length, flag == 2))
+                self._pdata_range_starts = None
+            if flag == 2:
+                # a packed fragment of another function's body: its begin word continues that
+                # function rather than starting one, so it names no candidate
                 continue
             # Exception records also name funclets and function fragments, whose
             # begin address is a mid-body word continuing the enclosing function;
@@ -1016,6 +1038,18 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if word in (0, NOP):  # inter-function padding
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
+            if self._pdata_ranges and self.config.USE_PE_ARM64_PDATA_INTERIOR_GAPS:
+                # the emptiness test comes first: this runs once per scanned word, and on an
+                # ELF or Mach-O image there is no exception directory to consult at all
+                containing = self.declaredExceptionRangeContaining(self.gap_pointer)
+                if containing is not None and (containing[2] or containing[0] in self.disassembly.functions):
+                    # A fragment record is evidence on its own -- it says the whole extent is
+                    # part of another function. A primary record only speaks once the function
+                    # it names has actually been recovered; until then the record says nothing
+                    # about what covers this address. Resuming at the extent's end skips the
+                    # body rather than the one word, which is what the record describes.
+                    self.gap_pointer = containing[1]
+                    continue
             if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(self.gap_pointer, word):
                 self.gap_pointer = self._endOfRefusedLandingPadRun(self.gap_pointer)
                 continue

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -59,8 +59,20 @@ class FunctionCandidateManager:
         # backstop against memory usage explosion during candidate identification
         self._candidate_cap_logged = False
         self._cb_analysis_timeout = None
+        #: (start, end, is_fragment) per exception-directory record, filled by whichever
+        #: backend reads that directory. Sorted lazily on first lookup because seeding
+        #: appends in table order. Uncapped, unlike the candidate registry: one tuple per
+        #: record is about 145 bytes, so an image with 200,000 functions holds ~29 MB here,
+        #: and capping it would silently stop suppressing on exactly the largest images
+        #: rather than bounding anything that matters.
+        self._pdata_ranges = []
+        self._pdata_range_starts = None
+        self._pdata_range_reach = []
 
     def init(self, disassembly, cbAnalysisTimeout=None):
+        self._pdata_ranges = []
+        self._pdata_range_starts = None
+        self._pdata_range_reach = []
         if disassembly.binary_info.code_areas:
             self._code_areas = disassembly.binary_info.code_areas
         self.disassembly = disassembly
@@ -517,6 +529,42 @@ class FunctionCandidateManager:
             if self.disassembly.isCode(start):
                 continue
             yield start
+
+    def declaredExceptionRangeContaining(self, addr):
+        """The RUNTIME_FUNCTION extent `addr` sits inside without being an entry, or None.
+
+        `(start, end, is_fragment)`. A primary record's own start is the function's entry, so
+        only a strictly interior address answers; a fragment record describes part of some
+        other function, so its first byte is interior too and answers as well.
+
+        The extents come from whichever backend read the exception directory -- x64 reads an
+        EndAddress field, ARM64 reconstructs the length from packed or .xdata unwind data --
+        but what to do with a range once it is known does not differ between them.
+
+        Extents are deliberately not merged. Functions are laid out end-to-start, so merging
+        adjacent records would collapse the text section into a handful of spans in which
+        every address but the first reads as interior.
+        """
+        if self._pdata_range_starts is None:
+            self._pdata_ranges.sort()
+            self._pdata_range_starts = [start for start, _, _ in self._pdata_ranges]
+            # Sorting by start does not order the ends, so "the previous record ends before
+            # `addr`" says nothing about the one before that. Two short records in front of
+            # a long one would end the walk on top of the extent that actually covers the
+            # address. The running maximum is what can be tested in one step: once no record
+            # at or before this index reaches past `addr`, none of them contains it.
+            highest = 0
+            self._pdata_range_reach = []
+            for _, end, _fragment in self._pdata_ranges:
+                highest = max(highest, end)
+                self._pdata_range_reach.append(highest)
+        index = bisect.bisect_right(self._pdata_range_starts, addr) - 1
+        while index >= 0 and self._pdata_range_reach[index] > addr:
+            start, end, fragment = self._pdata_ranges[index]
+            if addr < end and (start < addr or fragment):
+                return start, end, fragment
+            index -= 1
+        return None
 
     def _ehFrameFunctionStarts(self):
         binary_info = self.disassembly.binary_info

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -7,7 +7,6 @@ prologue byte-pattern seeding, jmp/call-pointer and PLT stub-chain discovery,
 PE x64 ``.pdata`` exception-record seeding, and the NOP/padding-aware gap scan.
 """
 
-import bisect
 import logging
 import re
 import struct
@@ -101,21 +100,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         self.pdata_start_addresses = set()
         self.pdata_end_addresses = set()
         #: (start, end, is_chained) for every RUNTIME_FUNCTION record the image declares,
-        #: sorted lazily on first lookup because seeding appends in table order. Uncapped,
-        #: unlike the candidate registry: one tuple per record is about 145 bytes, so an
-        #: image with 200,000 functions holds ~29 MB here, and capping it would silently
-        #: stop suppressing on exactly the largest images rather than bounding anything
-        #: that matters.
-        self._pdata_ranges = []
-        self._pdata_range_starts = None
-        self._pdata_range_reach = []
         self._retained_pad = None
 
     def init(self, disassembly, cbAnalysisTimeout=None):
         self._retained_pad = None
-        self._pdata_ranges = []
-        self._pdata_range_starts = None
-        self._pdata_range_reach = []
         # the gap scan decodes potential NOP instructions, so it needs an x86 capstone
         # matching the binary's bitness; build it before the base init runs discovery
         self.capstone = Cs(CS_ARCH_X86, CS_MODE_32)
@@ -904,38 +892,6 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             self._admitExceptionRecord(
                 base_addr, rva_start, rva_end, rva_unwind_info, record_pdata_ends, declared=False
             )
-
-    def declaredExceptionRangeContaining(self, addr):
-        """The RUNTIME_FUNCTION extent `addr` sits inside without being an entry, or None.
-
-        `(start, end, is_chained)`. A primary record's own start is the function's entry, so
-        only a strictly interior address answers; a chained record describes a fragment of
-        some other function, so its first byte is interior too and answers as well.
-
-        Extents are deliberately not merged. Functions are laid out end-to-start, so merging
-        adjacent records would collapse the text section into a handful of spans in which
-        every address but the first reads as interior.
-        """
-        if self._pdata_range_starts is None:
-            self._pdata_ranges.sort()
-            self._pdata_range_starts = [start for start, _, _ in self._pdata_ranges]
-            # Sorting by start does not order the ends, so "the previous record ends before
-            # `addr`" says nothing about the one before that. Two short records in front of
-            # a long one would end the walk on top of the extent that actually covers the
-            # address. The running maximum is what can be tested in one step: once no record
-            # at or before this index reaches past `addr`, none of them contains it.
-            highest = 0
-            self._pdata_range_reach = []
-            for _, end, _chained in self._pdata_ranges:
-                highest = max(highest, end)
-                self._pdata_range_reach.append(highest)
-        index = bisect.bisect_right(self._pdata_range_starts, addr) - 1
-        while index >= 0 and self._pdata_range_reach[index] > addr:
-            start, end, chained = self._pdata_ranges[index]
-            if addr < end and (start < addr or chained):
-                return start, end, chained
-            index -= 1
-        return None
 
     def _isChainedUnwindInfo(self, rva_unwind_info):
         # x64 UNWIND_INFO header byte 0 packs Version (bits 0-2) and Flags (bits 3-7);

--- a/tests/testAArch64PdataExtraction.py
+++ b/tests/testAArch64PdataExtraction.py
@@ -377,5 +377,136 @@ class AArch64CondBranchExceptionBoundaryTestSuite(unittest.TestCase):
         )
 
 
+class AArch64PdataExtentTestSuite(unittest.TestCase):
+    """An ARM64 RUNTIME_FUNCTION has no EndAddress, so the extent the record declares has to be
+    reconstructed before anything can be called interior to it. The length lives in one of two
+    places depending on the flag, and both count instructions rather than bytes."""
+
+    def _ranges(self, records, xdata_bytes=VALID_XDATA):
+        return _candidates_for(_build_arm64_pe(records, xdata_bytes=xdata_bytes))._pdata_ranges
+
+    def test_a_packed_record_spells_its_length_in_the_unwind_word(self):
+        # flag 1, FunctionLength 0x10 in bits 2-12: 16 instructions, so 0x40 bytes
+        ranges = self._ranges(_record(TEXT_RVA, (0x10 << 2) | 1))
+
+        self.assertEqual(ranges, [(IMAGE_BASE + TEXT_RVA, IMAGE_BASE + TEXT_RVA + 0x40, False)])
+
+    def test_a_full_record_takes_its_length_from_the_xdata_it_points_at(self):
+        # VALID_XDATA carries FunctionLength 0x10 in bits 0-17 of the first word
+        ranges = self._ranges(_record(TEXT_RVA, XDATA_RVA))
+
+        self.assertEqual(ranges, [(IMAGE_BASE + TEXT_RVA, IMAGE_BASE + TEXT_RVA + 0x40, False)])
+
+    def test_a_fragment_record_declares_an_extent_and_seeds_no_candidate(self):
+        # flag 2 describes part of another function: the extent is still what the unwinder says
+        # belongs to a routine, and the fragment's own first word is interior to it as well
+        fcm = _candidates_for(_build_arm64_pe(_record(TEXT_RVA + 8, (0x4 << 2) | 2)))
+
+        self.assertEqual(fcm._pdata_ranges, [(IMAGE_BASE + TEXT_RVA + 8, IMAGE_BASE + TEXT_RVA + 0x18, True)])
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 8, _exception_candidates(fcm))
+
+    def test_a_reserved_record_declares_nothing(self):
+        self.assertEqual(self._ranges(_record(TEXT_RVA, (0x10 << 2) | 3)), [])
+
+    def test_an_unreadable_xdata_length_declares_no_extent(self):
+        # the record points past the image, so there is no length to read and nothing to declare
+        ranges = self._ranges(_record(TEXT_RVA, 0x900000))
+
+        self.assertEqual(ranges, [])
+
+    def test_an_absent_xdata_pointer_declares_no_extent(self):
+        # flag 0 with no pointer at all: nothing to read a length from, so nothing is declared
+        self.assertEqual(self._ranges(_record(TEXT_RVA, 0)), [])
+
+    def test_a_declared_extent_answers_for_its_interior_but_not_its_start(self):
+        fcm = _candidates_for(_build_arm64_pe(_record(TEXT_RVA, (0x10 << 2) | 1)))
+
+        self.assertIsNone(fcm.declaredExceptionRangeContaining(IMAGE_BASE + TEXT_RVA))
+        self.assertEqual(
+            fcm.declaredExceptionRangeContaining(IMAGE_BASE + TEXT_RVA + 4),
+            (IMAGE_BASE + TEXT_RVA, IMAGE_BASE + TEXT_RVA + 0x40, False),
+        )
+        self.assertIsNone(fcm.declaredExceptionRangeContaining(IMAGE_BASE + TEXT_RVA + 0x40))
+
+    def test_a_fragment_extent_answers_for_its_own_start_too(self):
+        fcm = _candidates_for(_build_arm64_pe(_record(TEXT_RVA + 8, (0x4 << 2) | 2)))
+
+        self.assertEqual(
+            fcm.declaredExceptionRangeContaining(IMAGE_BASE + TEXT_RVA + 8),
+            (IMAGE_BASE + TEXT_RVA + 8, IMAGE_BASE + TEXT_RVA + 0x18, True),
+        )
+
+
+class AArch64PdataInteriorGapTestSuite(unittest.TestCase):
+    """The gap scan is what reaches an address nothing references. On an ARM64 PE the exception
+    directory already says which addresses are inside a routine, and until now that was read for
+    seeding and never for refusing."""
+
+    STP_PROLOGUE = 0xA9BF7BFD  # stp x29, x30, [sp, #-16]!
+    RET = 0xD65F03C0
+    NOP = 0xD503201F
+    MOV_W0_1 = 0x52800020
+
+    #: a word the gap scan books when nothing forbids it. Deliberately not a prologue shape:
+    #: the prologue sweep runs before the gap scan and this rule does not constrain it, so a
+    #: prologue here would be booked either way and prove nothing about the rule.
+    INTERIOR_ENTRY_SHAPE = MOV_W0_1
+
+    def _words(self):
+        # the declared function ends at +0x08, so +0x0C onwards is never reached by decoding it
+        # and falls to the gap scan -- which is the pass this rule constrains
+        return [
+            self.STP_PROLOGUE,  # +0x00  the function .pdata declares
+            self.MOV_W0_1,  # +0x04
+            self.RET,  # +0x08  decoding stops here
+            self.INTERIOR_ENTRY_SHAPE,  # +0x0C  in a gap, but interior to the declared extent
+            self.RET,  # +0x10
+            self.NOP,  # +0x14
+            self.NOP,  # +0x18
+            self.NOP,  # +0x1C
+        ]
+
+    def _starts(self, records, interior_gaps=True):
+        code = b"".join(word.to_bytes(4, "little") for word in self._words())
+        blob = _build_arm64_pe(records, text_bytes=code)
+        config = SmdaConfig()
+        config.WITH_STRINGS = False
+        config.USE_PE_ARM64_PDATA_INTERIOR_GAPS = interior_gaps
+        report = Disassembler(config).disassembleUnmappedBuffer(blob)
+        self.assertEqual(report.status, "ok")
+        return {function.offset for function in report.getFunctions()}
+
+    def test_a_gap_candidate_inside_a_declared_extent_is_refused(self):
+        # the record covers +0x00..+0x18, so the entry-shaped word at +0x0C is interior to a
+        # routine the image itself declares
+        records = _record(TEXT_RVA, (0x6 << 2) | 1)
+
+        starts = self._starts(records)
+
+        self.assertIn(IMAGE_BASE + TEXT_RVA, starts)
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 0x0C, starts)
+
+    def test_the_same_image_books_it_with_the_rule_off(self):
+        """Control on what decided it: the word is entry-shaped and unreferenced either way, so
+        it is the declared extent and not the image that keeps it out above."""
+        records = _record(TEXT_RVA, (0x6 << 2) | 1)
+
+        starts = self._starts(records, interior_gaps=False)
+
+        self.assertIn(IMAGE_BASE + TEXT_RVA + 0x0C, starts)
+
+    def test_an_extent_whose_function_was_not_recovered_suppresses_nothing(self):
+        """A record can name an address the analysis never recovered -- a fragment start it
+        declined, or a begin that is not an entry. Until the function it names exists, the
+        record says nothing about what covers an address inside it."""
+        # the record begins at +0x04, a mid-instruction word no pass books as a function
+        records = _record(TEXT_RVA + 4, (0x5 << 2) | 1)
+
+        starts = self._starts(records)
+
+        self.assertNotIn(IMAGE_BASE + TEXT_RVA + 4, starts)
+        self.assertIn(IMAGE_BASE + TEXT_RVA + 0x0C, starts)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The ARM64 counterpart of #309: an ARM64 PE declares an exception directory too, the engine already reads it for candidates, and it never consulted it again when the gap scan carved entries out of addresses the image had declared to belong to a routine starting earlier.

#309 explicitly left this case open, because there is no ARM64 PE in the sample set that PR was measured against and it was itself the argument against shipping an unmeasured suppression rule. This PR closes it against a set that does contain them.

## What is different about ARM64

An x64 `RUNTIME_FUNCTION` carries `EndAddress`. An ARM64 one does not: the extent has to be reconstructed, either from the packed unwind data in the record itself or from the `.xdata` record it points at. That is the only difference. Once an extent is known, what to do with it is identical, which is why the lookup moves rather than being written twice.

`declaredExceptionRangeContaining` and its `_pdata_ranges` state move from `intel/FunctionCandidateManager` up into `common/FunctionCandidateManager`, and the ARM64 manager fills the same list from what it reconstructs. The x64 path is unchanged — same list, same bisect, same running-maximum walk, same deliberate refusal to merge adjacent extents.

`USE_PE_ARM64_PDATA_INTERIOR_GAPS`, on by default, mirrors the x64 flag: a fragment record suppresses on its own because it says the whole extent is part of another function, a primary record only once the function it names has actually been recovered, and the scan resumes at the extent's end rather than one word on.

## Branch layout

This branch stacks on **#309** and on **#310 plus its follow-up series**, because it hoists code #309 introduces and edits a gap-scan loop those change. Its own commit is the last one; everything before it is those two PRs. Taking them first leaves this as a single commit on top.

## Tests

`tests/testAArch64PdataExtraction.py` gains the interior-gap cases over a synthetic ARM64 PE carrying `.pdata` and `.xdata`: an interior address inside a recovered primary extent refused and the scan resumed at its end, a fragment record suppressing from its own first byte, a primary record not suppressing while the function it names is unrecovered, and the flag off restoring the old behaviour.

## Validation

`ruff check` / `ruff format --check` pass, `ty check` exit 0, full suite green on this branch, and the x64 `.pdata` suite from #309 passes unchanged after the hoist — which is the assertion that the move is a move.

## Branch shape

Rebased onto current master (395c88d) as 14 flat commits: #309's one, #311's ten, and this branch's own three. Dropped the five merge commits, the three pre-squash copies of #310, and **three** duplicate `fix(ci)` commits that had accumulated through the merges.

Content-neutral: the tree is `0b2ce4d`, byte for byte what the merge-based version resolved to. `ruff check`, `ruff format --check` and `ty` 0.0.74 clean; the full suite was 1959 passed / 1 skipped / 2593 subtests on this identical tree.

Once #309 and #311 land this reduces to its own three commits, which is the shape described above.

