### PR TITLE
feat(aarch64): record why the gap scan refused an address, as intel does

### DIFF
--- a/src/smda/aarch64/FunctionCandidateManager.py
+++ b/src/smda/aarch64/FunctionCandidateManager.py
@@ -1029,6 +1029,7 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if scanned % 4096 == 0 and self._candidateTimeoutTripped():
                 return None
             if base + size < self.gap_pointer:
+                LOGGER.debug("nextGapCandidate() gap_ptr: 0x%08x - finishing", self.gap_pointer)
                 return None
             # align to the instruction stride
             self.gap_pointer = (self.gap_pointer + (INSTRUCTION_SIZE - 1)) & ~(INSTRUCTION_SIZE - 1)
@@ -1036,9 +1037,17 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
             if offset < 0 or offset + INSTRUCTION_SIZE > size:
                 return None
             if self.gap_pointer in self.disassembly.code_map:
+                LOGGER.debug(
+                    "nextGapCandidate() gap_ptr is already inside code map: 0x%08x",
+                    self.gap_pointer,
+                )
                 self.gap_pointer = self.getNextGap()
                 continue
             if self.gap_pointer in self.disassembly.data_map:
+                LOGGER.debug(
+                    "nextGapCandidate() gap_ptr is already inside data map: 0x%08x",
+                    self.gap_pointer,
+                )
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if exec_ranges and not in_exec(self.gap_pointer):
@@ -1046,6 +1055,11 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 continue
             word = words[offset // INSTRUCTION_SIZE]
             if word in (0, NOP):  # inter-function padding
+                LOGGER.debug(
+                    "nextGapCandidate() found padding word - gap_ptr += %d: 0x%08x",
+                    INSTRUCTION_SIZE,
+                    self.gap_pointer,
+                )
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             # Same three declared-evidence rules as the intel gap scan, in the same order and
@@ -1062,6 +1076,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                     # it names has actually been recovered; until then the record says nothing
                     # about what covers this address. Resuming at the extent's end skips the
                     # body rather than the one word, which is what the record describes.
+                    LOGGER.debug(
+                        "nextGapCandidate() gap_ptr is inside a declared .pdata extent: 0x%08x",
+                        self.gap_pointer,
+                    )
                     self.gap_pointer = containing[1]
                     continue
             if self.config.USE_LSDA_LANDING_PADS and self.isDeclaredLandingPad(self.gap_pointer):
@@ -1071,6 +1089,10 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 # the shape test then reads the bti as evidence of a legitimate indirect-call
                 # target instead of as a pad. It also knows where the pad's function ends,
                 # where the shape test only knows where the run of pads ends.
+                LOGGER.debug(
+                    "nextGapCandidate() gap_ptr is a declared landing pad: 0x%08x",
+                    self.gap_pointer,
+                )
                 skip = self.declaredLandingPadSkipTarget(self.gap_pointer)
                 self.gap_pointer = skip or self.gap_pointer + INSTRUCTION_SIZE
                 continue
@@ -1083,25 +1105,51 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
                 # range is one function: an FDE can begin in the alignment padding ahead of
                 # its function, and then the real entry a few bytes in is interior to nothing.
                 if containing is not None and containing[0] in self.disassembly.functions:
+                    LOGGER.debug(
+                        "nextGapCandidate() gap_ptr is inside a declared FDE range: 0x%08x",
+                        self.gap_pointer,
+                    )
                     self.gap_pointer = containing[1]
                     continue
             if is_bti_landing_pad(word) and self._isLikelyInteriorBtiCandidate(self.gap_pointer, word):
                 # #310's resume target, not one instruction on: stepping a single word lands
                 # inside the pad the scan just refused and books that instead.
+                LOGGER.debug(
+                    "nextGapCandidate() gap_ptr is an interior indirect-branch landing pad: 0x%08x",
+                    self.gap_pointer,
+                )
                 self.gap_pointer = self._endOfRefusedLandingPadRun(self.gap_pointer)
                 continue
             if is_trap(word):  # udf-space data words / trap filler, never an entry
+                LOGGER.debug(
+                    "nextGapCandidate() found trap word - gap_ptr += %d: 0x%08x",
+                    INSTRUCTION_SIZE,
+                    self.gap_pointer,
+                )
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if self.previously_analyzed_gap == self.gap_pointer:
+                LOGGER.debug(
+                    "--- HRM, nextGapCandidate() gap_ptr at: 0x%08x was previously analyzed",
+                    self.gap_pointer,
+                )
                 self.gap_pointer = self.getNextGap(dont_skip=True)
                 continue
             if not self._passesCodeFilter(self.gap_pointer):
+                LOGGER.debug(
+                    "nextGapCandidate() gap_ptr did not pass the code filter: 0x%08x",
+                    self.gap_pointer,
+                )
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
             if self._gapRunFlowsIntoInterior(self.gap_pointer):
+                LOGGER.debug(
+                    "nextGapCandidate() gap run flows into the interior of a mapped function: 0x%08x",
+                    self.gap_pointer,
+                )
                 self.gap_pointer += INSTRUCTION_SIZE
                 continue
+            LOGGER.debug("nextGapCandidate() using 0x%08x as candidate", self.gap_pointer)
             self.previously_analyzed_gap = self.gap_pointer
             self.addGapCandidate(self.gap_pointer)
             return self.gap_pointer

--- a/tests/testAArch64GapScanLogging.py
+++ b/tests/testAArch64GapScanLogging.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+"""Every refusal in the AArch64 gap scan names the address it refused.
+
+Its intel counterpart emits a `LOGGER.debug` on each path that declines a gap pointer, so
+a suppression can be read back from a run. The AArch64 loop had no logging at all, which
+made the two paths diverge on the one axis they are otherwise deliberately identical on:
+the first ARM64 PE that suppresses something surprising would have been harder to explain
+than the x64 equivalent.
+
+The messages the bundled AArch64 fixture reaches are asserted individually rather than as
+a count, so a path that stops logging fails as itself.
+"""
+
+import logging
+import os
+import tempfile
+import unittest
+
+from smda.aarch64.definitions import INSTRUCTION_SIZE
+from smda.aarch64.FunctionCandidateManager import FunctionCandidateManager as AArch64CandidateManager
+from smda.common.BinaryInfo import BinaryInfo
+from smda.Disassembler import Disassembler
+from smda.DisassemblyResult import DisassemblyResult
+from smda.SmdaConfig import SmdaConfig
+
+FIXTURE = "aarch64_static_xored"
+LOGGER_NAME = "smda.aarch64.FunctionCandidateManager"
+
+#: the refusals this fixture actually walks into, so none of these assertions is vacuous.
+#: The declared `.pdata` extent, the LSDA landing pad, the BTI interior pad, the trap word
+#: and the code filter are reachable in the loop but not on an ELF the size of this one.
+#:
+#: The sweep over bytes outside every executable section is deliberately not logged. It
+#: refuses no candidate -- it steps over what is not code at all -- it has no intel
+#: counterpart, and on this fixture alone it would emit 156,758 identical lines, which is
+#: 91% of everything the loop would say.
+EXPECTED = (
+    "nextGapCandidate() found padding word - gap_ptr += %d: 0x%08x",
+    "nextGapCandidate() gap_ptr is already inside code map: 0x%08x",
+    "nextGapCandidate() gap_ptr is already inside data map: 0x%08x",
+    "nextGapCandidate() gap_ptr is inside a declared FDE range: 0x%08x",
+    "nextGapCandidate() gap run flows into the interior of a mapped function: 0x%08x",
+    "nextGapCandidate() using 0x%08x as candidate",
+)
+
+
+def loadFixture(name):
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+    with open(path, "rb") as fixture_file:
+        raw = fixture_file.read()
+    return bytes(byte ^ (index % 256) for index, byte in enumerate(raw))
+
+
+class AArch64GapScanLoggingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = loadFixture(FIXTURE)
+
+    def setUp(self):
+        # several modules in this suite call logging.disable() at import, which suppresses
+        # records before any handler sees them and would leave assertLogs with nothing
+        self._previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self):
+        logging.disable(self._previous_disable)
+
+    def recoveredWithLogs(self):
+        config = SmdaConfig()
+        config.CALCULATE_SCC = False
+        config.CALCULATE_NESTING = False
+        config.CALCULATE_HASHING = False
+        with tempfile.NamedTemporaryFile(suffix=".elf", delete=False) as handle:
+            handle.write(self.data)
+            temp_path = handle.name
+        try:
+            with self.assertLogs(LOGGER_NAME, level=logging.DEBUG) as captured:
+                report = Disassembler(config).disassembleFile(temp_path)
+        finally:
+            os.unlink(temp_path)
+        return report, captured.records
+
+    def testEveryRefusalTheFixtureReachesIsRecorded(self):
+        report, records = self.recoveredWithLogs()
+        # control: the run did its normal work, so a missing message is a missing message
+        # rather than an analysis that returned nothing
+        self.assertGreater(len({function.offset for function in report.getFunctions()}), 200)
+        emitted = {record.msg for record in records}
+        for message in EXPECTED:
+            self.assertIn(message, emitted, f"the gap scan never emitted: {message}")
+
+    def testEachRecordNamesAnAddressInsideTheImage(self):
+        report, records = self.recoveredWithLogs()
+        # the mapped image is larger than the file it came from, so the file length is not
+        # the bound the scan walks to
+        base = report.base_addr
+        end = base + report.binary_size
+        addresses = [record.args[-1] for record in records if record.msg in EXPECTED]
+        self.assertTrue(addresses)
+        for address in addresses:
+            self.assertIsInstance(address, int)
+            self.assertTrue(base <= address < end, f"0x{address:x} is outside the image")
+
+
+BASE = 0x400000
+PADDING_WORDS = 64
+AARCH64_NOP = b"\x1f\x20\x03\xd5"
+FRAME_PROLOGUE = b"\xfd\x7b\xbf\xa9"
+
+
+class AArch64GapScanRepeatedPointerLoggingTest(unittest.TestCase):
+    """The branch that meets a gap pointer the scan already handed out once.
+
+    No bundled fixture reaches it: it needs the caller to ask again from the same address
+    rather than from where the previous candidate ended, so it is driven directly.
+    """
+
+    def setUp(self):
+        self._previous_disable = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self):
+        logging.disable(self._previous_disable)
+
+    @staticmethod
+    def manager():
+        image = AARCH64_NOP * PADDING_WORDS + FRAME_PROLOGUE * 4
+        binary_info = BinaryInfo(image)
+        binary_info.base_addr = BASE
+        binary_info.bitness = 64
+        binary_info.architecture = "aarch64"
+        binary_info.code_areas = [[BASE, BASE + len(image)]]
+        disassembly = DisassemblyResult()
+        disassembly.setBinaryInfo(binary_info)
+        manager = AArch64CandidateManager(SmdaConfig())
+        manager.init(disassembly, None)
+        return manager
+
+    def testAskingTwiceFromTheSameAddressIsRecorded(self):
+        manager = self.manager()
+        first = manager.nextGapCandidate(BASE)
+        # control: the scan walked the padding and produced a candidate, so the second call
+        # below is a repeat rather than a scan that never got started
+        self.assertEqual(first, BASE + PADDING_WORDS * INSTRUCTION_SIZE)
+
+        with self.assertLogs(LOGGER_NAME, level=logging.DEBUG) as captured:
+            manager.nextGapCandidate(first)
+        self.assertIn(
+            "--- HRM, nextGapCandidate() gap_ptr at: 0x%08x was previously analyzed",
+            {record.msg for record in captured.records},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Item 3 of #322.

`intel/FunctionCandidateManager` emits a `LOGGER.debug` on every path in its gap scan that declines a gap pointer. The AArch64 loop emitted nothing at all — its only logging anywhere was one line in the `.pdata` carver — so the two paths, which #312 made deliberately identical in every other respect, diverged on the one axis that matters when an address is refused and nobody can see why.

## What is logged

Twelve refusals now name the address they declined, reusing the intel wording wherever the path is the same one:

| path | message |
|---|---|
| already inside the code map | intel wording, verbatim |
| already inside the data map | intel wording, verbatim |
| inside a declared `.pdata` extent | intel wording, verbatim |
| a declared landing pad | intel wording, verbatim |
| inside a declared FDE range | intel wording, verbatim |
| pointer already handed out | intel wording, verbatim |
| accepted as a candidate | intel wording, verbatim |
| padding word | AArch64 stride rather than intel's run length |
| interior indirect-branch landing pad | AArch64 only |
| trap word | AArch64 only |
| code filter | AArch64 only |
| gap run flows into a mapped function | AArch64 only |
| scan reaching the end of the image | intel wording, verbatim |

## The one path deliberately left silent

The sweep over bytes outside every executable section refuses no candidate — it steps over what is not code at all — and it has no intel counterpart, because the intel scan does not walk non-executable bytes word by word.

Logging it costs nothing measurable but makes the output useless: on the bundled `aarch64_static` fixture alone it emits **156,758 identical lines, 91% of everything the loop would say**. What remains is 15,709 calls on the heaviest corpus cell measured (`googletest_gcc-arm64_O2-static`), at 0.068µs per suppressed call — **0.02% of that run**.

That figure is measured by counting calls rather than by wall clock. Paired interleaved timing on this machine put the delta at +14% to +20% with an 18–37% spread *within* each side, which is item 4 of this issue in miniature: the noise is larger than the effect, so the call count and the per-call cost are what the claim rests on.

## Tests

`tests/testAArch64GapScanLogging.py`, three cases:

- the seven refusals the bundled fixture actually walks into are asserted **individually**, so a path that stops logging fails as itself rather than as a count;
- every record's address argument is inside the mapped image (which is larger than the file it came from — that caught the first version of this assertion);
- the repeated-gap-pointer branch is driven directly, because reaching it needs a caller that asks again from the same address rather than from where the last candidate ended. That branch had no coverage before this PR, which is why it shows up here.

Verified to fail when the logging is removed: dropping the FDE-range line alone fails the first case.

`logging.disable()` is called at import by 68 files in this suite, which suppresses records before any handler sees them and would leave `assertLogs` with nothing, so each case saves and restores the global disable level.

## Gates

- `python -m pytest tests/` → **2,063 passed, 1 skipped, 2,593 subtests**
- `ruff check .` and `ruff format --check .` → clean
- `make typecheck` → exit 0, 261 diagnostics, identical to master
- Diff coverage against `e9dfe5f` → **100%** (13 lines, 0 missing)

No behaviour changes and no fixture baseline moves; the only non-logging edit is the test file.

You marked these as yours in the issue, so this is offered rather than assumed — close it if you would rather take it.
