### PR TITLE
feat(common): let the exception directory refuse an interior candidate too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,18 @@ past roughly six lines it belongs in the PR the entry links.
 
 ### Changed
 
+- **(common)** Let a PE exception directory refuse an interior candidate too, not only an ELF's
+  `.eh_frame`. A `RUNTIME_FUNCTION` extent names the addresses inside a routine the way an FDE range
+  does, and it now answers where analysis would begin on a candidate from any source, under the same
+  guards: the record's own function has to be recovered, and its recovered extent has to surround the
+  address. A fragment record is not the shortcut it is in the gap scan -- its own start is not the
+  function covering the address, so it declines rather than refusing. *Measured on `fb510c4` against
+  compiler symbol tables:* 120 MinGW PE x64 cells 93.191 -> 93.235 PPV (-47 false positives, 109/120
+  bit-identical) and 2 Rust windows-gnu-x64 cells (-2), both at identical true positives and false
+  negatives; the 140 C/C++ ELF cells and all 57 malpedia dumps are bit-identical. Three of the dumps
+  do declare an exception directory, and the rule is consulted on all three and refuses nothing, which
+  is what makes that a control rather than an absence. (#329)
+
 - **(tests)** `make test` now runs the fast tier and `make test-all` runs the whole suite. The `slow`
   marker already existed, was already applied to the eleven fixture-corpus files, and was documented in
   `pyproject.toml` with its own deselect recipe — but no entry point used it, so every local run paid for
@@ -129,6 +141,10 @@ past roughly six lines it belongs in the PR the entry links.
 ### Security
 
 ### Compatibility
+
+- Recovery output moves on PE images that declare an exception directory: an address a
+  `RUNTIME_FUNCTION` extent covers is no longer reported as a function start unless it is that
+  record's own start. No true positive was lost on the corpora this was measured over. (#329)
 
 - Recovery output moves on Intel PE and ELF images whose gap scan meets a failed candidate: the
   bytes after it are now scanned instead of skipped. No true positive was lost on the corpora

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,13 @@ past roughly six lines it belongs in the PR the entry links.
   before the memo was written, so a section naming one dead pointer from every record read it once per record;
   remembered by address, that is now one read. *All 447 cells across the six corpora are bit-identical.* (#335)
 
+- **(common)** Let each backend decide whether its own exception-directory interior rule is enabled. Both native
+  backends fill the same `_pdata_ranges` list, but the shared rule named `USE_PE_X64_PDATA_INTERIOR_GAPS` alone,
+  so on an ARM64 PE the refusal answered to a switch for a format it never sees: the ARM64 flag no longer turned
+  it off, and the x64 flag would have. Default output does not move -- with both flags on the gap scan reaches
+  those addresses first -- so this is flag semantics rather than a recovery change, and the bundled ARM64 PE
+  fixture is what makes it visible. (#329)
+
 ### Security
 
 ### Compatibility

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -147,8 +147,11 @@ class SmdaConfig:
     #   2 Rust windows-gnu-x64    -2 FP at identical TP and FN
     # Nothing else moves at all. The 140 x86-64 ELF cells, 72 AArch64 ELF cells, 23 Go cells,
     # 11 ARM64 Mach-O cells, the 32-bit and ELF Rust cells and all 57 malpedia dumps are
-    # bit-identical. The dumps are the reading worth keeping: none of the 57 declares an
-    # exception directory at all, so this evidence does not reach a mapped image.
+    # bit-identical. The dumps are the reading worth keeping, and not because the evidence is
+    # absent: three of the 57 do declare an exception directory, 282 to 430 records each, and on
+    # all three the rule is consulted and refuses nothing - every address its guards see is
+    # declined. Reachable and declining is the stronger control; an earlier note here claimed
+    # none of the dumps carried a directory, which is not so.
     USE_PE_X64_PDATA_INTERIOR_GAPS = True
     # Refuse a gap candidate that an ARM64 PE image's own exception directory places inside a
     # routine. The same evidence and the same rule as the x64 flag above, reached differently:

--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -137,6 +137,18 @@ class SmdaConfig:
     # an analysis that ran past the end of the routine the address sat inside and absorbed
     # the small aligned functions after it. On the cell examined, all eight functions
     # recovered sit 11 to 79 bytes past a declared extent's end.
+    # The same extents also answer for a candidate from any other source, at the point analysis
+    # would begin on it, under the guards the .eh_frame arm carries: the record's own function
+    # has to be recovered and its recovered extent has to surround the address. A fragment is
+    # not the shortcut it is in the gap scan - its start is not the function covering the
+    # address, so it declines here rather than refusing.
+    # Worth much less than the .eh_frame arm, and the numbers are why it is a change of its own:
+    #   120 MinGW PE x64 cells   -47 FP at identical TP and FN, 109 of 120 bit-identical
+    #   2 Rust windows-gnu-x64    -2 FP at identical TP and FN
+    # Nothing else moves at all. The 140 x86-64 ELF cells, 72 AArch64 ELF cells, 23 Go cells,
+    # 11 ARM64 Mach-O cells, the 32-bit and ELF Rust cells and all 57 malpedia dumps are
+    # bit-identical. The dumps are the reading worth keeping: none of the 57 declares an
+    # exception directory at all, so this evidence does not reach a mapped image.
     USE_PE_X64_PDATA_INTERIOR_GAPS = True
     # Refuse a gap candidate that an ARM64 PE image's own exception directory places inside a
     # routine. The same evidence and the same rule as the x64 flag above, reached differently:

--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -1032,6 +1032,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             or auth_or_exception_return
         )
 
+    def _pdataInteriorRefusalEnabled(self):
+        """The flag this backend's gap scan already answers to, for the analysis-time rule."""
+        return self.config.USE_PE_ARM64_PDATA_INTERIOR_GAPS
+
     def nextGapCandidate(self, start_gap_pointer=None):
         # AArch64 gap scan: a fixed-stride linear sweep of unanalyzed executable bytes
         # for functions that no prologue, call reference or stored pointer reached

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -733,8 +733,23 @@ class FunctionCandidateManager:
             index -= 1
         return None
 
+    def _pdataInteriorRefusalEnabled(self):
+        """Whether this backend's exception-directory interior rule is enabled.
+
+        `_pdata_ranges` is filled by whichever backend read the directory, and the two that do
+        answer to separate flags: the x64 and ARM64 PE rules are separate features with separate
+        defaults. Naming either flag here would leave one architecture's rule answering to the
+        other architecture's switch, so each backend says instead. Those two are also the only
+        managers this engine builds today, so what is inherited here is the answer for one that
+        carves no directory at all: off, there being no extents for the rule to read.
+        """
+        return False
+
     def declaredInteriorOwner(self, addr):
-        """The recovered function whose declared `.eh_frame` range contains `addr`, or None.
+        """The recovered function whose declared range contains `addr`, or None.
+
+        Either structure that declares one answers: an ELF's `.eh_frame` FDE ranges, or a PE
+        exception directory's `RUNTIME_FUNCTION` extents.
 
         The same evidence the gap scan already refuses on, asked at the point a candidate from
         any source is about to be analysed rather than only where the gap pointer reaches. Both
@@ -747,9 +762,13 @@ class FunctionCandidateManager:
         Both structures answer here, as they do in the gap scan, and they are format-disjoint:
         `_pdata_ranges` is only ever filled from a PE exception directory and the `.eh_frame`
         ranges decode nothing unless lief reports an ELF, so no address is arbitrated between
-        them. A fragment record is not the shortcut it is in the gap scan: its own start is not
-        the function that covers the address, so it fails the recovered-owner test below and
-        declines, which is the conservative reading at a point where a better one is available.
+        them. Disjointness is load-bearing rather than merely tidy, unlike in the gap scan: a
+        declared FDE range whose start was never recovered sets `owner` and then fails the
+        recovered-owner test, so on an image carrying both structures the exception directory
+        would never be asked about that address. A fragment record is not the shortcut it is in
+        the gap scan: its own start is not the function that covers the address, so it fails the
+        recovered-owner test below and declines, which is the conservative reading at a point
+        where a better one is available.
 
         A third guard the gap scan does not need: the owner's own recovered extent has to
         surround the address. An FDE can reach past everything its function's control flow
@@ -770,7 +789,7 @@ class FunctionCandidateManager:
             declared = self.declaredFdeRangeContaining(addr)
             if declared is not None:
                 owner = declared[0]
-        if owner is None and self._pdata_ranges and self.config.USE_PE_X64_PDATA_INTERIOR_GAPS:
+        if owner is None and self._pdata_ranges and self._pdataInteriorRefusalEnabled():
             declared = self.declaredExceptionRangeContaining(addr)
             if declared is not None:
                 owner = declared[0]

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -744,6 +744,13 @@ class FunctionCandidateManager:
         begin in the alignment padding ahead of its function, which leaves the real entry a few
         bytes in interior to nothing.
 
+        Both structures answer here, as they do in the gap scan, and they are format-disjoint:
+        `_pdata_ranges` is only ever filled from a PE exception directory and the `.eh_frame`
+        ranges decode nothing unless lief reports an ELF, so no address is arbitrated between
+        them. A fragment record is not the shortcut it is in the gap scan: its own start is not
+        the function that covers the address, so it fails the recovered-owner test below and
+        declines, which is the conservative reading at a point where a better one is available.
+
         A third guard the gap scan does not need: the owner's own recovered extent has to
         surround the address. An FDE can reach past everything its function's control flow
         arrives at, and refusing an address out there discards bytes nothing else claims --
@@ -758,17 +765,21 @@ class FunctionCandidateManager:
         nothing in the format forbids that; what bounds it is measurement rather than
         structure, no true positive lost across the ELF corpora this was measured over.
         """
-        if not self.config.USE_ELF_FDE_INTERIOR_GAPS:
+        owner = None
+        if self.config.USE_ELF_FDE_INTERIOR_GAPS and not self.isInDeclaredPltSection(addr):
+            declared = self.declaredFdeRangeContaining(addr)
+            if declared is not None:
+                owner = declared[0]
+        if owner is None and self._pdata_ranges and self.config.USE_PE_X64_PDATA_INTERIOR_GAPS:
+            declared = self.declaredExceptionRangeContaining(addr)
+            if declared is not None:
+                owner = declared[0]
+        if owner is None or owner not in self.disassembly.functions:
             return None
-        if self.isInDeclaredPltSection(addr):
-            return None
-        containing = self.declaredFdeRangeContaining(addr)
-        if containing is None or containing[0] not in self.disassembly.functions:
-            return None
-        borders = self.disassembly.function_borders.get(containing[0])
+        borders = self.disassembly.function_borders.get(owner)
         if borders is None or not borders[0] <= addr < borders[1]:
             return None
-        return containing[0]
+        return owner
 
     def opensInsideDeclaredFdeRange(self, addr):
         """Whether `addr` falls inside a declared FDE range without being that range's start."""

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -239,6 +239,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             return None
         return target
 
+    def _pdataInteriorRefusalEnabled(self):
+        """The flag this backend's gap scan already answers to, for the analysis-time rule."""
+        return self.config.USE_PE_X64_PDATA_INTERIOR_GAPS
+
     def nextGapCandidate(self, start_gap_pointer=None):
         if self.language_candidates_only:
             return None

--- a/tests/testFdeInteriorGaps.py
+++ b/tests/testFdeInteriorGaps.py
@@ -196,13 +196,16 @@ class _RecoveredDisassembly:
         self.function_borders = borders
 
 
-def declaredOwnerOf(address, ranges, functions, borders, plt=(), enabled=True):
+def declaredOwnerOf(address, ranges, functions, borders, plt=(), enabled=True, pdata=(), pe_enabled=True):
     manager = FunctionCandidateManager(SmdaConfig())
     manager.config.USE_ELF_FDE_INTERIOR_GAPS = enabled
+    manager.config.USE_PE_X64_PDATA_INTERIOR_GAPS = pe_enabled
     manager.disassembly = _RecoveredDisassembly(dict.fromkeys(functions), dict(borders))
     manager._eh_frame_fde_ranges = list(ranges)
     manager._eh_frame_fde_starts = [start for start, _ in ranges]
     manager._plt_ranges = list(plt)
+    manager._pdata_ranges = list(pdata)
+    manager._pdata_range_starts = None
     return manager.declaredInteriorOwner(address)
 
 
@@ -247,6 +250,52 @@ class DeclaredInteriorOwnerTest(unittest.TestCase):
 
     def testTheFlagTurnsTheRefusalOff(self):
         self.assertIsNone(declaredOwnerOf(0x1500, self.RANGES, self.FUNCTIONS, self.BORDERS, enabled=False))
+
+
+class DeclaredInteriorOwnerPeTest(unittest.TestCase):
+    """The same question asked of a PE exception directory rather than an `.eh_frame`.
+
+    The two structures never describe the same image, so the arms are exercised apart: an
+    ELF names no `RUNTIME_FUNCTION` extents and a PE decodes no FDE ranges.
+    """
+
+    PDATA = [(0x1000, 0x2000, False)]
+    FUNCTIONS = [0x1000]
+    BORDERS = {0x1000: (0x1000, 0x1F00)}
+
+    def ownerOf(self, address, **kwargs):
+        options = {
+            "ranges": [],
+            "functions": self.FUNCTIONS,
+            "borders": self.BORDERS,
+            "pdata": self.PDATA,
+            **kwargs,
+        }
+        return declaredOwnerOf(address, **options)
+
+    def testAnAddressInsideADeclaredExtentIsRefused(self):
+        self.assertEqual(self.ownerOf(0x1500), 0x1000)
+
+    def testAnExtentStartIsNotInteriorToItself(self):
+        self.assertIsNone(self.ownerOf(0x1000))
+
+    def testAnExtentWhoseOwnerWasNotRecoveredRefusesNothing(self):
+        self.assertIsNone(self.ownerOf(0x1500, functions=[]))
+
+    def testAnAddressPastTheOwnersRecoveredExtentIsKept(self):
+        self.assertIsNone(self.ownerOf(0x1500, borders={0x1000: (0x1000, 0x1100)}))
+
+    def testAFragmentRecordDeclinesRatherThanRefusing(self):
+        # the gap scan takes a fragment as evidence on its own; here the record's own start is
+        # not the function covering the address, so it fails the recovered-owner test instead
+        self.assertIsNone(self.ownerOf(0x1500, pdata=[(0x1400, 0x1600, True)]))
+
+    def testTheFlagTurnsTheRefusalOff(self):
+        self.assertIsNone(self.ownerOf(0x1500, pe_enabled=False))
+
+    def testTheElfFlagDoesNotGateTheExceptionDirectory(self):
+        # the two arms carry their own switches; turning the ELF one off leaves this one alone
+        self.assertEqual(self.ownerOf(0x1500, enabled=False), 0x1000)
 
 
 if __name__ == "__main__":

--- a/tests/testFdeInteriorGaps.py
+++ b/tests/testFdeInteriorGaps.py
@@ -14,9 +14,11 @@ import unittest
 
 import lief
 
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager as Aarch64FunctionCandidateManager
 from smda.common.EhFrameDecoder import decodeEhFrameFdeRanges
 from smda.common.FunctionCandidateManager import FunctionCandidateManager
 from smda.Disassembler import Disassembler
+from smda.intel.FunctionCandidateManager import FunctionCandidateManager as IntelFunctionCandidateManager
 from smda.SmdaConfig import SmdaConfig
 
 logging.disable(logging.CRITICAL)
@@ -196,10 +198,25 @@ class _RecoveredDisassembly:
         self.function_borders = borders
 
 
-def declaredOwnerOf(address, ranges, functions, borders, plt=(), enabled=True, pdata=(), pe_enabled=True):
-    manager = FunctionCandidateManager(SmdaConfig())
+def declaredOwnerOf(
+    address,
+    ranges,
+    functions,
+    borders,
+    plt=(),
+    enabled=True,
+    pdata=(),
+    pe_enabled=True,
+    arm64_pe_enabled=True,
+    manager_class=FunctionCandidateManager,
+):
+    # the exception-directory arm asks the backend whether its own rule is on, and the common
+    # class answers no, so a PE case has to be posed to the backend that fills those ranges --
+    # otherwise it passes by declining for the wrong reason
+    manager = manager_class(SmdaConfig())
     manager.config.USE_ELF_FDE_INTERIOR_GAPS = enabled
     manager.config.USE_PE_X64_PDATA_INTERIOR_GAPS = pe_enabled
+    manager.config.USE_PE_ARM64_PDATA_INTERIOR_GAPS = arm64_pe_enabled
     manager.disassembly = _RecoveredDisassembly(dict.fromkeys(functions), dict(borders))
     manager._eh_frame_fde_ranges = list(ranges)
     manager._eh_frame_fde_starts = [start for start, _ in ranges]
@@ -263,12 +280,15 @@ class DeclaredInteriorOwnerPeTest(unittest.TestCase):
     FUNCTIONS = [0x1000]
     BORDERS = {0x1000: (0x1000, 0x1F00)}
 
+    MANAGER_CLASS = IntelFunctionCandidateManager
+
     def ownerOf(self, address, **kwargs):
         options = {
             "ranges": [],
             "functions": self.FUNCTIONS,
             "borders": self.BORDERS,
             "pdata": self.PDATA,
+            "manager_class": self.MANAGER_CLASS,
             **kwargs,
         }
         return declaredOwnerOf(address, **options)
@@ -296,6 +316,46 @@ class DeclaredInteriorOwnerPeTest(unittest.TestCase):
     def testTheElfFlagDoesNotGateTheExceptionDirectory(self):
         # the two arms carry their own switches; turning the ELF one off leaves this one alone
         self.assertEqual(self.ownerOf(0x1500, enabled=False), 0x1000)
+
+    def testTheOtherArchitecturesFlagDoesNotGateThisOne(self):
+        self.assertEqual(self.ownerOf(0x1500, arm64_pe_enabled=False), 0x1000)
+
+
+class DeclaredInteriorOwnerArm64PeTest(DeclaredInteriorOwnerPeTest):
+    """The same extents read by the backend that carves an ARM64 PE's `.pdata`.
+
+    Both backends fill `_pdata_ranges` and each gap scan gates on its own architecture's flag,
+    so the analysis-time rule has to as well: naming one flag in the shared helper leaves the
+    other architecture's rule answering to a switch for an image format it never sees.
+    """
+
+    MANAGER_CLASS = Aarch64FunctionCandidateManager
+
+    def testTheFlagTurnsTheRefusalOff(self):
+        self.assertIsNone(self.ownerOf(0x1500, arm64_pe_enabled=False))
+
+    def testTheOtherArchitecturesFlagDoesNotGateThisOne(self):
+        self.assertEqual(self.ownerOf(0x1500, pe_enabled=False), 0x1000)
+
+
+class DeclaredInteriorOwnerUnbackedPeTest(unittest.TestCase):
+    """A manager that carves no exception directory refuses nothing on one.
+
+    The two native backends are the only ones that reach the rule today, so this pins what the
+    inherited answer is: a manager added without an override cannot start refusing on extents
+    it never filled.
+    """
+
+    def testTheCommonManagerDeclinesAnExtentItCouldNotHaveFilled(self):
+        self.assertIsNone(
+            declaredOwnerOf(
+                0x1500,
+                ranges=[],
+                functions=[0x1000],
+                borders={0x1000: (0x1000, 0x1F00)},
+                pdata=[(0x1000, 0x2000, False)],
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #328. **Stacked on #327** — it extends the helper that PR introduces, so it must merge after it. The diff shown against `master` will include #327's commit until then; this PR's own commit is `2efa621`.

Third of the three rules named in the #324 sweep, and the last one with anything left to reach. #327 widened the `.eh_frame` arm to a candidate from any source; this does the same for the PE exception directory, under the guards that arm established.

## The rule

The same two conditions, unchanged: the `RUNTIME_FUNCTION` record's own function has to be recovered, and its *recovered* extent has to surround the address. The two evidence sources stay format-disjoint exactly as the gap scan's comment already notes — `_pdata_ranges` is only ever filled from a PE exception directory and the `.eh_frame` ranges decode nothing unless lief reports an ELF — so no address is ever arbitrated between them.

One deliberate difference from the gap scan. There, a **fragment record is evidence on its own**: it says the extent is part of some other function, and the scan needs nothing more. Here it is not taken as that. A fragment's own start is not the function covering the address, so it fails the recovered-owner test and declines rather than refusing. At a point where the better evidence — an actual recovered owner — is available, using the weaker form would be the wrong reading. No fragment record appeared among the interior false positives in the sample either way.

## Measured

`feat/fde-interior-analysis-gate` (#327) → this branch, so the figures isolate this arm.

| corpus | n | TP | ΔFP | bit-identical cells |
|---|---|---|---|---|
| Built C/C++ MinGW PE x64 | 120 | unchanged | **−47** | 109 / 120 |
| Built Rust, `windows-gnu-x64` | 2 | unchanged | **−2** | — |
| Built C/C++ ELF (gcc, clang) | 140 | unchanged | 0 | **140 / 140** |
| Built C/C++ AArch64 ELF | 72 | unchanged | 0 | **72 / 72** |
| Built Go | 23 | unchanged | 0 | **23 / 23** |
| ARM64 Mach-O | 11 | unchanged | 0 | **11 / 11** |
| Rust, ELF and 32-bit PE cells | 22 | unchanged | 0 | **22 / 22** |
| Malpedia dumps | 57 | unchanged | 0 | **57 / 57** |

**No corpus loses a true positive, and only PE x64 cells differ anywhere** — which is the control this arm has to pass, the mirror of #327's ELF-only one.

## The part worth reading before merging

**On memory dumps this evidence does not exist.** None of the 57 malpedia dumps declares an exception directory at all — `_pdata_ranges` is empty, so the rule never reaches its first condition. That is the corpus SMDA cares most about, and it is the honest limit of this change.

Between that and 47 false positives on one PE corpus, this is a small win, and #328 says so rather than selling it. It is here because it is free of recall risk under guards that are already measured, and because leaving one of three siblings unwidened without a reason is worse than either doing it or declining it on the record. If you would rather close #328 and keep the surface smaller, that is a reasonable call and the numbers are the argument either way.

## One thing I had wrong

I filed #328 saying 14 of 1,038 on a 20-cell sample, and scaled that to roughly 80 across 120 cells. The real figure is **47**. The sample over-predicted; the table above is the measurement.

I also assumed the Rust corpus was ELF, which is why the two moving cells looked like an anomaly at first. They are `windows-gnu-x64` — PE x64, exactly where this applies. The corpus is mixed, and every one of its ELF and 32-bit cells is bit-identical.

## Tests

Seven cases in `tests/testFdeInteriorGaps.py::DeclaredInteriorOwnerPeTest`, one condition each, exercising the arm through a stubbed exception directory so the ELF and PE arms are tested apart. Each was checked to fail when the guard it describes is removed: dropping the arm fails two, dropping its flag check fails one.

- `python -m pytest tests/` → **2,076 passed, 1 skipped, 2,593 subtests**
- `ruff check .` and `ruff format --check .` → clean
- `make typecheck` → exit 0, 0 error-level diagnostics, no new diagnostics
- Diff coverage against this PR's base → **100%** (12 lines, 0 missing)

No bundled fixture baseline moves.


## Fixed after review

**The shared rule answered to the wrong architecture's flag.** Both native backends fill `_pdata_ranges` — `intel` from an x64 exception directory, `aarch64` from an ARM64 PE's — and each gap scan gates on its own flag, but `declaredInteriorOwner` named only `USE_PE_X64_PDATA_INTERIOR_GAPS`. On an ARM64 PE that left `USE_PE_ARM64_PDATA_INTERIOR_GAPS` unable to turn the ARM64 rule off, and the x64 flag able to. Default output does not move — with both flags on the gap scan reaches those addresses first — but `testArm64PeInteriorGapFixture` fails, five of its eight pinned addresses stopping short of `off - on`.

Each backend now answers for itself through a `_pdataInteriorRefusalEnabled()` hook, mirroring the split the two gap scans already have. The base returns the disabled answer, which is what a manager carving no exception directory should give.

**The PE unit cases had to move with it.** `declaredOwnerOf` built a bare common manager, which now inherits that answer: two of the seven cases would fail outright and the other five would pass vacuously, taking their `None` from the gate rather than from the condition each is about. The helper takes a `manager_class` and the PE class builds the backend that fills the ranges. `DeclaredInteriorOwnerArm64PeTest` asks all seven of the same conditions of `aarch64`'s manager, each class asserting that the *other* architecture's flag does not gate it, and `DeclaredInteriorOwnerUnbackedPeTest` pins the inherited answer so a manager added without an override cannot start refusing on extents it never filled.

Four mutations verified, each caught by the intended case and nothing else: either backend's override answering to the other's flag, the shared gate naming a flag directly, and the base returning `True`.

**Also documented:** disjointness between the two structures is load-bearing here in a way it is not in the gap scan — a declared FDE range whose start was never recovered sets `owner` and then fails the recovered-owner test, so on an image carrying both the exception directory would never be asked about that address.

Full suite on the current tip: **2,136 passed, 1 skipped, 2,596 subtests**, `ruff` clean, `make typecheck` exit 0.
