### PR TITLE
docs(core): record why the ARM64 pdata seeding keeps its over-reporting

### DIFF
--- a/src/smda/SmdaConfig.py
+++ b/src/smda/SmdaConfig.py
@@ -59,6 +59,23 @@ class SmdaConfig:
     # record with the X bit clear or no .xdata at all, so they are not exception funclets and
     # nothing in the unwind data distinguishes them. clang/llvm-mingw emits one record per function
     # symbol and does not split them, so a from-source ARM64 PE is unaffected either way.
+    #
+    # That over-reporting is a trade taken deliberately, not a gap waiting on a better test.
+    # Chunks are ordinary MSVC output rather than a peculiarity of the three system binaries:
+    # across thirteen MSVC ARM64 images with private-PDB extents, 3,473 classified chunks. The
+    # entry-shape filter already refuses 2,829 of them (81.5%), and 643 of the 644 that survive
+    # into seeding open with a genuine routine shape - a recognised prologue, a BTI pad, a
+    # single-register `str Xt, [sp, #-imm]!`, or a bare `sub sp, sp, #imm`. Shape is applied and
+    # the remainder is 643-to-1 against it. A packed record is never a chunk at all: 6,763 of
+    # them, none, so seeding those is right.
+    # What is left to read is the space between adjacent functions, and that cannot be read
+    # portably. The three system binaries pad between functions and these images pack them back
+    # to back, so a rule testing whether a record begins where another's extent ends inverts
+    # between them: refusing an unreferenced, unaligned record that abuts an extent end removes
+    # 51 of the 78 for 2 real functions on ping/robocopy/bcrypt, and over the six packed images
+    # carrying PDB extents removes nothing at all while losing 712 of 3,026. Every removal in
+    # the first figure comes from one of the three binaries, which is the tell before the second
+    # is measured at all.
     USE_PE_ARM64_PDATA_CANDIDATES = True
     # do not read `bti j` as a function entry on AArch64. The four BTI forms are not
     # interchangeable: J permits a target reached by `br` - an indirect jump, which is what a


### PR DESCRIPTION
Item 1 of #322, written down rather than left open.

The `USE_PE_ARM64_PDATA_CANDIDATES` comment already describes the problem honestly — 78 addresses seeded inside functions IDA labels on ping/robocopy/bcrypt, and refusing them by shape costs 13 the PDBs name. It stops there, which reads as a gap waiting on a better test. It is not one, and this records why next to the option instead of in an issue.

No behaviour change. The default, the filter and the code are untouched; this is the comment only.

## What closes the shape question

Chunks are ordinary MSVC output, not a peculiarity of three PGO-split system binaries. Across thirteen MSVC ARM64 images with private-PDB extents there are 3,473 classified chunks, and:

| | |
|---|---|
| refused by the entry-shape filter already in `locatePeExceptionCandidates` | **2,829 (81.5%)** |
| surviving into seeding | 644 |
| of those, opening with a genuine routine shape | **643** |
| packed records (`UnwindData` flag 1) that are chunks | **0 of 6,763** |

MSVC gives a separated chunk its own frame setup, so what survives the filter is byte-for-byte what an entry looks like. Shape is applied and the remainder is 643-to-1 against it.

## What closes the gap question

The only signal left is the space between adjacent functions, and it does not travel between the two ARM64 PE populations. The three system binaries **pad** between functions; the .NET images **pack** them back to back. So a rule reading whether a record begins exactly where another's extent ends inverts between them.

I measured the best such predicate I could find — refuse an unreferenced, unaligned record that abuts an extent end:

| corpus | FP removed | real lost |
|---|---|---|
| ping / robocopy / bcrypt (padded, IDA truth) | **51 of 78** | **2 of 622** |
| six .NET images with PDB extents (packed) | **0** | **712 of 3,026** |

51-for-2 is better than the 13 the shape test costs, which is exactly why it is worth writing down that it is not real. On the packed images it removes nothing and destroys 23.5% of the truth.

The tell was available before the holdout and is in the comment for the next person: **all 51 removals come from `robocopy` alone**, while `bcrypt` gets none removed and both losses. A rule whose entire effect lives in one of three binaries is a layout artefact.

That is also the shape of `smda#169`, which was built and validated on the padded three alone.

## Verification

- `python -m pytest tests/` → **2,060 passed, 1 skipped, 2,593 subtests**
- `ruff check .` and `ruff format --check .` → clean
- `make typecheck` → exit 0, 261 diagnostics, identical to master
- Comment-only: no executable line changes, no fixture baselines move.

The 81.5% / 643-of-644 / 0-of-6,763 figures are re-derivable from the `chunk_census`, `chunk_overlap` and `chunk_features2` probes; the 51-for-2 and 0-and-712 rows are mine and were measured for this.

Offered rather than assumed, as with the other #322 items — this is the "decide the trade explicitly" branch of that item rather than the "find a discriminator" one, and if you would rather word the verdict yourself the numbers are all here.
