### PR TITLE
build(ci): pin ruff and keep it level with the pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.16.4
+    rev: v0.16.6
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,13 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "ruff",
+    # pinned, and kept equal to the ruff-pre-commit rev in .pre-commit-config.yaml:
+    # this pin governs the Code Quality job and `make lint`, that rev governs
+    # `pre-commit run`, and pre-commit resolves it in its own isolated env. Left
+    # floating, the two drift apart on astral's release schedule and a hook that
+    # passes locally reddens CI on a rule the other version does not have yet.
+    # Move both in one change.
+    "ruff==0.16.6",
     # pinned: ty is pre-1.0 and adds lint rules in patch releases, so an unpinned
     # floating version reddens unrelated PRs on someone else's release schedule
     # (0.0.69/0.0.70 added unsound-return-statement and unsound-yield; 0.0.74


### PR DESCRIPTION
`ruff` had two independent version sources and nothing held them equal.

| source | governs | was |
|---|---|---|
| `pyproject.toml` `[dev]` | the `Code Quality` job (`pip install -e ".[dev]"`, then `python -m ruff`) and `make lint` / `make format` | **unpinned** |
| `.pre-commit-config.yaml` `rev:` | `pre-commit run`, resolved in pre-commit's own isolated env | `v0.16.4` |

So CI linted with whatever was newest at install time while the hook stayed at a fixed rev. The two drift apart on astral's release schedule, and when they do, a hook run that passes locally reddens CI on a rule the other version does not carry yet.

This is the same hazard the `ty` pin immediately below it already describes — and 572acd7 showed what it costs. That commit took ty to 0.0.74 through Dependabot with its new `unsound-return-statement` / `unsound-assignment` rules unaddressed, and master failed `Code Quality` with **41 errors across 15 files** until #302 landed as 7f892b9. ruff is post-1.0 and far steadier than a pre-1.0 ty, so the risk here is smaller — but it is the same class, and it was live: CI had already moved to 0.16.5 and then 0.16.6 on its own while the hook sat at 0.16.4.

## The change

Pin `ruff==0.16.6` and move the hook rev to `v0.16.6`, so one version governs both paths.

Dependabot cannot keep these level on its own: `pip` and `pre-commit` are separate ecosystems and `groups` do not span ecosystems, so there is no configuration that puts both bumps in one PR. The invariant is therefore stated in the comment beside the pin — move both together — rather than delegated to tooling.

0.16.6 is the current release on both sides (latest on PyPI, and `v0.16.6` exists as a `ruff-pre-commit` tag).

## Relationship to #315

#315 is Dependabot's `ruff-pre-commit` `v0.16.4` → `v0.16.6` bump. This PR makes the identical hook-rev change **and** pins the pip side, so it supersedes #315 — closing that one is the tidier outcome. If #315 lands first this still merges cleanly: both set the same value on the same line, so git resolves it without a conflict (verified with `git merge-tree`).

## Validation

At 0.16.6 on this tree, resolved through `pip install -e ".[dev]"` so the pin is what CI will actually get:

| Gate | Result |
|---|---|
| `ruff check .` | All checks passed |
| `ruff format --check .` | 257 files already formatted |
| `ty check src/smda/ fuzzing/ profiling/ .github/workflows/scripts/` | exit 0 |
| `pre-commit run ruff --all-files` | Passed |
| `pre-commit run ruff-format --all-files` | Passed, `--fix` made no changes |

No source file is touched — the diff is two config lines plus the comment.

## One follow-up, deliberately not in this PR

At v0.16.x the hook prints `ruff (legacy alias)`, because astral renamed `id: ruff` to `id: ruff-check`. The alias still works and will presumably be dropped in a future major, so switching the id is worth doing — but it is a separate concern from pinning, and folding it in here would mean this PR changes hook behaviour as well as versions.
