### PR TITLE
ci(ci): require a changelog entry beside an engine change

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,60 @@
+name: Changelog
+
+# pull_request rather than pull_request_target: this needs the PR's changed-file list and no
+# secrets, so the read-only token a fork PR receives is enough, and no PR content is checked
+# out or executed. `labeled`/`unlabeled` are here so applying the skip label re-runs the check
+# rather than leaving a stale failure behind.
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-entry:
+    name: Changelog entry
+    runs-on: ubuntu-latest
+    steps:
+      # The job runs unconditionally and decides inside the step, rather than skipping on an
+      # `if`: a skipped job reports as neither passing nor failing, and the reason a PR is
+      # exempt belongs in the log where the next reader will look for it.
+      - name: Require a changelog entry beside an engine change
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # contains() matches an array element exactly, so a label carrying a comma or a
+          # name this one is a prefix of cannot be mistaken for it
+          SKIP_LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+        run: |
+          set -euo pipefail
+
+          if [ "${SKIP_LABELLED}" = "true" ]; then
+            echo "Labelled no-changelog; entry not required."
+            exit 0
+          fi
+
+          changed="$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+
+          if ! printf '%s\n' "${changed}" | grep -q '^src/smda/'; then
+            echo "No files under src/smda/ changed; entry not required."
+            exit 0
+          fi
+
+          if printf '%s\n' "${changed}" | grep -qx 'CHANGELOG.md'; then
+            echo "CHANGELOG.md touched beside the engine change."
+            exit 0
+          fi
+
+          echo "::error file=CHANGELOG.md::This PR changes src/smda/ but does not touch CHANGELOG.md. Add an entry under ## Unreleased describing what moved and what it cost, or apply the no-changelog label if the change genuinely needs no entry."
+          exit 1


### PR DESCRIPTION
The one from #323 that is not on the original list, and the one you said lands first.

## What it enforces

A PR touching `src/smda/**` also has to touch `CHANGELOG.md`, or carry the `no-changelog` label. Everything else passes untouched.

Built to your specifics: `pull_request` rather than `pull_request_target`, since it needs the changed-file list and no secrets, so the read-only token a fork PR receives is enough and no PR content is checked out or executed. File-level only — a PR that edits an older entry rather than `Unreleased` passes, which is the acceptable false negative for a check whose job is to be loud rather than clever.

Two choices worth stating because they are not obvious from the diff:

**The job runs unconditionally and decides inside the step**, rather than skipping on an `if`. A skipped job reports as neither passing nor failing, which is exactly the ambiguity this check exists to remove — and it puts the reason a PR is exempt in the log, where the next reader looks. **`labeled` and `unlabeled` are among the triggers**, so applying the label re-runs the check instead of leaving a stale failure behind.

The label is matched with `contains()` against the label array rather than a joined string, so a label carrying a comma, or one this name is a prefix of, cannot be mistaken for it.

## Verified

Driven locally against a stubbed file list, all eight outcomes:

| changed files | label | result |
|---|---|---|
| `src/smda/intel/x.py`, `tests/t.py` | — | **fail** |
| `src/smda/intel/x.py`, `CHANGELOG.md` | — | pass |
| `src/smda/intel/x.py` | `no-changelog` | pass |
| `tests/t.py`, `.github/workflows/ci.yml` | — | pass |
| *(none)* | — | pass |
| `src/smda/cil/y.py`, `docs/CHANGELOG.md` | — | **fail** |
| `src/smda/aarch64/z.py` (deletion) | — | **fail** |
| `src/smdax/q.py` | — | pass |

`zizmor --persona=regular` reports no findings, which is what `security.yml` gates on. Full suite **2,110 passed, 1 skipped, 2,596 subtests**; `ruff` clean; `make typecheck` exit 0 at master's own diagnostic count. No Python changes.

## Two things to know before merging

**It needs the `no-changelog` label to exist** — you said you would create it. Referencing one that does not exist is harmless (the match simply never fires), so the order does not matter, but the escape hatch is not usable until it is there.

**It changes what #327, #329 and #335 need.** All three touch `src/smda/**` and none touches `CHANGELOG.md`, so once this and the format PR are both in, each needs an `Unreleased` entry on its next push. That is the intended demonstration rather than a problem — they are v4.7.0's content — and I will add the three entries once the format PR lands, unless you would rather write them.

It is also not a required check until you make it one in branch protection; until then it reports without blocking.

Closes nothing on its own — #323 stays open for the `docs(docs)` format PR, which I will raise against an empty `Unreleased` next.
