### PR TITLE
feat(common): refuse a candidate the image declares interior, not only a gap one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ past roughly six lines it belongs in the PR the entry links.
   not only a gap-scan candidate -- the gap pointer reaches only what the gap scan walks to, so the prologue,
   reference and symbol scans seeded the rest unchecked. A procedure linkage table is exempt, the declared
   range's own start has to be a recovered function, and that owner's recovered extent has to surround the
-  address. *Measured on `a043145` against compiler symbol tables:* 72 AArch64 ELF cells 95.994 -> 97.063 PPV
+  address. *Measured on `857081f` against compiler symbol tables:* 72 AArch64 ELF cells 95.994 -> 97.063 PPV
   (-683 false positives) and 140 built C/C++ ELF cells 98.903 -> 98.969 (-77), both at identical true positives
   and false negatives; the PE, Go, ARM64 Mach-O and 57 malpedia cells are bit-identical, which is the control
   that it reaches only images carrying an `.eh_frame`. *Not reproducible from the bundled fixtures, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ past roughly six lines it belongs in the PR the entry links.
 
 ### Changed
 
+- **(common)** Refuse a candidate from any source that the image's `.eh_frame` declares interior to a function,
+  not only a gap-scan candidate -- the gap pointer reaches only what the gap scan walks to, so the prologue,
+  reference and symbol scans seeded the rest unchecked. A procedure linkage table is exempt, the declared
+  range's own start has to be a recovered function, and that owner's recovered extent has to surround the
+  address. *Measured on `a043145` against compiler symbol tables:* 72 AArch64 ELF cells 95.994 -> 97.063 PPV
+  (-683 false positives) and 140 built C/C++ ELF cells 98.903 -> 98.969 (-77), both at identical true positives
+  and false negatives; the PE, Go, ARM64 Mach-O and 57 malpedia cells are bit-identical, which is the control
+  that it reaches only images carrying an `.eh_frame`. *Not reproducible from the bundled fixtures, which
+  produce 0 refusals.* (#327)
+
 ### Deprecated
 
 ### Removed
@@ -83,6 +93,10 @@ past roughly six lines it belongs in the PR the entry links.
 ### Security
 
 ### Compatibility
+
+- Recovery output moves on ELF images carrying an `.eh_frame`: an address a declared FDE range covers is no
+  longer reported as a function start unless it is that range's own start. No true positive was lost on the
+  corpora this was measured over. (#327)
 
 ## Older releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ past roughly six lines it belongs in the PR the entry links.
   not only a gap-scan candidate -- the gap pointer reaches only what the gap scan walks to, so the prologue,
   reference and symbol scans seeded the rest unchecked. A procedure linkage table is exempt, the declared
   range's own start has to be a recovered function, and that owner's recovered extent has to surround the
-  address. *Measured on `857081f` against compiler symbol tables:* 72 AArch64 ELF cells 95.994 -> 97.063 PPV
+  address. *Measured on `0a0a4c6` against compiler symbol tables:* 72 AArch64 ELF cells 95.994 -> 97.063 PPV
   (-683 false positives) and 140 built C/C++ ELF cells 98.903 -> 98.969 (-77), both at identical true positives
   and false negatives; the PE, Go, ARM64 Mach-O and 57 malpedia cells are bit-identical, which is the control
   that it reaches only images carrying an `.eh_frame`. *Not reproducible from the bundled fixtures, which

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -211,6 +211,21 @@ class SmdaConfig:
     # table names `dispatch`, and aarch64_static drops 0x400350 and 0x40DF30, both mid-function
     # instructions inside a declared FDE. None of the six carries a symbol or is a declared
     # start, so both baselines moved toward the truth.
+    # The same evidence also refuses a candidate from any other source, at the point analysis
+    # would begin on it, since the gap pointer reaches only what the gap scan walks to and the
+    # seeding scans reach the rest. That arm carries a third condition the gap scan does not
+    # need: the owner's own recovered extent has to surround the address. A declared range can
+    # reach past everything its function's control flow arrives at, and refusing an address out
+    # there discards bytes nothing else claims along with any reference only those bytes carry
+    # - without it the AArch64 corpus loses three functions reached through exactly that shape.
+    # Measured against compiler symbol tables, no corpus losing a true positive:
+    #   72 AArch64 ELF cells   PPV 95.994 -> 97.063  -683 FP at identical TP and FN
+    #   140 built C/C++ ELF    PPV 98.903 -> 98.969   -77 FP at identical TP and FN
+    # The 120 MinGW PE cells, 23 Go cells, 11 ARM64 Mach-O cells and all 57 malpedia dumps are
+    # bit-identical, the control that it reaches only images carrying an .eh_frame. Rust is too,
+    # and not because the rule is inert there: its images decode their ranges and 25 of 26 false
+    # positives on the first cell are interior to one, but the two conditions above decline all
+    # of them - 78 of 94 on the owner's extent, the rest on the owner not being recovered.
     USE_ELF_FDE_INTERIOR_GAPS = True
     RESOLVE_REGISTER_CALLS = True
     # resolve "call/jmp dword ptr [<reg> + <disp>]" against a runtime-built import table and

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -725,7 +725,15 @@ class FunctionCandidateManager:
         surround the address. An FDE can reach past everything its function's control flow
         arrives at, and refusing an address out there discards bytes nothing else claims --
         along with any reference only those bytes carry, which costs real functions elsewhere.
-        Inside the extent the owner already accounts for the address, so nothing is lost.
+        Inside the extent, the address is never one the owner decoded: a candidate landing on
+        recovered code is refused a step earlier against a byte-level code map, and
+        `function_borders` records only the extremes of that code, not its coverage. What
+        reaches here sits in the holes -- alignment between blocks, an unreached tail, a data
+        island -- so the exposure is a real entry with no FDE of its own in one of them, which
+        loses whatever reference only its bytes carry. An entry that carries its own FDE is
+        never interior to it, so the shape needs a routine covered by a neighbour's range, and
+        nothing in the format forbids that; what bounds it is measurement rather than
+        structure, no true positive lost across the ELF corpora this was measured over.
         """
         if not self.config.USE_ELF_FDE_INTERIOR_GAPS:
             return None

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -710,6 +710,35 @@ class FunctionCandidateManager:
             index -= 1
         return None
 
+    def declaredInteriorOwner(self, addr):
+        """The recovered function whose declared `.eh_frame` range contains `addr`, or None.
+
+        The same evidence the gap scan already refuses on, asked at the point a candidate from
+        any source is about to be analysed rather than only where the gap pointer reaches. Both
+        of that rule's guards apply unchanged. A PLT is exempt because the whole table sits
+        under one FDE, so the range test reads every stub after the first as interior to the
+        first. And the range's own start has to be a recovered function, because an FDE can
+        begin in the alignment padding ahead of its function, which leaves the real entry a few
+        bytes in interior to nothing.
+
+        A third guard the gap scan does not need: the owner's own recovered extent has to
+        surround the address. An FDE can reach past everything its function's control flow
+        arrives at, and refusing an address out there discards bytes nothing else claims --
+        along with any reference only those bytes carry, which costs real functions elsewhere.
+        Inside the extent the owner already accounts for the address, so nothing is lost.
+        """
+        if not self.config.USE_ELF_FDE_INTERIOR_GAPS:
+            return None
+        if self.isInDeclaredPltSection(addr):
+            return None
+        containing = self.declaredFdeRangeContaining(addr)
+        if containing is None or containing[0] not in self.disassembly.functions:
+            return None
+        borders = self.disassembly.function_borders.get(containing[0])
+        if borders is None or not borders[0] <= addr < borders[1]:
+            return None
+        return containing[0]
+
     def opensInsideDeclaredFdeRange(self, addr):
         """Whether `addr` falls inside a declared FDE range without being that range's start."""
         return self.declaredFdeRangeContaining(addr) is not None

--- a/src/smda/common/RecursiveDisassembler.py
+++ b/src/smda/common/RecursiveDisassembler.py
@@ -261,6 +261,13 @@ class RecursiveDisassembler:
             # state.getBlocks(); this collision path is unreachable from the gap pass today, so
             # the change is behavior-neutral (output stays byte-for-byte identical).
             return state
+        declared_owner = self.fc_manager.declaredInteriorOwner(start_addr)
+        if declared_owner is not None:
+            self.fc_manager.updateAnalysisAborted(
+                start_addr,
+                f"inside the declared range of function 0x{declared_owner:08x}",
+            )
+            return state
         blocks_processed = 0
         while state.hasUnprocessedBlocks():
             blocks_processed += 1

--- a/tests/testFdeInteriorGaps.py
+++ b/tests/testFdeInteriorGaps.py
@@ -15,6 +15,7 @@ import unittest
 import lief
 
 from smda.common.EhFrameDecoder import decodeEhFrameFdeRanges
+from smda.common.FunctionCandidateManager import FunctionCandidateManager
 from smda.Disassembler import Disassembler
 from smda.SmdaConfig import SmdaConfig
 
@@ -86,10 +87,6 @@ class FdeInteriorGapRuleTest(unittest.TestCase):
         self.assertEqual((off & named) - on, set())
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class FdeInteriorGapRuleAArch64Test(unittest.TestCase):
     """The rule lives in the shared candidate manager and both gap scans consult it.
 
@@ -138,3 +135,114 @@ class FdeInteriorGapRuleAArch64Test(unittest.TestCase):
             self.assertIsNotNone(owner, f"0x{address:x} was refused but is inside no declared range")
             # the condition that keeps an FDE opening in padding from refusing its own function
             self.assertIn(owner[0], on, f"0x{address:x} was refused by a range whose start is not a function")
+
+    def analysedFixture(self, claim=None):
+        """Run the fixture, optionally having the rule claim one address, and keep the manager."""
+        config = SmdaConfig()
+        config.CALCULATE_SCC = False
+        config.CALCULATE_NESTING = False
+        config.CALCULATE_HASHING = False
+        original = FunctionCandidateManager.declaredInteriorOwner
+        if claim is not None:
+            address, owner = claim
+
+            def claiming(manager, candidate_address):
+                if candidate_address == address:
+                    return owner
+                return original(manager, candidate_address)
+
+            FunctionCandidateManager.declaredInteriorOwner = claiming
+        with tempfile.NamedTemporaryFile(suffix=".elf", delete=False) as handle:
+            handle.write(self.data)
+            temp_path = handle.name
+        disassembler = Disassembler(config)
+        try:
+            report = disassembler.disassembleFile(temp_path)
+        finally:
+            os.unlink(temp_path)
+            FunctionCandidateManager.declaredInteriorOwner = original
+        return disassembler.disassembler, {function.offset for function in report.getFunctions()}
+
+    def testAnalysisItselfDeclinesWhatTheRuleClaims(self):
+        """The refusal is wired into analysis, not only into the gap scan.
+
+        On this fixture every address the rule would claim is one the gap scan already
+        refused or the collision check already caught, so asserting over what it happens to
+        drop here would assert nothing. Claiming one address the fixture does recover is what
+        shows analysis consults the rule at all, and that it declines rather than reports.
+        """
+        _, baseline = self.analysedFixture()
+        self.assertGreater(len(baseline), 200)
+        owner, target = sorted(baseline)[0], sorted(baseline)[1]
+
+        backend, recovered = self.analysedFixture(claim=(target, owner))
+        self.assertNotIn(target, recovered, "analysis reported an address the rule claimed")
+        self.assertEqual(baseline - recovered, {target}, "the claim moved more than the address it named")
+        # the reason is not asserted: a refused address is offered again as a gap candidate,
+        # and that pass records its own outcome over this one
+        self.assertTrue(backend.fc_manager.candidates[target].analysis_aborted)
+
+
+class _RecoveredDisassembly:
+    """The two things `declaredInteriorOwner` reads about what analysis has recovered."""
+
+    def __init__(self, functions, borders):
+        self.functions = functions
+        self.function_borders = borders
+
+
+def declaredOwnerOf(address, ranges, functions, borders, plt=(), enabled=True):
+    manager = FunctionCandidateManager(SmdaConfig())
+    manager.config.USE_ELF_FDE_INTERIOR_GAPS = enabled
+    manager.disassembly = _RecoveredDisassembly(dict.fromkeys(functions), dict(borders))
+    manager._eh_frame_fde_ranges = list(ranges)
+    manager._eh_frame_fde_starts = [start for start, _ in ranges]
+    manager._plt_ranges = list(plt)
+    return manager.declaredInteriorOwner(address)
+
+
+class DeclaredInteriorOwnerTest(unittest.TestCase):
+    """The conditions the analysis-time refusal requires, one at a time.
+
+    The gap scan reaches a candidate only where its pointer walks; this answers the same
+    question for a candidate from any source, so each condition needs a case of its own
+    rather than whatever a corpus happens to exercise.
+    """
+
+    RANGES = [(0x1000, 0x2000)]
+    FUNCTIONS = [0x1000]
+    BORDERS = {0x1000: (0x1000, 0x1F00)}
+
+    def testAnAddressItsOwnerSurroundsIsRefused(self):
+        self.assertEqual(declaredOwnerOf(0x1500, self.RANGES, self.FUNCTIONS, self.BORDERS), 0x1000)
+
+    def testARangeStartIsNotInteriorToItself(self):
+        self.assertIsNone(declaredOwnerOf(0x1000, self.RANGES, self.FUNCTIONS, self.BORDERS))
+
+    def testAnAddressOutsideEveryRangeIsKept(self):
+        self.assertIsNone(declaredOwnerOf(0x2500, self.RANGES, self.FUNCTIONS, self.BORDERS))
+
+    def testARangeWhoseStartWasNotRecoveredRefusesNothing(self):
+        # an FDE can begin in the alignment padding ahead of its function, and then the real
+        # entry a few bytes in is interior to nothing
+        self.assertIsNone(declaredOwnerOf(0x1500, self.RANGES, [], self.BORDERS))
+
+    def testAnAddressPastTheOwnersRecoveredExtentIsKept(self):
+        # the declared range reaches further than the owner's control flow arrived; refusing
+        # out there discards bytes nothing else claims, and any reference only they carry
+        short = {0x1000: (0x1000, 0x1100)}
+        self.assertIsNone(declaredOwnerOf(0x1500, self.RANGES, self.FUNCTIONS, short))
+
+    def testAnOwnerWithNoRecordedExtentRefusesNothing(self):
+        self.assertIsNone(declaredOwnerOf(0x1500, self.RANGES, self.FUNCTIONS, {}))
+
+    def testAStubInADeclaredPltIsExempt(self):
+        # the whole table sits under one FDE, so every stub after the first reads as interior
+        self.assertIsNone(declaredOwnerOf(0x1500, self.RANGES, self.FUNCTIONS, self.BORDERS, plt=[(0x1400, 0x1600)]))
+
+    def testTheFlagTurnsTheRefusalOff(self):
+        self.assertIsNone(declaredOwnerOf(0x1500, self.RANGES, self.FUNCTIONS, self.BORDERS, enabled=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testFdeInteriorGaps.py
+++ b/tests/testFdeInteriorGaps.py
@@ -152,14 +152,19 @@ class FdeInteriorGapRuleAArch64Test(unittest.TestCase):
                 return original(manager, candidate_address)
 
             FunctionCandidateManager.declaredInteriorOwner = claiming
-        with tempfile.NamedTemporaryFile(suffix=".elf", delete=False) as handle:
-            handle.write(self.data)
-            temp_path = handle.name
-        disassembler = Disassembler(config)
+        temp_path = None
         try:
+            with tempfile.NamedTemporaryFile(suffix=".elf", delete=False) as handle:
+                handle.write(self.data)
+                temp_path = handle.name
+            disassembler = Disassembler(config)
             report = disassembler.disassembleFile(temp_path)
         finally:
-            os.unlink(temp_path)
+            if temp_path is not None:
+                os.unlink(temp_path)
+            # restore inside the finally, and with everything after the patch inside the try:
+            # a failure while writing the sample or building the disassembler would otherwise
+            # leave the claim installed on the class for every later test in the process
             FunctionCandidateManager.declaredInteriorOwner = original
         return disassembler.disassembler, {function.offset for function in report.getFunctions()}
 


### PR DESCRIPTION
Closes #324.

`USE_ELF_FDE_INTERIOR_GAPS` refuses a candidate that opens strictly inside a range the image's own `.eh_frame` declares. It is reached only from the gap scan — it tests `self.gap_pointer` — so candidates from the prologue scan, from branch targets and from the tailcall paths never meet it. On the 72-cell AArch64 ELF corpus, 2,245 of the 2,484 false positives still standing after #300 are interior to a declared range, and **not one of them is a gap candidate**: 1,213 come from the initial seeding scans and 1,001 carry a call reference.

This asks the same question at the point analysis is about to begin on a candidate, whatever seeded it. Nothing new is read from the image and no heuristic is added; the evidence and the rule are the ones already shipped.

## The guards

Both of the gap rule's conditions apply unchanged. A PLT is exempt, because the whole table sits under one FDE and the range test would read every stub after the first as interior to it. And the range's own start has to be a recovered function, because an FDE can begin in the alignment padding ahead of its function, which leaves the real entry a few bytes in interior to nothing.

**A third is new, and the corpus is what found it.** A declared range can reach past everything its function's control flow actually arrives at. Refusing an address out there discards bytes nothing else claims — along with any reference only those bytes carry. Without this guard the AArch64 corpus loses three true positives, and all three are the same shape: a real function whose only incoming reference sits in the unreached tail of another function's declared range. In `brotli_gcc-arm64_O2-static` the entry point's FDE is `[0x401e40, 0x401e7c)`, its control flow stops before `0x401e78`, and the `bl` at that address is the only thing naming the real function at `0x400600`.

Requiring the owner's own recovered extent to surround the address costs 163 of the refusals and returns all three. It is also most of why Rust comes out unchanged.

## Measured

Against compiler symbol tables, `master` `e9dfe5f` → this branch, both trees run back to back on the same machine. Re-measured after the rebase onto #325; the figures are unchanged, which is expected since that PR's one behaviour change is PE-only and this rule is ELF-only. **No corpus loses a true positive.**

| corpus | n | PPV | TPR | ΔFP | ΔTP |
|---|---|---|---|---|---|
| Built C/C++ AArch64 ELF | 72 | 95.994 → **97.063** | 98.657 | **−683** | 0 |
| Built C/C++ ELF (gcc, clang) | 140 | 98.903 → **98.969** | unchanged | **−77** | 0 |
| Built C/C++ MinGW PE | 120 | bit-identical | bit-identical | 0 | 0 |
| Built Rust (gnu targets) | 24 | bit-identical | bit-identical | 0 | 0 |
| Built Go (pclntab truth) | 23 | bit-identical | bit-identical | 0 | 0 |
| ARM64 Mach-O (`LC_FUNCTION_STARTS`) | 11 | bit-identical | bit-identical | 0 | 0 |
| Malpedia dumps (`.fnmap` truth) | 57 | bit-identical | bit-identical | 0 | 0 |

Micro (pooled) figures; TP and FN are identical in every row. The four bit-identical rows are the control, not filler: 120 PE cells, 23 Go, 11 Mach-O and 57 memory dumps carry no `.eh_frame`, so any movement there would have meant the rule firing where it has no business firing.

**Rust is bit-identical for a reason, not because the rule is inert there.** Its images decode their ranges — 740 FDEs on the first cell — and 25 of that cell's 26 false positives *are* interior to one. The guards decline all of them: over its first four cells, 78 of 94 on the owner's recovered extent and the other 12 on the owner not being recovered.

The rule never refuses an address the image names. Across the four densest AArch64 cells it refuses 4,070 addresses and every one is inferred-only — not a symbol, not an exception record, not language metadata, not a gap or tailcall candidate.

Analysis is slightly faster, because a refused candidate is one nothing then analyses: `zlib_gcc-arm64_O2-static` 1.26s → 1.19s, `lua_gcc-arm64_O2-static` 2.04s → 1.92s (median of 3).

## Tests

Nine new cases in `tests/testFdeInteriorGaps.py`. Eight drive `declaredInteriorOwner` directly, one condition each, and the ninth covers the wiring: it claims one address the fixture does recover and asserts analysis then declines it. Each was checked to fail when the guard it describes is removed, and only that one — dropping the extent guard fails two, the PLT exemption one, the recovered-owner condition one, and removing the call site fails the wiring case.

The bundled fixtures reach the gap scan's own refusal or the collision check before this arm sees anything, which is why the wiring case claims an address rather than asserting over what the fixture happens to drop. An earlier version of it asserted over the recovered set and passed with the feature removed; that is why it is written this way.

This file also had `unittest.main()` sitting above a test class, so running it directly never defined `FdeInteriorGapRuleAArch64Test`. Moved to the end.

- `python -m pytest tests/` → **2,069 passed, 1 skipped, 2,593 subtests**
- `ruff check .` and `ruff format --check .` → clean
- `make typecheck` → exit 0, 0 error-level diagnostics
- Diff coverage against this PR's base → **100%** (16 lines, 0 missing)

No bundled fixture baseline moves.

## One sibling, deliberately left out

Three rules read declared evidence at the gap pointer only: the `.pdata` exception range, `USE_LSDA_LANDING_PADS`, and the one widened here. The landing-pad rule has nothing left to reach — of 302 false positives still standing on four AArch64 cells, none is a declared landing pad. The `.pdata` rule does: 6 of 74 remaining false positives on three MinGW PE cells are inside a declared range.

That one is left for its own change. It moves PE, which is exactly the control that makes this one safe to read, and it needs its own measurement over the PE corpora rather than riding on these numbers. Happy to open an issue for it, or fold it in here if you would rather see them together.


## Corrected after review

**The docstring's claim about what the rule can reach was wrong.** It said that inside the owner's recovered extent "the owner already accounts for the address, so nothing is lost". The rule is consulted immediately after the collision check, which tests membership in `code_map` — every byte of every recovered instruction — so every address that reaches it is one the owner's analysis never covered, and `function_borders` is an envelope built from the instruction extremes rather than a coverage map.

It now names the population (alignment holes between blocks, an unreached tail, a data island), names the residual exposure (a real entry carrying no FDE of its own, sitting in one of those holes inside a neighbour's declared range), and says that what bounds it is the measurement rather than the structure. The magnitude stays out of the source: an absolute false-positive count is a property of every other rule in the engine on the day it was taken, while the invariant — no true positive lost — is a property of the mechanism.

**A test-isolation fix found in the same pass.** `analysedFixture()` patches `declaredInteriorOwner` onto the class and restores it in a `finally`, but the sample write and the disassembler construction sat outside the `try`; either raising would leave the claim installed for every later test in the process. Everything after the patch is inside the `try` now.

Full suite on the current tip: **2,119 passed, 1 skipped, 2,596 subtests**, `ruff` clean, `make typecheck` exit 0.
