### PR TITLE
chore: correct the figures and the directory lookup #300 shipped

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -160,14 +160,16 @@ class SmdaConfig:
     # inside the pad, and the scan books that instead - a worse candidate than the one refused.
     # Resuming at the declaring FDE's end passes over that function's body only; over the three
     # corpora that carry pads, 0 of 41,215 have a declared function start between the pad and
-    # that end. Measured against compiler symbol tables, macro means:
-    #   260 built C/C++ cells    PPV 92.623 -> 94.109 at TPR 95.525 -> 95.595 (+193 recovered)
-    #   72 AArch64 ELF cells     PPV 76.676 -> 79.172 at TPR 95.939 -> 95.963 (+15 recovered)
-    #   24 Rust cells            PPV 78.951 -> 82.435 at TPR 97.493 -> 97.578 (+13 recovered)
-    # 12,453 false positives removed, 221 real functions gained, no corpus loses recall. Go,
-    # ARM64 Mach-O and .NET are bit-identical, which is the control that it reaches only ELF
-    # images carrying an LSDA. It also pays for itself: on the two cells with the most pads,
-    # analysis is 3.8% faster, because the candidates it refuses are ones nothing then analyses.
+    # that end. Measured against compiler symbol tables on the tree #300 landed on, everything
+    # else in that PR on and this rule the only thing switched, macro means:
+    #   72 AArch64 ELF cells   PPV 91.554 -> 93.176 at TPR 98.045 -> 98.067  -1,732 FP, +18 TP
+    #   24 Rust cells          PPV 82.805 -> 86.303 at TPR 98.237 -> 98.321    -654 FP, +13 TP
+    # No corpus loses recall. Go, ARM64 Mach-O and .NET are bit-identical, which is the control
+    # that it reaches only ELF images carrying an LSDA. The 260-cell C/C++ matrix was rebuilt
+    # and re-measured at branch level only (PPV 94.038 -> 96.908 over 213,706 truth functions),
+    # so this rule has no per-rule row on it. It also pays for itself: on the two cells with the
+    # most pads, analysis is 3.8% faster, because the candidates it refuses are ones nothing
+    # then analyses.
     USE_LSDA_LANDING_PADS = True
     # Refuse a gap candidate strictly inside a range the image's own .eh_frame declares, and
     # resume at that range's end. Broader than USE_LSDA_LANDING_PADS, which refuses only the
@@ -180,17 +182,18 @@ class SmdaConfig:
     # start must be a recovered function, because an FDE can begin in the alignment padding
     # ahead of its function - the remaining 35 losses were all of that shape, two per statically
     # linked cell, one of them rt_sigreturn under a signal-frame CIE.
-    # Measured against compiler symbol tables, macro means:
-    #   260 built C/C++ cells    PPV 94.109 -> 94.725 at TPR 95.595 -> 95.596 (+4 recovered)
-    #   72 AArch64 ELF cells     PPV 79.172 -> 80.554 at TPR 95.963 -> 95.964 (+3 recovered)
-    #   24 Rust cells            PPV 82.435 -> 83.608 at TPR 97.578 -> 97.617 (+6 recovered)
-    #   4 .NET cells             PPV 93.589 -> 95.332 at TPR 99.461 -> 99.469 (+2 recovered)
-    # 4,088 false positives removed, 15 real functions gained, no corpus loses recall, Go and
-    # ARM64 Mach-O bit-identical, and analysis time is inside an off-vs-off control band.
+    # Measured against compiler symbol tables on the tree #300 landed on, everything else in
+    # that PR on including USE_LSDA_LANDING_PADS, so these are what this rule adds on top of
+    # it. Macro means:
+    #   72 AArch64 ELF cells   PPV 93.176 -> 94.947 at TPR 98.067 -> 98.069  -1,846 FP,  +3 TP
+    #   24 Rust cells          PPV 86.303 -> 87.480 at TPR 98.321 -> 98.361    -197 FP,  +6 TP
+    # No corpus loses recall, Go and ARM64 Mach-O are bit-identical, and analysis time is
+    # inside an off-vs-off control band.
     # Enabling it moved two bundled fixtures, deliberately: elf_cet_landing_pads_x64 drops four
     # endbr64 addresses that are jump-table case labels strictly inside the function the symbol
-    # table names `dispatch`, and aarch64_static drops two mid-function instructions. None of
-    # the six carries a symbol or is a declared start, so both baselines moved toward the truth.
+    # table names `dispatch`, and aarch64_static drops 0x400350 and 0x40DF30, both mid-function
+    # instructions inside a declared FDE. None of the six carries a symbol or is a declared
+    # start, so both baselines moved toward the truth.
     USE_ELF_FDE_INTERIOR_GAPS = True
     RESOLVE_REGISTER_CALLS = True
     # resolve "call/jmp dword ptr [<reg> + <disp>]" against a runtime-built import table and
@@ -225,8 +228,17 @@ class SmdaConfig:
     # A jump into an already-recovered function is still treated as a tailcall with the pass
     # off - only the promotion of not-yet-known targets needs it. The AArch64 backend's
     # bl fall-through path follows the same flag: it cuts the caller either way, and seeding
-    # the boundary as well measured worse on both AArch64 corpora (ARM64 Mach-O n=11: 12
-    # fewer functions and 28 more false positives; Go n=45: 430 more false positives).
+    # the boundary as well measures worse. Gate off -> gate on, everything else in #300 on,
+    # against the tree it landed on:
+    #   Go, n=47                  -408 FP at identical TP
+    #   ARM64 Mach-O, n=11         -27 FP,  +11 TP
+    #   Built C/C++ AArch64 ELF, n=72   -580 FP,  -53 TP
+    # That last row is the one trade in it, and it is a reject by the per-change rule the
+    # branch set itself. It survives because the 53 are all .eh_frame FDE starts the deferred
+    # FDE pass would claim if a wrong tailcall seed did not veto them first: with
+    # USE_ELF_EH_FRAME_CANDIDATES on, the gate costs 13 and gains 24 - net +11 against -583
+    # false positives. Gating it is also what makes the seeding switchable at all; before
+    # #300 the AArch64 backend seeded these regardless of this flag.
     RESOLVE_TAILCALLS = False
     # optional metadata generation options; the largest built-in performance lever.
     # Measured on the cutwail fixture, as a share of all Python calls per run: hashing 10.0%,

--- a/src/smda/common/BinaryInfo.py
+++ b/src/smda/common/BinaryInfo.py
@@ -275,14 +275,14 @@ class BinaryInfo:
         """
         if self._getLiefType() != "PE":
             return None
-        for directory in self.getLiefBinary().data_directories:
-            if "EXCEPTION" not in str(directory.type):
-                continue
-            if not directory.size or not directory.rva:
-                break
-            start = self.base_addr + directory.rva
-            return start, start + directory.size
-        return None
+        # the typed lookup rather than a substring of the enum's repr: it is what the AArch64
+        # directory walk already uses for this same directory, and a match on "EXCEPTION" also
+        # claims any future type whose name happens to contain it
+        directory = self.getLiefBinary().data_directory(lief.PE.DataDirectory.TYPES.EXCEPTION_TABLE)
+        if directory is None or not directory.size or not directory.rva:
+            return None
+        start = self.base_addr + directory.rva
+        return start, start + directory.size
 
     def isInCodeAreas(self, address):
         is_inside = False

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -99,8 +99,9 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         super().__init__(config)
         self.pdata_start_addresses = set()
         self.pdata_end_addresses = set()
+        #: the prologue byte strings this scan seeds, so a later match can tell whether it
+        #: begins where an earlier one ends and is therefore inside that function's body
         self._seeded_prologues = ()
-        #: (start, end, is_chained) for every RUNTIME_FUNCTION record the image declares,
         self._retained_pad = None
 
     def init(self, disassembly, cbAnalysisTimeout=None):

--- a/tests/testAArch64Disassembler.py
+++ b/tests/testAArch64Disassembler.py
@@ -1724,17 +1724,21 @@ class TestAArch64StaticFixture(unittest.TestCase):
         for function_start in (0x40CFE0, 0x40DD78, 0x40F370, 0x410B24, 0x41150C, 0x411590, 0x4134D0):
             self.assertIsNotNone(self.report.getFunction(function_start), f"missing 0x{function_start:x}")
 
-        # The one Binary Ninja start this fixture no longer recovers, and it is a cost rather
-        # than a correction. Both readings of it are refused: 0x40DF34 is where Binary Ninja
-        # puts the routine, and 0x40DF30 is where the gap scan puts it since #311 stopped
-        # skipping a word that opens on a conditional branch -- the 16-aligned word after the
-        # previous function's `ret` and its padding nop, against Binary Ninja's 4-aligned,
-        # mid-line reading. USE_ELF_FDE_INTERIOR_GAPS refuses both because the FDE at 0x40DDC0
-        # covers them, and that FDE really is one unwind range: 0x40DF34 repeats the range's
-        # opening minus its `prfm` prefetch, so it is an alternate entry sharing one frame
-        # rather than a routine of its own. The unwinder and Binary Ninja disagree about
-        # whether that counts as a function; the rule follows the unwinder. Asserted rather
-        # than dropped from the list so the disagreement stays visible.
+        # The two starts #300 costs this fixture, which is the whole of its 278 -> 276. Both
+        # are refused by USE_ELF_FDE_INTERIOR_GAPS, and both are mid-function instructions
+        # rather than anything that reads as an entry:
+        #   0x400350 is `ldr w3, [sp, #0x90]`, inside the FDE at [0x400180, 0x400534)
+        #   0x40DF30 is `cbz x14, ...`,        inside the FDE at [0x40DDC0, 0x40DFCC)
+        # 0x40DF30 is where the gap scan puts a routine Binary Ninja puts one instruction on
+        # at 0x40DF34, since #311 stopped skipping a word that opens on a conditional branch.
+        # That reading is refused too and is asserted below, but it is not one of the two the
+        # fixture lost: 0x40DF34 was never recovered here in the first place. The FDE really
+        # is one unwind range -- 0x40DF34 repeats its opening minus the `prfm` prefetch, so it
+        # is an alternate entry sharing one frame rather than a routine of its own. The
+        # unwinder and Binary Ninja disagree about whether that counts as a function and the
+        # rule follows the unwinder. Asserted rather than dropped from the list above so the
+        # disagreement stays visible.
+        self.assertIsNone(self.report.getFunction(0x400350))
         self.assertIsNone(self.report.getFunction(0x40DF30))
         self.assertIsNone(self.report.getFunction(0x40DF34))
 


### PR DESCRIPTION
Three findings from the review of #300, plus one leftover from #312. All are text or a single expression, so they are fixed here rather than sent back to @r0ny123 for another round.

## 1. The config comments carried the figures the description retracted

`USE_LSDA_LANDING_PADS` and `USE_ELF_FDE_INTERIOR_GAPS` shipped with their per-rule attribution measured before #304/#307/#309/#310/#311 landed:

```
#   260 built C/C++ cells    PPV 92.623 -> 94.109 ...
#   72 AArch64 ELF cells     PPV 76.676 -> 79.172 ...
```

That is the same baseline #300's description dropped rather than annotated, because master's own PPV on that corpus had moved from 76.676 to **91.497** while the branch waited. The description was corrected; the copies in `SmdaConfig.py` came along unchanged.

Replaced with the re-measured attribution from [the rebase comment](https://github.com/danielplohmann/smda/pull/300#issuecomment-5595452147), which is what the rule is worth on the tree it landed on, everything else in #300 on and the rule under test the only thing switched:

| flag | corpus | PPV | FP | TP |
|---|---|---|---|---|
| `USE_LSDA_LANDING_PADS` | AArch64 ELF, n=72 | 91.554 → 93.176 | −1,732 | +18 |
| | Rust, n=24 | 82.805 → 86.303 | −654 | +13 |
| `USE_ELF_FDE_INTERIOR_GAPS` | AArch64 ELF, n=72 | 93.176 → 94.947 | −1,846 | +3 |
| | Rust, n=24 | 86.303 → 87.480 | −197 | +6 |

The 260-cell C/C++ row is gone rather than restated: that matrix was rebuilt and re-measured at branch level only (PPV 94.038 → 96.908 over 213,706 truth functions), so there is no per-rule figure to put back. The comment says so instead of leaving the absence to be noticed.

`RESOLVE_TAILCALLS` had the same problem one PR further back. It described the AArch64 `bl` fall-through gate as it measured before #307 changed what `addTailcallCandidate` does (`ARM64 Mach-O n=11: 12 fewer functions and 28 more false positives; Go n=45: 430 more`), and it omitted the built C/C++ AArch64 ELF corpus, which is the one row where the gate is a trade rather than a win. It now carries all three re-measured rows including the −580 FP against −53 TP, says that by the branch's own per-change rule that row is a reject, and says why it survives: the 53 are all `.eh_frame` FDE starts that a wrong tailcall seed vetoes, so with `USE_ELF_EH_FRAME_CANDIDATES` on the gate costs 13 and gains 24.

A PR description records a conversation. A config comment is what the next reader has.

## 2. `getExceptionDirectory` matched a substring of the enum's repr

```python
if "EXCEPTION" not in str(directory.type):
```

The typed lookup is already the idiom in two other places, one of them `aarch64/FunctionCandidateManager.py` walking this same directory:

```python
directory = self.getLiefBinary().data_directory(lief.PE.DataDirectory.TYPES.EXCEPTION_TABLE)
```

Behaviour is unchanged on every bundled fixture, `dotnet_readytorun_pe` included — it still finds the table the ReadyToRun compiler put in `.data`, and `testPeExceptionTableDiscovery` still passes in full.

## 3. `aarch64_static` lost two starts and the test named one of them

The comment explained 278 → 276 through the Binary Ninja disagreement over `0x40DF34`. That address is refused, but it was not recovered before the change either, so it is not one of the two the fixture lost. The actual pair, checked against the image's own unwind data:

| address | decodes as | declared FDE |
|---|---|---|
| `0x400350` | `ldr w3, [sp, #0x90]` | `[0x400180, 0x400534)` |
| `0x40DF30` | `cbz x14, ...` | `[0x40DDC0, 0x40DFCC)` |

Both are mid-function instructions inside a range the image declares — a plainer story than the one the comment led with, and a better one, since neither reads as an entry on any account. `0x400350` is now asserted absent alongside the other two, and the `USE_ELF_FDE_INTERIOR_GAPS` comment names both rather than saying "two mid-function instructions".

## 4. A comment #312 left dangling

`#: (start, end, is_chained) for every RUNTIME_FUNCTION record the image declares,` sat in `intel/FunctionCandidateManager.__init__` with nothing under it since #312 hoisted `_pdata_ranges` into `common/`, where the same text already lives in full. #300 added an attribute above it, which left it reading as documentation for `_retained_pad`. Removed, and `_seeded_prologues` gets the one-line comment it should have had.

## Not fixed here

Two findings from the same pass are going to #322 instead, because both are about how durable our own paths are rather than about anything wrong in #300:

- `_opensInsideAnEarlierPrologue` fires only when the earlier prologue is already a candidate, so it depends on `DEFAULT_PROLOGUES` being scanned before `DEFAULT_PROLOGUES_64`. Measured: `push rbp; mov rbp, rsp` + `push r15; push r14` refuses the interior match at +4, and the reverse layout does not. Favourable today, pinned by nothing.
- The LSDA budget is charged only once a table's length field is reached, so an LSDA that fails earlier costs a `read_va` of up to `MAX_LSDA_BYTES` for free. Measured at ~1.2s for `MAX_RECORDS` distinct undecodable pointers, on top of the ~1s walk.

## Gates

- `python -m pytest tests/`: **2060 passed, 1 skipped, 2593 subtests**
- `ruff check .` and `ruff format --check .`: clean
- `make typecheck`: exit 0, 0 error-level diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
