### PR TITLE
chore: review follow-ups from the open-PR triage pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v0.16.6
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter.
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ the native backends, `intel` and `aarch64`. On the two managed ones they are **f
 | `dalvik` | the offset of the code item in the DEX file |
 
 The two are not the same kind of number, so correlating a managed report with a native one - or
-either with another tool's output - compares two different address spaces. A report names the backend
-that produced it in two places, `report.architecture` and `metadata.language` in `toDict()`, so a
-consumer can tell which rule applies before treating an offset as an address.
+either with another tool's output - compares two different address spaces. `report.architecture` is
+what says which rule applies, and it is the field to branch on before treating an offset as an
+address. Do not read `metadata.language` as the backend: it is a source-language score map, and while
+it happens to carry a single decisive entry on the two managed backends (`{'.net': 1.0}`,
+`{'dalvik': 1.0}`), on a native one it is a distribution that includes a `.net` score - so branching
+on `.net` appearing in it can read a native report as managed, which is the exact mistake this
+section exists to prevent.
 
 The two managed cases differ in why. A CIL method has an RVA, and reporting the file offset instead
 is a choice; a DEX carries no load address at all, so the file offset is the only address there is.

--- a/src/smda/aarch64/AArch64CapstoneVerification.py
+++ b/src/smda/aarch64/AArch64CapstoneVerification.py
@@ -111,12 +111,14 @@ def normalize_capstone_text(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
 
-def smda_instruction_matches_capstone(smda_instruction, capstone_instruction):
+def smda_instruction_matches_capstone(smda_instruction, capstone_instruction) -> bool:
     if smda_instruction.mnemonic != capstone_instruction.mnemonic:
         return False
     if normalize_capstone_text(smda_instruction.operands) != normalize_capstone_text(capstone_instruction.op_str):
         return False
-    return capstone_instruction.size * 2 == len(smda_instruction.bytes)
+    # capstone_instruction is untyped, so `.size` is Unknown and the comparison infers Unknown;
+    # bool() is what makes the declared return type true rather than dropping the annotation
+    return bool(capstone_instruction.size * 2 == len(smda_instruction.bytes))
 
 
 def escape_capstone_operand(operand) -> str:

--- a/src/smda/intel/definitions.py
+++ b/src/smda/intel/definitions.py
@@ -364,6 +364,10 @@ GAP_SEQUENCES = {
     15: frozenset({b"\x66\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00"}),
 }
 
+# Read well beyond the alignment cut: intel/FunctionCandidateManager consults this table in
+# five places (the exact-length and any-length filler tests, the candidate scan, and the
+# gap-length walk) and X86Backend in two. Adding an encoding here sharpens every one of them,
+# so a change to this table is a change to all padding-aware discovery, not to one caller.
 GAP_SEQUENCE_FIRST_BYTES = frozenset(sequence[:1] for sequences in GAP_SEQUENCES.values() for sequence in sequences)
 #: Longest entry in the table, so a scan over a bounded window does not re-derive it per step.
 MAX_GAP_SEQUENCE_LENGTH = max(GAP_SEQUENCES)

--- a/tests/testLateCandidateProduction.py
+++ b/tests/testLateCandidateProduction.py
@@ -179,6 +179,14 @@ class LateCandidateTestBase:
         )
 
     def test_late_tailcall_does_not_rebuild_queue(self):
+        """Guards against reintroducing scoring into addTailcallCandidate.
+
+        This assertion is trivially true today: the AArch64 override no longer records an
+        inbound call reference, so it has no score to change and cannot reach
+        candidate_queue.update at all. It is kept rather than deleted because the queue
+        rebuild is what the removed bookkeeping used to trigger, and a future change that
+        scores a tailcall seed again would want to be told.
+        """
         with patch.object(self.manager.candidate_queue, "update", wraps=self.manager.candidate_queue.update) as update:
             self.manager.addTailcallCandidate(0xA5E0)
 


### PR DESCRIPTION
Closes the actionable half of #317 — five small corrections found while reviewing #302 through #311, none of which was worth blocking its PR on or opening a PR for on its own.

No behaviour change: the only `src/smda/**` edits are one `bool()` wrapper whose result is identical, and two comments.

## What changed

### `README` — the address-space section contradicted itself

It told a consumer the backend is named "in two places, `report.architecture` and `metadata.language` in `toDict()`". The second is wrong in exactly the direction that section exists to prevent:

```
cil      -> {'.net': 1.0}
dalvik   -> {'dalvik': 1.0}
intel    -> {'c/asm': 0.1, 'delphi': 0.0, '.net': 0.0, 'visualbasic': 0.0, 'go': 0.0, ...}
aarch64  -> {'c/asm': 0.1, 'delphi': 0.0, '.net': 0.0, ...}
```

`metadata.language` is a source-language score map. It carries a single decisive entry on the two managed backends and a **distribution** on the native ones — including a `.net` score. A consumer following that advice and branching on `.net` appearing in it can read a *native* report as managed, and then treat virtual addresses as file offsets, which is the precise mistake the section was added to stop.

The README already stated the score-map contract 130 lines further down ("`SmdaReport.metadata.language` is always a score map"), so the two halves disagreed. `report.architecture` is authoritative on all four backends and is now named as the field to branch on. The `CilDisassembler` docstring added by #308 was already careful here — it says "the language score map" — so only the consumer-facing half needed the correction.

### `smda_instruction_matches_capstone` gets its `-> bool` back

#302 removed the annotation to satisfy ty 0.0.74's `unsound-return-statement`. The cause is upstream of the annotation: `capstone_instruction` is untyped, so `.size` is `Unknown` and `Unknown * 2 == len(...)` infers `Unknown`. `bool()` around the return makes the declared type true rather than deleting the declaration.

### `id: ruff` becomes `id: ruff-check`

At ruff-pre-commit v0.16.x the hook reports itself as `ruff (legacy alias)`. astral renamed it; the alias still resolves and will presumably be dropped in a future major. Verified both hooks run under the new id, and that `ruff` no longer resolves (`No hook with id 'ruff' in stage 'pre-commit'`), which is the intended state.

### `GAP_SEQUENCES` gains a note about its reach

#304 added two CS-prefixed GCC nops to it while being titled and measured as a change to the alignment cut. That table is read in seven places outside the cut — five in `intel/FunctionCandidateManager` (the exact-length and any-length filler tests, the candidate scan, and the gap-length walk) and two in `X86Backend` — so an encoding added there sharpens all padding-aware discovery. Worth a comment, because it is what makes a measurement over a change to this table hard to attribute to one caller.

### One test says what it is for

`test_late_tailcall_does_not_rebuild_queue` was renamed by #307 from `test_new_scored_candidate_does_not_rebuild_queue`, and its `update.assert_not_called()` is now trivially true: the AArch64 `addTailcallCandidate` no longer records a call reference, so it has no score to change and cannot reach `candidate_queue.update`. Kept rather than deleted — it is a reasonable guard against reintroducing scoring there — with a docstring saying so, so the next reader does not have to work out whether it is load-bearing.

## Two items from #317 deliberately left out

Both turned out to need work *upstream* of the annotation rather than the annotation itself, which is worth recording as the reason #302 took the shortcut it did. I have added the detail to #317.

**Typing `SmdaFunction.blocks`.** `Dict[int, List[SmdaInstruction]]` is accurate — both population sites build `SmdaInstruction` objects — and it does restore `getInstructionsForBlock`'s return type. But it surfaces two `no-matching-overload` errors at `SmdaFunction.py:463` and `:479`, where `getPicHashSequence` and `getOpcHashSequence` do `"".join(escaped_binary_seqs)` over a list built from `instruction.bytes`, which #302 annotated `Optional[str]`. A block instruction always carries bytes in practice, so this is latent rather than live — but joining a possibly-`None` sequence is a real soundness gap and deserves its own change rather than a suppression here.

**Narrowing `extract_strings`.** `Tuple[str, Any, Any, str]` cannot be tightened while `read_string`, `read_go_string` and `derefs` are untyped: all three yield sites then infer `tuple[Unknown, Unknown, Unknown, Unknown]`, so even `str` in the first position is unprovable and the annotation produces three `unsound-yield` errors. Typing those three helpers comes first.

## Validation

| Gate | Result |
|---|---|
| `ty check src/smda/ fuzzing/ profiling/ .github/workflows/scripts/` | exit 0, zero errors, warning count unchanged |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 260 files already formatted |
| `pre-commit run ruff-check --all-files` | Passed |
| `pre-commit run ruff-format --all-files` | Passed |
| full suite | 1882 passed, 2 skipped, 2591 subtests |
