### PR TITLE
test(tests): pin the bti j split that no bundled binary can show

### DIFF
--- a/tests/testAArch64BtiTargetType.py
+++ b/tests/testAArch64BtiTargetType.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+"""`bti j` marks a jump target, not a callable entry.
+
+`USE_AARCH64_BTI_TARGET_TYPE` refuses a `bti j` word as a function start: the hint says an
+indirect *branch* may land there, which a compiler emits for jump-table cases and cleanup
+blocks inside a routine, where `bti c` marks a call target and stays a plausible entry.
+
+Every AArch64 binary bundled with this repo carries its `bti j` words inside exception
+landing pads, where the shape test refuses them on its own account and the LSDA rule refuses
+them before that -- so on those the flag is redundant and changes nothing either way. The
+image below places the word where the shape test would otherwise accept it: after alignment
+padding, opening a block that looks exactly like an entry, in a raw buffer that declares no
+`.eh_frame` and so no landing pads at all. That is the one arrangement in which the flag
+decides the outcome by itself.
+"""
+
+import struct
+import unittest
+
+from smda.Disassembler import Disassembler
+from smda.SmdaConfig import SmdaConfig
+
+BASE = 0x400000
+
+NOP = 0xD503201F
+RET = 0xD65F03C0
+#: stp x29, x30, [sp, #-16]! / ldp x29, x30, [sp], #16 -- an ordinary frame open and close
+STP_FRAME = 0xA9BF7BFD
+LDP_FRAME = 0xA8C17BFD
+
+BTI = 0xD503241F
+BTI_C = 0xD503245F
+BTI_J = 0xD503249F
+BTI_JC = 0xD50324DF
+
+#: where the hint word lands, and where the block behind it starts
+HINT = BASE + 0x20
+BODY = HINT + 4
+
+
+def words(*values):
+    return b"".join(struct.pack("<I", value) for value in values)
+
+
+def image(hint):
+    """A function, alignment padding, then `hint` opening an entry-shaped block."""
+    return (
+        words(STP_FRAME, NOP, LDP_FRAME, RET)
+        + words(NOP, NOP, NOP, NOP)
+        + words(hint, STP_FRAME, LDP_FRAME, RET)
+        + words(NOP, NOP)
+    )
+
+
+def recovered(hint, target_type):
+    config = SmdaConfig()
+    config.CALCULATE_SCC = False
+    config.CALCULATE_NESTING = False
+    config.CALCULATE_HASHING = False
+    config.USE_AARCH64_BTI_TARGET_TYPE = target_type
+    report = Disassembler(config).disassembleBuffer(image(hint), BASE, bitness=64, architecture="aarch64")
+    return {function.offset for function in report.getFunctions()}
+
+
+class AArch64BtiTargetTypeTest(unittest.TestCase):
+    def testTheFlagIsOnByDefault(self):
+        self.assertTrue(SmdaConfig().USE_AARCH64_BTI_TARGET_TYPE)
+
+    def testAJumpOnlyHintIsNotAnEntry(self):
+        self.assertNotIn(HINT, recovered(BTI_J, True))
+        # the block behind it is still recovered, so the hint word is refused rather than the
+        # code it labels being lost with it
+        self.assertIn(BODY, recovered(BTI_J, True))
+
+    def testTheSameWordIsAnEntryWithTheFlagOff(self):
+        # the control that makes the case above measure this rule and not some other filter
+        self.assertIn(HINT, recovered(BTI_J, False))
+        self.assertNotIn(BODY, recovered(BTI_J, False))
+
+    def testACallTargetHintStaysAnEntry(self):
+        # `bti c` is the hint a compiler puts on a real function under branch protection
+        for target_type in (False, True):
+            self.assertIn(HINT, recovered(BTI_C, target_type))
+
+    def testTheCombinedAndBareHintsAreUnaffected(self):
+        # `bti jc` admits a call, and a bare `bti` admits both, so neither says jump-only
+        for hint in (BTI_JC, BTI):
+            self.assertEqual(recovered(hint, False), recovered(hint, True))
+            self.assertIn(HINT, recovered(hint, True))
+
+    def testTheFirstFunctionIsRecoveredInEveryArrangement(self):
+        # every assertion above reads a set that is empty on a run that did nothing
+        for hint in (BTI, BTI_C, BTI_J, BTI_JC):
+            for target_type in (False, True):
+                self.assertIn(BASE, recovered(hint, target_type))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Item 2 of #322, the `bti j` row.

## What changed since the issue was written

> no bundled fixture contains a single `bti j` word, and every bundled AArch64 fixture is bit-identical across that change

The first clause is no longer true. #300 bundled `elf_cxx_landing_pads_arm64_xored`, which carries **five `bti j` words**, and instrumenting a run shows all five reach `_isLikelyInteriorBtiCandidate`.

The second clause still holds, and the reason is worth recording rather than just working around. All five sit inside exception landing pads: `isDeclaredLandingPad` is true for every one, and the shape test independently returns "interior" for every one. So `USE_AARCH64_BTI_TARGET_TYPE` decides nothing there — the address is refused with the flag on or off, by two other rules, one of which (#300's LSDA pass) is documented as having to precede the shape test precisely because under `-mbranch-protection` every pad opens with a `bti`.

That is why bundling a BTI-built binary would not have closed this row either. A compiler emits `bti j` at exception landing pads and jump-table cases, and on anything with unwind data the landing pads are already refused by the time this rule is consulted.

## What the flag needs to decide by itself

A `bti j` the shape test would otherwise **accept**: after alignment padding, opening a block that looks like an entry, in an image that declares no landing pads at all. A raw buffer is exactly that image, so this builds one instead of asking for a binary that cannot be bundled.

| hint word | flag off | flag on | flag decides |
|---|---|---|---|
| `bti j` | hint booked at `+0x20` | hint refused, block at `+0x24` booked | **yes** |
| `bti c` | booked | booked | no |
| `bti jc` | booked | booked | no |
| bare `bti` | booked | booked | no |

The three that do not move are the point of the test as much as the one that does: they are what makes it measure the jump-only split rather than `bti` handling in general. `bti jc` admits a call and a bare `bti` admits both, so neither says jump-only, and neither should be refused.

## Tests

`tests/testAArch64BtiTargetType.py`, six cases: the default, the refusal, the flag-off control, `bti c`, the combined and bare hints, and a case asserting the first function is recovered in all eight arrangements so no other assertion can pass by reading an empty set.

Verified to fail when the rule is disabled: forcing the `word == BTI_J` branch false fails `testAJumpOnlyHintIsNotAnEntry` and nothing else.

## What this does not close

The corpus **magnitude** in #310 — 803 false / 0 true for `bti j` against `bti c`'s 505/0 — is still not reproducible from anything in this repo, and this PR does not claim to change that. It makes the mechanism regression-testable, which is the durable half of the two options the issue lists; the number remains a figure measured elsewhere.

## Gates

- `python -m pytest tests/` → **2,066 passed, 1 skipped, 2,593 subtests**
- `ruff check .` and `ruff format --check .` → clean
- `make typecheck` → exit 0, 261 diagnostics, identical to master
- Test-only: no `src/` change, no fixture added, no baseline moves.

You marked these as yours in the issue, so this is offered rather than assumed.
