### PR TITLE
refactor(common): type the attributes the dropped annotations rest on

### DIFF
--- a/src/smda/common/SmdaFunction.py
+++ b/src/smda/common/SmdaFunction.py
@@ -5,7 +5,7 @@ import logging
 import re
 import struct
 from operator import itemgetter
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, NoReturn, Optional
 
 from smda.aarch64.AArch64InstructionEscaper import AArch64InstructionEscaper
 from smda.aarch64.definitions import CALL_INS as AARCH64_CALL_INS
@@ -23,6 +23,9 @@ from smda.dalvik.DalvikInstructionEscaper import DalvikInstructionEscaper
 from smda.intel.IntelInstructionEscaper import IntelInstructionEscaper
 
 from .SmdaInstruction import SmdaInstruction
+
+if TYPE_CHECKING:
+    from smda.common.SmdaReport import SmdaReport
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,13 +150,13 @@ class LazyIntKeyDict(dict):
 
 
 class SmdaFunction:
-    smda_report = None
+    smda_report: Optional["SmdaReport"] = None
     offset: Optional[int] = None
     # Class-level defaults are immutable sentinels only; every real instance rebinds
     # these to fresh containers in __init__ (a mutable class default would be shared
     # by every SmdaFunction). They stay declared here because tests build instances
     # via __new__, bypassing __init__.
-    blocks: Dict[int, List[Any]] = {}
+    blocks: Dict[int, List["SmdaInstruction"]] = {}
     _sorted_block_keys: List[int] = []
     apirefs: Dict[int, Any] = {}
     stringrefs: Dict[int, Any] = {}
@@ -281,7 +284,9 @@ class SmdaFunction:
     def num_calls(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
-            return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("invoke-"))
+            return sum(
+                1 for block in self.blocks.values() for ins in block if (ins.mnemonic or "").startswith("invoke-")
+            )
         if architecture == "aarch64":
             call_mnemonics = AARCH64_CALL_INS
         elif architecture == "cil":
@@ -296,7 +301,9 @@ class SmdaFunction:
     def num_returns(self):
         architecture = self.smda_report.architecture if self.smda_report else ""
         if architecture == "dalvik":
-            return sum(1 for block in self.blocks.values() for ins in block if ins.mnemonic.startswith("return"))
+            return sum(
+                1 for block in self.blocks.values() for ins in block if (ins.mnemonic or "").startswith("return")
+            )
         if architecture == "aarch64":
             return_mnemonics = AARCH64_RET_INS | AARCH64_EXCEPTION_RETURN_INS
         else:
@@ -337,7 +344,7 @@ class SmdaFunction:
             return False
         first_ins = block[0]
         if architecture == "dalvik":
-            return first_ins.mnemonic.startswith("invoke-")
+            return (first_ins.mnemonic or "").startswith("invoke-")
         mnemonic = self._baseMnemonic(first_ins.mnemonic)
         if architecture == "cil":
             return mnemonic in ("call", "calli", "callvirt", "jmp")
@@ -377,11 +384,11 @@ class SmdaFunction:
             return None
         return struct.pack("<Q", self.pic_hash).hex()
 
-    def getInstructions(self):
+    def getInstructions(self) -> Iterator["SmdaInstruction"]:
         for block in self.getBlocks():
             yield from block.getInstructions()
 
-    def getInstructionsForBlock(self, offset):
+    def getInstructionsForBlock(self, offset: Optional[int]) -> List["SmdaInstruction"]:
         if offset is None:
             offset = self.offset
         if offset is None:
@@ -439,6 +446,20 @@ class SmdaFunction:
             reraise_non_operational_exception(exc)
         return nesting_depth
 
+    @staticmethod
+    def _refuseInstructionWithoutBytes(instruction: "SmdaInstruction") -> NoReturn:
+        """Raise rather than hash an instruction that carries no bytes.
+
+        `SmdaInstruction.bytes` is `Optional[str]` because the class default is None and
+        `fromDict` copies whatever the report holds; every instruction SMDA itself puts in a
+        block is given `ins[4].hex()`, so this is unreachable on a report we produced. It is a
+        refusal rather than the `or ""` used elsewhere in this file because those sites are
+        formatting and length arithmetic, where a blank is harmless, while here it would
+        silently hash a different instruction sequence and the result would still look like a
+        valid PIC/OPC hash to everything that consumes one.
+        """
+        raise ValueError(f"instruction at offset {instruction.offset} carries no bytes and cannot be hashed")
+
     def getPicHash(self, binary_info):
         return struct.unpack("<Q", hashlib.sha256(self.getPicHashSequence(binary_info)).digest()[:8])[0]
 
@@ -446,7 +467,11 @@ class SmdaFunction:
         escaper = self._escaper
         blocks = self.blocks
         if escaper is None:
-            escaped_binary_seqs = [instruction.bytes for key in self._sorted_block_keys for instruction in blocks[key]]
+            escaped_binary_seqs = [
+                instruction.bytes if instruction.bytes is not None else self._refuseInstructionWithoutBytes(instruction)
+                for key in self._sorted_block_keys
+                for instruction in blocks[key]
+            ]
         else:
             lower_addr = binary_info.base_addr
             upper_addr = lower_addr + binary_info.binary_size
@@ -469,7 +494,11 @@ class SmdaFunction:
         escaper = self._escaper
         blocks = self.blocks
         if escaper is None:
-            escaped_binary_seqs = [instruction.bytes for key in self._sorted_block_keys for instruction in blocks[key]]
+            escaped_binary_seqs = [
+                instruction.bytes if instruction.bytes is not None else self._refuseInstructionWithoutBytes(instruction)
+                for key in self._sorted_block_keys
+                for instruction in blocks[key]
+            ]
         else:
             escaped_binary_seqs = [
                 escaper.escapeToOpcodeOnly(instruction)

--- a/src/smda/common/SmdaInstruction.py
+++ b/src/smda/common/SmdaInstruction.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Iterator, List, Optional
 
 from capstone.arm64 import ARM64_OP_IMM, ARM64_OP_MEM
 from capstone.x86 import X86_OP_IMM, X86_OP_MEM
@@ -14,10 +14,10 @@ class SmdaInstruction:
     smda_function = None
     offset: Optional[int] = None
     bytes: Optional[str] = None
-    mnemonic = None
-    operands = None
+    mnemonic: Optional[str] = None
+    operands: Optional[str] = None
     detailed = None
-    _data_refs = None
+    _data_refs: Optional[List[int]] = None
     # x87 instructions have explicit-WAIT and no-WAIT encodings (e.g. FSTCW vs FNSTCW).
     # For the WAIT-prefixed form Capstone decodes the 0x9b prefix as a standalone
     # `wait`/`fwait` instruction, so it must be skipped when picking the operation detail.
@@ -31,13 +31,16 @@ class SmdaInstruction:
             self.mnemonic = ins_list[2]
             self.operands = ins_list[3]
 
-    def getDataRefs(self):
-        data_refs_cached = getattr(self, "_data_refs", None)
+    def getDataRefs(self) -> Iterator[int]:
+        # direct read rather than getattr(): the class-level default covers the unpickled
+        # case the getattr guarded, and it keeps the declared Optional[List[int]] instead
+        # of widening to Any
+        data_refs_cached = self._data_refs
         if data_refs_cached is not None:
             yield from data_refs_cached
             return
 
-        data_refs = []
+        data_refs: List[int] = []
         emitted = set()
         smda_function = self.smda_function
         if smda_function is None:

--- a/src/smda/common/SmdaReport.py
+++ b/src/smda/common/SmdaReport.py
@@ -65,10 +65,10 @@ REQUIRED_STATISTICS_FIELDS = frozenset(
 class SmdaReport:
     architecture = None
     abi = None
-    base_addr = None
+    base_addr: Optional[int] = None
     binary_size = None
     binweight: float = 0.0
-    bitness = None
+    bitness: Optional[int] = None
     block_locator: Optional[BlockLocator] = None
     buffer: Optional[bytes] = None
     _sorted_functions: Optional[List["SmdaFunction"]] = None
@@ -103,6 +103,7 @@ class SmdaReport:
     data_refs_from: Optional[Dict[int, List[int]]] = None
     data_refs_to = None
     _string_cache: Dict[Any, Optional[Tuple[str, str]]]
+    _derefs_cache: Dict[int, List[int]]
 
     # on first usage, initialize codexrefs objects for all functions based on inrefs/outrefs (requires knowledge about all functions)
     _has_codexrefs = False
@@ -114,7 +115,7 @@ class SmdaReport:
         # their lifecycle is explicit and every construction path (incl. fromDict via cls(None))
         # starts with empty caches rather than relying on monkey-patched attributes.
         self._string_cache: Dict[Any, Optional[Tuple[str, str]]] = {}
-        self._derefs_cache = {}
+        self._derefs_cache: Dict[int, List[int]] = {}
         # start every construction path with an empty CFG so accessors like
         # num_functions/getFunction work on reports without a disassembly
         # (e.g. controlled error reports for unsupported architectures);


### PR DESCRIPTION
First of the two items left open in #317, both of which needed work upstream of the annotation rather than the annotation itself.

## What #302 actually hit

`getInstructionsForBlock` lost its `-> List[SmdaInstruction]` to satisfy ty 0.0.74's `unsound-return-statement`. The declaration was not the problem: `SmdaFunction.blocks` was `Dict[int, List[Any]]`, so the return could not have been anything better. Typing `blocks` accurately — both population sites build `SmdaInstruction` objects — restores the return annotation for free.

## The `Optional[str]` join, and why it refuses rather than defaults

Typing `blocks` surfaces exactly what #317 predicted: `getPicHashSequence` and `getOpcHashSequence` join over `instruction.bytes`, which is `Optional[str]`.

Seven other sites in these files write `bytes or ""`. Those are formatting and length arithmetic, where a blank is harmless. A hash is not that: a blank there would silently hash a *different* instruction sequence and the result would still look like a valid PIC/OPC hash to everything that consumes one, MCRIT included. So this refuses instead, via a `NoReturn` helper — which also means the ternary narrows to `str` without adding a call per instruction on the hot path.

## Root cause, one level down

`SmdaInstruction.mnemonic` and `.operands` were untyped for the same reason. Annotating them makes three Dalvik `.startswith` reads visible; those take the `or ""` the file already uses, which is behaviour-preserving for a count — a None mnemonic starts with nothing either way.

`SmdaReport.base_addr`, `.bitness`, `._derefs_cache` and `SmdaFunction.smda_report` are annotated here because #317's *second* item, narrowing `extract_strings`, cannot be typed without them. That change follows in its own `utility` scope rather than riding along in this one.

## Verification

Behaviour-neutral, measured rather than asserted:

| check | result |
|---|---|
| PIC/OPC hashes over cutwail, komplex, mirai_x64 (394 functions) | bit-identical |
| guarded-path timing | flat (0.1759s → 0.1767s on mirai_x64) |
| full suite | 1947 passed, 2 skipped, 2593 subtests |
| `ruff check` / `ruff format --check` | clean |
| `ty` errors | 0 |

The only diagnostic movement is two categories becoming *more* precise (`None | Unknown` → `SmdaReport | None`), plus **one new warning** at `StringExtractor.py:201`, where `.operands` is now known to be optional. The follow-up PR clears it and returns the count to the master baseline exactly.

Refs #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDCLUmqGzE5fwJqUWsSStr
