### PR TITLE
fix(common): bound the LSDA reads that lead nowhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ past roughly six lines it belongs in the PR the entry links.
 
 ### Fixed
 
+- **(common)** Bound the LSDA reads that lead nowhere, and remember a pointer that reads back empty. The
+  call-site table budget is charged only once a table's length field is parsed, so an LSDA failing before that
+  point -- an unsupported LPStart mode, a short buffer, a TType offset that will not read -- cost a read of up to
+  `MAX_LSDA_BYTES` and charged nothing: a section naming `MAX_RECORDS` such pointers read 12.2 GB over 199,999
+  reads. `MAX_LSDA_FAILED_READ_BYTES` holds that to 256 MB over 4,096, leaving 8.6x headroom over the heaviest
+  real image measured, which spends 29.75 MB. Separately, an address the reader hands nothing back for returned
+  before the memo was written, so a section naming one dead pointer from every record read it once per record;
+  remembered by address, that is now one read. *All 447 cells across the six corpora are bit-identical.* (#335)
+
 ### Security
 
 ### Compatibility

--- a/src/smda/common/EhFrameDecoder.py
+++ b/src/smda/common/EhFrameDecoder.py
@@ -260,6 +260,23 @@ MAX_LSDA_BYTES = 0x10000
 #: two orders of magnitude of headroom while capping a section built to be hostile at about a
 #: second.
 MAX_LSDA_TABLE_BYTES = 8 * 1024 * 1024
+#: bytes read for LSDAs that then decode to nothing, across one section. The table budget above
+#: cannot bound these: it is charged where a table's length field is parsed, so an LSDA failing
+#: before that point - an unsupported LPStart mode, a short buffer, a TType offset that will not
+#: read - costs a read of up to MAX_LSDA_BYTES and charges nothing. A section naming MAX_RECORDS
+#: distinct pointers that all fail early therefore reads about 12 GB while spending none of it.
+#: Charging those reads to the table budget instead is not the fix: read_va is asked for
+#: MAX_LSDA_BYTES and returns whatever the section holds, so a real image asks for far more than
+#: it decodes - 92 MB against 26 KB of tables on the heaviest cell measured - and the 8 MB above
+#: would be gone within about 128 reads of the 1,473 that cell makes. Only the failures need a
+#: bound, and they separate the two cases: the heaviest real image spends 29.75 MB on them
+#: (476 reads), the corpora's Rust cells spend none, and a section naming MAX_RECORDS distinct
+#: pointers that fail this early spends 12.2 GB over 199,999 reads. This bound holds that to
+#: 256 MB over 4,096, leaving 8.6x headroom over the heaviest real image measured. Note the
+#: failure has to come before the table's length field to reach here at all: one that fails
+#: after it is already charged, which is why the same shape built with a too-long length runs
+#: 512 reads rather than 200,000.
+MAX_LSDA_FAILED_READ_BYTES = 256 * 1024 * 1024
 
 
 def _isSupportedApplication(encoding):
@@ -343,7 +360,13 @@ def _decodeLsdaLandingPads(data, lsda_va, function_start, pointer_size, budget=N
 
 
 def decodeEhFrameLandingPads(
-    data, section_va, read_va, pointer_size=8, max_records=MAX_RECORDS, max_table_bytes=MAX_LSDA_TABLE_BYTES
+    data,
+    section_va,
+    read_va,
+    pointer_size=8,
+    max_records=MAX_RECORDS,
+    max_table_bytes=MAX_LSDA_TABLE_BYTES,
+    max_failed_read_bytes=MAX_LSDA_FAILED_READ_BYTES,
 ):
     """Every exception landing pad the image's own LSDAs declare.
 
@@ -356,9 +379,11 @@ def decodeEhFrameLandingPads(
     string carries 'L'. The LSDA lives in another section, so ``read_va(va, length)`` supplies
     the bytes; it may return fewer than asked for, or nothing.
 
-    ``max_table_bytes`` bounds the call-site table bytes decoded across the whole section, and
-    with them how often ``read_va`` is called at all. It is a parameter rather than only a
-    constant so a test can exhaust it without building a section large enough to.
+    ``max_table_bytes`` bounds the call-site table bytes decoded across the whole section.
+    ``max_failed_read_bytes`` bounds the bytes read for LSDAs that then decode to nothing, which
+    the first cannot reach because it is charged only once a table's length field is parsed.
+    Both are parameters rather than only constants so a test can exhaust them without building a
+    section large enough to.
     """
     pads = set()
     # keyed by LSDA address: one LSDA legitimately serves one function, but nothing stops a
@@ -366,13 +391,16 @@ def decodeEhFrameLandingPads(
     # FDE is the difference between milliseconds and minutes
     decoded = {}
     budget = [max_table_bytes]
+    read_budget = [max_failed_read_bytes]
     for cie, pos, record_end in _walkEhFrameFdes(data, pointer_size, max_records):
         if cie.lsda_encoding != DW_EH_PE_omit:
-            pads |= _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, budget)
+            pads |= _fdeLandingPads(
+                data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, budget, read_budget
+            )
     return pads
 
 
-def _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, budget):
+def _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, budget, read_budget):
     field_pos = pos
     initial_location, pos = _read_encoded_value(data, pos, record_end, cie.fde_encoding, pointer_size)
     address_range, pos = _read_encoded_value(data, pos, record_end, cie.fde_encoding & 0x0F, pointer_size)
@@ -394,17 +422,20 @@ def _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_siz
     # memo is keyed by both rather than by the table alone
     key = (lsda_va, initial_location)
     if key not in decoded:
-        # the budget gates the read as well as the decode: the reader is asked for
-        # MAX_LSDA_BYTES and a section naming a distinct LSDA per record would otherwise copy
-        # that much per record before the decode declines it
-        if budget[0] <= 0:
+        # either budget gates the read: the table one once enough tables have been decoded, the
+        # failed-read one once enough reads have led nowhere. Without the second, an LSDA that
+        # fails before its length field is reached costs MAX_LSDA_BYTES and charges nothing
+        if budget[0] <= 0 or read_budget[0] <= 0:
             return set()
         lsda_bytes = read_va(lsda_va, MAX_LSDA_BYTES)
         if not lsda_bytes:
             return set()
         # an exhausted budget reads as "declares nothing" from here on, which costs recall on
         # a section built to exhaust it and never invents a pad
-        decoded[key] = _decodeLsdaLandingPads(lsda_bytes, lsda_va, initial_location, pointer_size, budget) or set()
+        pads = _decodeLsdaLandingPads(lsda_bytes, lsda_va, initial_location, pointer_size, budget) or set()
+        if not pads:
+            read_budget[0] -= len(lsda_bytes)
+        decoded[key] = pads
     # A landing pad is interior to the function its own FDE names; the format says so, and over
     # 43,881 pads across four corpora and three system libraries not one falls outside. That
     # makes this the check separating a real table from an LSDA pointer that led into arbitrary

--- a/src/smda/common/EhFrameDecoder.py
+++ b/src/smda/common/EhFrameDecoder.py
@@ -275,7 +275,11 @@ MAX_LSDA_TABLE_BYTES = 8 * 1024 * 1024
 #: 256 MB over 4,096, leaving 8.6x headroom over the heaviest real image measured. Note the
 #: failure has to come before the table's length field to reach here at all: one that fails
 #: after it is already charged, which is why the same shape built with a too-long length runs
-#: 512 reads rather than 200,000.
+#: 512 reads rather than 200,000. What is charged is broader than that failure, though: the
+#: condition is that the read yielded no pads, which also catches a table that parsed cleanly
+#: and declares none. That case is real and negligible - across the bundled fixtures it is one
+#: LSDA of 11,656 bytes, on elf_cxx_landing_pads_x64_xored, and none on the other four - and
+#: the 29.75 MB above already counts it, being the same condition measured.
 MAX_LSDA_FAILED_READ_BYTES = 256 * 1024 * 1024
 
 
@@ -390,17 +394,25 @@ def decodeEhFrameLandingPads(
     # corrupt or hostile image pointing every FDE at the same table, and decoding it once per
     # FDE is the difference between milliseconds and minutes
     decoded = {}
+    # keyed by address alone: a pointer that reads back empty does so whatever function named
+    # it, and that result never reaches `decoded`, so without this a section naming one
+    # unreadable address from every record calls the reader once per record. Bounded by
+    # max_records like `decoded` is; its worst case is the one it cannot help, a distinct
+    # unreadable address per record, where it holds about 10 MB and saves no read
+    unreadable = set()
     budget = [max_table_bytes]
     read_budget = [max_failed_read_bytes]
     for cie, pos, record_end in _walkEhFrameFdes(data, pointer_size, max_records):
         if cie.lsda_encoding != DW_EH_PE_omit:
             pads |= _fdeLandingPads(
-                data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, budget, read_budget
+                data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, unreadable, budget, read_budget
             )
     return pads
 
 
-def _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, budget, read_budget):
+def _fdeLandingPads(
+    data, pos, record_end, section_va, cie, read_va, pointer_size, decoded, unreadable, budget, read_budget
+):
     field_pos = pos
     initial_location, pos = _read_encoded_value(data, pos, record_end, cie.fde_encoding, pointer_size)
     address_range, pos = _read_encoded_value(data, pos, record_end, cie.fde_encoding & 0x0F, pointer_size)
@@ -422,6 +434,8 @@ def _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_siz
     # memo is keyed by both rather than by the table alone
     key = (lsda_va, initial_location)
     if key not in decoded:
+        if lsda_va in unreadable:
+            return set()
         # either budget gates the read: the table one once enough tables have been decoded, the
         # failed-read one once enough reads have led nowhere. Without the second, an LSDA that
         # fails before its length field is reached costs MAX_LSDA_BYTES and charges nothing
@@ -429,10 +443,13 @@ def _fdeLandingPads(data, pos, record_end, section_va, cie, read_va, pointer_siz
             return set()
         lsda_bytes = read_va(lsda_va, MAX_LSDA_BYTES)
         if not lsda_bytes:
+            unreadable.add(lsda_va)
             return set()
         # an exhausted budget reads as "declares nothing" from here on, which costs recall on
         # a section built to exhaust it and never invents a pad
         pads = _decodeLsdaLandingPads(lsda_bytes, lsda_va, initial_location, pointer_size, budget) or set()
+        # charged on yielding no pads rather than on failing, which is broader than the name;
+        # see MAX_LSDA_FAILED_READ_BYTES for what that costs a real image
         if not pads:
             read_budget[0] -= len(lsda_bytes)
         decoded[key] = pads

--- a/tests/testLsdaLandingPads.py
+++ b/tests/testLsdaLandingPads.py
@@ -6,6 +6,7 @@ import unittest
 import lief
 
 from smda.common.EhFrameDecoder import (
+    MAX_LSDA_FAILED_READ_BYTES,
     MAX_LSDA_TABLE_BYTES,
     _decodeLsdaLandingPads,
     decodeEhFrameFdeRanges,
@@ -432,6 +433,58 @@ class EhFrameLandingPadWalkTest(unittest.TestCase):
         budget = [10]
         self.assertEqual(_decodeLsdaLandingPads(blob, 0x1000, 0x2000, 8, budget), {0x2020})
         self.assertEqual(budget[0], 10 - (len(table) - 2))
+
+    def testAnLsdaThatDecodesIsNotChargedToTheFailedReadBudget(self):
+        """The condition that keeps this bound off working images.
+
+        A real image asks for far more than it decodes -- the heaviest cell measured reads
+        92 MB to decode 26 KB of tables -- so a bound charged for every read would have to be
+        enormous to be safe. Charging only the reads that lead nowhere is what lets it be
+        small enough to matter.
+        """
+        section = self.sectionWith(*[self.fdeBody(self.LSDA_VA + step, 0x2000 + step) for step in (0, 0x40, 0x80)])
+
+        def read_va(addr, length):
+            return self.LSDA_BYTES
+
+        # a budget smaller than a single read still reaches every table, because none fails
+        pads = decodeEhFrameLandingPads(section, 0x1000, read_va, max_failed_read_bytes=1)
+        self.assertEqual(pads, {0x2020, 0x2060, 0x20A0})
+
+    def testAnExhaustedFailedReadBudgetStopsCallingTheReader(self):
+        # the shape the bound exists for: distinct pointers that each cost a read of up to
+        # MAX_LSDA_BYTES and decode to nothing, which the table budget never sees
+        reads = []
+        #: an LSDA whose call-site table length runs past the bytes it arrived in, so the
+        #: decode declines before the table budget is charged anything
+        undecodable = bytes([0xFF, 0xFF, 0x01, 0xFF, 0x7F])
+
+        def counting_read(addr, length):
+            reads.append(addr)
+            return undecodable
+
+        section = self.sectionWith(*[self.fdeBody(self.LSDA_VA + step, 0x2000 + step) for step in (0, 0x40, 0x80)])
+        # control: with room, every distinct pointer is read and none of them declares a pad
+        self.assertEqual(decodeEhFrameLandingPads(section, 0x1000, counting_read), set())
+        self.assertEqual(len(reads), 3)
+
+        reads.clear()
+        self.assertEqual(decodeEhFrameLandingPads(section, 0x1000, counting_read, max_failed_read_bytes=0), set())
+        self.assertEqual(reads, [], "the reader was called with the failed-read budget already spent")
+
+        reads.clear()
+        # one read's worth admits exactly one, then the bound stops the walk
+        self.assertEqual(
+            decodeEhFrameLandingPads(section, 0x1000, counting_read, max_failed_read_bytes=len(undecodable)),
+            set(),
+        )
+        self.assertEqual(len(reads), 1)
+
+    def testTheFailedReadBudgetClearsTheHeaviestRealImageMeasured(self):
+        # a bound sized below real input would drop pads on the images this rule is for; the
+        # worst measured across the built ELF corpora spends 29.75 MB on reads that decode to
+        # nothing, on a cell making 476 of them
+        self.assertGreater(MAX_LSDA_FAILED_READ_BYTES, 8 * 29_753_856)
 
     def testTheBudgetClearsTheHeaviestShapeThisDecoderIsBuiltFor(self):
         # a bound sized below real input would silently drop pads, which is how the first

--- a/tests/testLsdaLandingPads.py
+++ b/tests/testLsdaLandingPads.py
@@ -480,6 +480,54 @@ class EhFrameLandingPadWalkTest(unittest.TestCase):
         )
         self.assertEqual(len(reads), 1)
 
+    def testAnUnreadableLsdaPointerIsReadOnceHoweverManyRecordsNameIt(self):
+        # an address that reads back empty never reaches the per-(table, function) memo, so
+        # without one by address a section naming the same dead pointer from every record
+        # calls the reader once per record -- 199,999 times at max_records
+        reads = []
+
+        def counting_read(addr, length):
+            reads.append(addr)
+            return b""
+
+        section = self.sectionWith(*[self.fdeBody(self.LSDA_VA, 0x2000 + 0x40 * step) for step in range(16)])
+        self.assertEqual(decodeEhFrameLandingPads(section, 0x1000, counting_read), set())
+        self.assertEqual(reads, [self.LSDA_VA])
+
+    def testEachDistinctUnreadablePointerIsStillRead(self):
+        # the memo is by address rather than a latch: one dead pointer does not stop the next
+        # address being tried
+        reads = []
+
+        def counting_read(addr, length):
+            reads.append(addr)
+            return b""
+
+        section = self.sectionWith(
+            *[self.fdeBody(self.LSDA_VA + 0x100 * step, 0x2000 + 0x40 * step) for step in range(4)]
+        )
+        self.assertEqual(decodeEhFrameLandingPads(section, 0x1000, counting_read), set())
+        self.assertEqual(reads, [self.LSDA_VA + 0x100 * step for step in range(4)])
+
+    def testATableThatDecodesAndDeclaresNoPadIsChargedToo(self):
+        # the charge condition is that the read yielded no pads, which is broader than failing
+        # before the table length: this table parses cleanly, charges the table budget and
+        # still declares nothing. Documented rather than separated because it is negligible --
+        # one LSDA of 11,656 bytes across the bundled fixtures and none on four of the five
+        declares_no_pad = bytes([0xFF, 0xFF, 0x01, 0x04, 0x00, 0x10, 0x00, 0x00])
+        reads = []
+
+        def counting_read(addr, length):
+            reads.append(addr)
+            return declares_no_pad
+
+        section = self.sectionWith(*[self.fdeBody(self.LSDA_VA + step, 0x2000 + step) for step in (0, 0x40)])
+        self.assertEqual(
+            decodeEhFrameLandingPads(section, 0x1000, counting_read, max_failed_read_bytes=len(declares_no_pad)),
+            set(),
+        )
+        self.assertEqual(len(reads), 1, "a clean decode that declares no pad was not charged")
+
     def testTheFailedReadBudgetClearsTheHeaviestRealImageMeasured(self):
         # a bound sized below real input would drop pads on the images this rule is for; the
         # worst measured across the built ELF corpora spends 29.75 MB on reads that decode to


### PR DESCRIPTION
Item 6 of #322.

## The diagnosis in the issue is right

`_fdeLandingPads` checks the table budget before reading, and the comment there says that budget *"gates the read as well as the decode"*. It does not. The budget is charged where a table's length field is parsed, so an LSDA failing before that point — an unsupported LPStart application mode, a short buffer, a TType offset that will not read — costs a read of up to `MAX_LSDA_BYTES` and charges nothing.

Measured: a section naming `MAX_RECORDS` distinct such pointers performs **199,999 reads handing back 12.2 GB**, spending none of its budget.

## But the fix as described would cost recall

"Charge the read at the point it happens" cannot mean charging it to `MAX_LSDA_TABLE_BYTES`. `read_va` is asked for `MAX_LSDA_BYTES` and returns whatever the section holds, so a real image asks for vastly more than it decodes:

| cell | reads | bytes asked for | tables decoded |
|---|---|---|---|
| `googletest_gcc-x64_O2-static` | 1,473 | **92.1 MB** | ~26 KB |
| `googletest_gcc-arm64_O2-static` | 1,133 | 70.8 MB | 26,584 B |
| `fmtheavy_linux-gnu-x64_debug` | 179 | 11.2 MB | — |

The 8 MB budget would be gone within about 128 of that first cell's 1,473 reads, and every LSDA after that reads as "declares nothing" — landing pads lost on an ordinary C++ binary. The existing comment's "counts what is decoded rather than what is read" is not a wording slip; it is why the current bound works.

## What separates the two cases

Only the reads that **lead nowhere**. Those are rare on real images and universal on hostile ones:

| corpus | worst cell's failing reads | bytes spent on them |
|---|---|---|
| built C/C++ ELF (140 cells) | 476 | **29.75 MB** |
| built AArch64 ELF (72 cells) | 100 | 6.25 MB |
| Rust (24 cells) | 0 | **0** |
| a section built to exhaust it | 199,999 | 12.2 GB |

`MAX_LSDA_FAILED_READ_BYTES = 256 MB` holds the hostile shape to **4,096 reads and 256 MB** — a 48× reduction — with **8.6× headroom** over the heaviest real image measured.

## Verification

**All 447 cells across all six corpora are bit-identical**, which is the assertion that this reaches only sections built to exhaust it:

| corpus | cells | identical |
|---|---|---|
| built AArch64 ELF | 72 | 72 |
| built C/C++ (260-cell matrix) | 260 | 260 |
| Rust | 24 | 24 |
| Go | 23 | 23 |
| ARM64 Mach-O | 11 | 11 |
| malpedia dumps | 57 | 57 |

- `python -m pytest tests/` → **2,063 passed, 1 skipped, 2,593 subtests**
- `ruff check .` and `ruff format --check .` → clean
- `make typecheck` → exit 0, 261 diagnostics, identical to master
- Diff coverage against `e9dfe5f` → **100%** (9 lines, 0 missing)

Three new cases: that a decoding LSDA is *not* charged (the condition that keeps the bound off working images — a budget of 1 byte still reaches every table), that an exhausted bound stops calling the reader at all, and that the constant clears the heaviest real image by a stated margin. Verified to fail when the bound is removed.

## One thing worth knowing about the shape

The failure has to come **before** the table's length field to reach the new bound at all. One that fails after it is already charged to the existing budget — which is why the same hostile section built with a too-long length field runs 512 reads rather than 200,000 and needs nothing new. My first attempt at reproducing this used exactly that shape and measured the old bound working, not the gap.

## On scope

I said on the issue I would leave this until you picked the number, since sizing it is a corpus judgement. The measurements above make it one: 29.75 MB is the worst real spend, 12.2 GB the hostile one, and any cap between them works. 256 MB is my proposal rather than a finding — change the constant and nothing else moves.


## Added after review

**An LSDA pointer that reads back empty is now memoised by address.** The empty result returns before the decode memo is written, so it is never stored — and because that memo is keyed by `(table, function start)`, storing it there would close only the case where records share a start. Measured on a section naming one dead address from `MAX_RECORDS` records: **199,999 reads → 1**, for both the shared-start and distinct-start shapes. The set is bounded by `max_records` like the decode memo is, and its worst case is the one it cannot help — a distinct dead address per record, where it holds about 10 MB (17.8 MB peak against 7.4 MB without it) and saves no read.

**What the read budget charges is stated, not narrowed.** The condition is that the read yielded no pads, which is broader than failing before the table length: a call-site table that parses cleanly and declares none is charged too. Across the bundled fixtures that is one LSDA of 11,656 bytes on `elf_cxx_landing_pads_x64_xored` and none on the other four, and the 29.75 MB worst real spend already counts it, being the same condition measured.

Three further cases, each verified to fail under a mutation of the line it covers: the dead pointer is read once however many records name it, a second dead address is still tried (a memo, not a latch), and a table that decodes cleanly with no pad is charged. Full suite **2,116 passed, 1 skipped, 2,596 subtests**; `ruff` clean; `make typecheck` exit 0 at the same diagnostic count as master.
