### PR TITLE
fix(intel): resume the gap scan inside the gap a failed candidate was in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,26 @@ past roughly six lines it belongs in the PR the entry links.
 
 ### Fixed
 
+- **(intel)** Resume the gap scan inside the gap a failed candidate was found in, rather than
+  abandoning the rest of it. `getNextGap`'s resume refinement is gated on the candidate being in
+  `code_map`, so one that failed to become a function fell through to the next entry of a gap map
+  that is snapshotted once when the gap phase opens and never refreshed -- everything between the
+  failed candidate and the end of its gap was never offered as a candidate at all. The Intel
+  backend now names the first entry past the padding run that ends the failed candidate, and only
+  when that entry is already 16-byte aligned; a backend with no reading of its own padding keeps
+  the previous behaviour. *Measured on `857081f` against compiler symbol tables:* 120 MinGW PE
+  cells +47 true positives against +18 false, 24 Rust cells +0 against +6, 57 malpedia dumps +7
+  against +12, and **no true positive lost on any corpus**. The 140 C/C++ ELF cells, 72 AArch64
+  ELF cells and 11 ARM64 Mach-O cells are bit-identical. *Not reproducible from the bundled
+  fixtures, which do not move.* (#338)
+
 ### Security
 
 ### Compatibility
+
+- Recovery output moves on Intel PE and ELF images whose gap scan meets a failed candidate: the
+  bytes after it are now scanned instead of skipped. No true positive was lost on the corpora
+  this was measured over. (#338)
 
 ## Older releases
 

--- a/src/smda/common/FunctionCandidateManager.py
+++ b/src/smda/common/FunctionCandidateManager.py
@@ -288,8 +288,31 @@ class FunctionCandidateManager:
                 dont_skip,
                 next_gap,
             )
+        elif dont_skip and self.gap_pointer is not None and self.disassembly is not None:
+            # The branch above only fires for a candidate that became a function. One that did
+            # not leaves gap_pointer outside code_map, so the scan resumes at the next entry of
+            # the gap map -- snapshotted once in initGapSearch() and never refreshed -- which
+            # abandons whatever is left of the gap this candidate was found in.
+            resume = self._failedGapResumeTarget()
+            if resume is not None:
+                next_gap = min(next_gap, resume)
+                LOGGER.debug(
+                    "getNextGap(%s) => resuming inside the gap a failed candidate was in: 0x%08x",
+                    dont_skip,
+                    next_gap,
+                )
         LOGGER.debug("getNextGap(%s) final gap_ptr: 0x%08x", dont_skip, next_gap)
         return next_gap
+
+    def _failedGapResumeTarget(self):
+        """Where to resume after a gap candidate failed to become a function, or None.
+
+        None keeps the historical behaviour of abandoning the rest of the gap. A backend
+        overrides this when it can name the next plausible entry cheaply; scanning byte by byte
+        from the failed address instead costs an order of magnitude in runtime, because the
+        candidates it then walks are mostly the interior of whatever the failed one was.
+        """
+        return None
 
     def nextGapCandidate(self, start_gap_pointer=None):
         """Architecture-specific gap scan; implemented per backend."""

--- a/src/smda/intel/FunctionCandidateManager.py
+++ b/src/smda/intel/FunctionCandidateManager.py
@@ -104,6 +104,14 @@ _PDATA_MAX_FUNCTION_SIZE = 0x100000
 # EHANDLER/UHANDLER/CHAININFO are defined -- so just these eight byte values are legal.
 _UNWIND_INFO_FIRST_BYTES = frozenset(0x01 | (flags << 3) for flags in range(8))
 
+_INT3 = b"\xcc"
+#: How far past a failed gap candidate to look for the padding run that ends it. A failed
+#: candidate whose gap holds no padding within this costs nothing and keeps the old behaviour.
+_FAILED_GAP_RESUME_WINDOW = 4096
+#: Alignment a resumed entry has to already sit on. Compilers align function entries; a byte
+#: that follows padding without being aligned is padding inside something else.
+_ENTRY_ALIGNMENT = 16
+
 
 class FunctionCandidateManager(_CommonFunctionCandidateManager):
     CANDIDATE_CLASS = FunctionCandidate
@@ -192,6 +200,44 @@ class FunctionCandidateManager(_CommonFunctionCandidateManager):
         ]:
             is_alignment_sequence = False
         return is_alignment_sequence
+
+    def _failedGapResumeTarget(self):
+        """The first address past the next int3 run after the failed candidate, when aligned.
+
+        A candidate that failed leaves the rest of its gap unscanned. Resuming one byte along
+        instead walks the interior of whatever the failed candidate was, byte by byte, which
+        costs an order of magnitude in runtime; the padding run a compiler leaves between two
+        adjacent functions steps over it in one move. The answer can fall past the end of the
+        gap, which is why the caller takes the nearer of it and the next gap.
+        """
+        if self.gap_pointer is None or self.disassembly is None:
+            return None
+        binary_info = self.disassembly.binary_info
+        if binary_info is None:
+            return None
+        start = self.gap_pointer + 1 - binary_info.base_addr
+        if start < 0:
+            # a slice from a negative offset reads the tail of the image instead of failing
+            return None
+        window = self.disassembly.getRawBytes(start, _FAILED_GAP_RESUME_WINDOW) or b""
+        run_start = window.find(_INT3)
+        if run_start < 0:
+            return None
+        cursor = run_start
+        while cursor < len(window) and window[cursor] == _INT3[0]:
+            cursor += 1
+        if cursor >= len(window):
+            return None
+        target = self.gap_pointer + 1 + cursor
+        # Decline rather than round up. Rounding moves the resume point to the next aligned
+        # address, which resumes somewhere else instead of not resuming -- measured, that keeps
+        # every unaligned candidate and finds more of them. Requiring the byte after the padding
+        # to be aligned already is what separates the two populations: a lone 0xCC inside a data
+        # structure leaves the remainder of that structure unaligned, while a compiler-emitted
+        # entry after real padding is aligned by construction.
+        if target % _ENTRY_ALIGNMENT:
+            return None
+        return target
 
     def nextGapCandidate(self, start_gap_pointer=None):
         if self.language_candidates_only:

--- a/tests/testFailedGapResume.py
+++ b/tests/testFailedGapResume.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python
+"""What the gap scan does after a candidate fails to become a function.
+
+`function_gaps` is a snapshot taken once, when the gap phase opens, and never refreshed. The
+resume path in `getNextGap` only looks past the candidate when that candidate *became* a
+function -- it tests membership in `code_map` -- so one that failed resumed at the next entry of
+that stale snapshot, abandoning whatever was left of the gap it was found in. Everything between
+the failed candidate and the end of its gap was never offered as a candidate at all.
+"""
+
+import logging
+import unittest
+
+from smda.common.FunctionCandidateManager import FunctionCandidateManager as CommonFunctionCandidateManager
+from smda.DisassemblyResult import DisassemblyResult
+from smda.intel.FunctionCandidateManager import _FAILED_GAP_RESUME_WINDOW, FunctionCandidateManager
+from smda.SmdaConfig import SmdaConfig
+
+logging.disable(logging.CRITICAL)
+
+BASE_ADDR = 0x400000
+GAP_START = 0x401000
+GAP_END = 0x402000
+#: the entry of the next gap in the snapshot, which is what an abandoned gap resumes at
+NEXT_GAP_START = 0x403000
+
+
+class _BufferBinaryInfo:
+    """The parts of BinaryInfo the gap resume reads, over a raw buffer."""
+
+    def __init__(self, binary):
+        self.bitness = 64
+        self.base_addr = BASE_ADDR
+        self.binary = binary
+        self.binary_size = len(binary)
+        self.code_areas = []
+
+
+def bufferWithPadding(pad_start, pad_length):
+    """A buffer whose only 0xCC run covers `pad_length` bytes from `pad_start` (an address)."""
+    buffer = bytearray(b"\x90" * (GAP_END + 0x2000 - BASE_ADDR))
+    offset = pad_start - BASE_ADDR
+    buffer[offset : offset + pad_length] = b"\xcc" * pad_length
+    return bytes(buffer)
+
+
+def managerAt(gap_pointer, buffer, manager_class=FunctionCandidateManager, recovered=None, gaps=None):
+    manager = manager_class(SmdaConfig())
+    disassembly = DisassemblyResult()
+    disassembly.binary_info = _BufferBinaryInfo(buffer)
+    if recovered is not None:
+        start, end = recovered
+        for address in range(start, end):
+            disassembly.code_map[address] = start
+            disassembly.ins2fn[address] = start
+        disassembly.function_borders[start] = (start, end)
+    manager.disassembly = disassembly
+    manager.gap_pointer = gap_pointer
+    manager.function_gaps = gaps or [
+        (GAP_START, GAP_END, GAP_END - GAP_START),
+        (NEXT_GAP_START, NEXT_GAP_START + 0x1000, 0x1000),
+    ]
+    return manager
+
+
+class FailedGapResumeTargetTest(unittest.TestCase):
+    """The Intel backend's answer for where to pick the gap back up."""
+
+    def testThePaddingRunInsideTheGapNamesTheEntryAfterIt(self):
+        # 0x401140..0x401150 is padding, so the entry the compiler aligned is at 0x401150
+        manager = managerAt(0x401100, bufferWithPadding(0x401140, 0x10))
+        self.assertEqual(manager._failedGapResumeTarget(), 0x401150)
+
+    def testAnUnalignedEntryAfterPaddingIsDeclined(self):
+        # a lone 0xCC inside a data structure leaves the rest of that structure unaligned;
+        # resuming there books the remainder as a function, which is what this refuses
+        manager = managerAt(0x401100, bufferWithPadding(0x401145, 0x01))
+        self.assertIsNone(manager._failedGapResumeTarget())
+
+    def testAGapWithNoPaddingInTheWindowNamesNothing(self):
+        manager = managerAt(0x401100, bytes(b"\x90" * (GAP_END + 0x2000 - BASE_ADDR)))
+        self.assertIsNone(manager._failedGapResumeTarget())
+
+    def testAPaddingRunThatFillsTheWindowNamesNothing(self):
+        # nothing inside the window says where the run stops, so it cannot name an entry
+        manager = managerAt(0x401100, bufferWithPadding(0x401101, 0x2000))
+        self.assertIsNone(manager._failedGapResumeTarget())
+
+    def testATargetAlwaysAdvancesPastTheFailedCandidate(self):
+        # the resume feeds straight back into gap_pointer, so a target at or behind the failed
+        # candidate would re-offer it forever
+        for pad_start in (0x401101, 0x401110, 0x401140, 0x401800):
+            manager = managerAt(0x401100, bufferWithPadding(pad_start, 0x10))
+            target = manager._failedGapResumeTarget()
+            if target is not None:
+                self.assertGreater(target, 0x401100, f"padding at 0x{pad_start:x} did not advance")
+
+    def testAnAddressBelowTheImageBaseNamesNothing(self):
+        """A negative offset must fail rather than slice.
+
+        `getRawBytes` slices the image directly, and a negative start reads from its tail. The
+        buffer here is shorter than the search window, which is what makes that tail slice
+        non-empty -- with a larger image the same bug returns nothing and hides.
+        """
+        small = bytearray(b"\x90" * 0x200)
+        # not at the very end: a run reaching the window's edge is refused for another reason,
+        # which would let this pass without exercising the guard it is about
+        small[0x1E0:0x1F0] = b"\xcc" * 0x10
+        manager = managerAt(BASE_ADDR - 0x100, bytes(small))
+        self.assertTrue(manager.disassembly.getRawBytes(-0xFF, _FAILED_GAP_RESUME_WINDOW))
+        self.assertIsNone(manager._failedGapResumeTarget())
+
+    def testAnImageWithNoBinaryInfoNamesNothing(self):
+        manager = managerAt(0x401100, bufferWithPadding(0x401140, 0x10))
+        manager.disassembly.binary_info = None
+        self.assertIsNone(manager._failedGapResumeTarget())
+
+    def testABackendWithoutAnOverrideNamesNothing(self):
+        # the common manager keeps the historical behaviour, so a backend that does not carve
+        # padding cannot start resuming on evidence it has no reading of
+        manager = managerAt(0x401100, bufferWithPadding(0x401140, 0x10), manager_class=CommonFunctionCandidateManager)
+        self.assertIsNone(manager._failedGapResumeTarget())
+
+
+class FailedGapResumeTest(unittest.TestCase):
+    """What `getNextGap` does with that answer."""
+
+    def testAFailedCandidateResumesInsideItsOwnGap(self):
+        manager = managerAt(0x401100, bufferWithPadding(0x401140, 0x10))
+        self.assertEqual(manager.getNextGap(dont_skip=True), 0x401150)
+
+    def testAFailedCandidateWithNoResumeTargetStillAbandonsTheGap(self):
+        # the historical behaviour, which is what a gap holding no padding keeps
+        manager = managerAt(0x401100, bytes(b"\x90" * (GAP_END + 0x2000 - BASE_ADDR)))
+        self.assertEqual(manager.getNextGap(dont_skip=True), NEXT_GAP_START)
+
+    def testACandidateThatBecameAFunctionStillResumesJustPastIt(self):
+        # the pre-existing branch: the address is in the code map, so its function's end wins
+        # and the padding answer is never consulted
+        manager = managerAt(0x401100, bufferWithPadding(0x401140, 0x10), recovered=(0x401100, 0x401120))
+        self.assertEqual(manager.getNextGap(dont_skip=True), 0x401120)
+
+    def testTheResumeOnlyAppliesWhenTheScanAskedNotToSkip(self):
+        manager = managerAt(0x401100, bufferWithPadding(0x401140, 0x10))
+        self.assertEqual(manager.getNextGap(dont_skip=False), NEXT_GAP_START)
+
+    def testTheResumeNeverOvershootsTheNextGap(self):
+        """Padding past the end of a short gap must not resume beyond where the next one starts.
+
+        The window the backend searches is fixed, so on a gap shorter than it the first padding
+        run can lie in the *next* gap. Resuming there would skip that gap's opening bytes --
+        the same class of loss this change exists to fix, one gap along.
+        """
+        near = [(GAP_START, 0x401200, 0x200), (0x401200, 0x401400, 0x200)]
+        manager = managerAt(0x401100, bufferWithPadding(0x401240, 0x10), gaps=near)
+        # the backend does name a target, and it is past the next gap's start
+        self.assertEqual(manager._failedGapResumeTarget(), 0x401250)
+        self.assertEqual(manager.getNextGap(dont_skip=True), 0x401200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #338.

## The answer to the question you asked

**The added population is mostly noise — 36% real — so the fix is the narrower one.** But the narrowing that works is not the one you tried: alignment as a **filter** rather than as a round-up.

Variant (b) on the 260-cell built C/C++ matrix, against compiler symbol tables:

| variant | true positives | false positives | ratio | micro PPV | bit-identical |
|---|---|---|---|---|---|
| master | — | — | — | 96.266 | — |
| (b) resume at padding | **+52** | **+93** | 0.56 : 1 | 96.225 | 248/260 |
| (b) + 16-byte round-up | +61 | +108 | 0.56 : 1 | 96.218 | 242/260 |
| **(b) + 16-byte filter** | **+47** | **+18** | **2.6 : 1** | **96.258** | **259/260** |

Declining to resume when the byte after the padding is not aligned keeps 90% of the real gains and removes 81% of the false ones. Rounding up keeps all of them and finds more, because it resumes *somewhere else* instead of not resuming — which is exactly why your measurement of it read as a wash.

## Why alignment separates, and why the round-up hid it

Taking the 145 addresses (b) adds across the corpus and classifying each against symbol truth:

| | real | false | precision |
|---|---|---|---|
| 16-byte aligned | **52** | 8 | **86.7%** |
| not aligned | **0** | 85 | 0.0% |

Every real gain is aligned and 91% of the false ones are not. That is your own hypothesis — it just cannot be applied by moving the target, only by refusing it. A lone `0xCC` inside a data structure leaves the remainder of that structure unaligned; an entry after real padding is aligned by construction.

**On the fixture you identified as the problem case**, loaded mapped so the baseline matches yours within 2%:

| | master | (b) | (b) + filter |
|---|---|---|---|
| `dotnet_readytorun_pe` | 626 | **+108** | **+0** |
| `cutwail` | 503 | +2 | +0 |

The 75-of-117 shape you found is gone entirely, not reduced.

## Full measurement

Paired before/after, symbol-table truth, no corpus losing a true positive:

| corpus | n | TP | FP | lost | bit-identical |
|---|---|---|---|---|---|
| MinGW PE | 120 | **+47** | +18 | **0** | 119/120 |
| malpedia dumps | 57 | +7 | +12 | **0** | 53/57 |
| Rust (mixed ELF/PE) | 24 | +0 | +6 | **0** | 18/24 |
| C/C++ ELF | 140 | +0 | +0 | **0** | **140/140** |
| AArch64 ELF | 72 | +0 | +0 | **0** | **72/72** |
| ARM64 Mach-O | 11 | +0 | +0 | **0** | **11/11** |

The last three are the control an Intel-only rule owes. Positive control for the zeroes: instrumented on the heaviest moving cell, 367 failed candidates consult the hook and it names a resume point for 328 — reachable and firing, not inert.

**Concentration, stated plainly.** On the built matrix the entire effect is one cell, `googletest_mingw-x86_O2-static`. Nine other `mingw-x86_O2-static` cells are bit-identical, so it is not "statically linked x86" as a population — it is the images that carry the shape, which is also what `hyperfine.exe` is. This is a rule that is inert until a binary has vtable shims behind padding, and then worth 47 functions.

**Runtime.** 2.51s on master, 2.24s with this, on that same cell — no cost, nothing like variant (a)'s order of magnitude. Resuming inside the gap also lets the scan finish regions it would otherwise re-enter.

## Scope

Two guards on top of your prototype, both for shapes it could reach:

- **A negative offset is refused.** `getRawBytes` slices the image directly, so a `gap_pointer` below the image base would read its *tail* rather than fail. `testAnAddressBelowTheImageBaseNamesNothing` uses a buffer shorter than the search window, because at a normal image size the bad slice comes back empty and the test passes without exercising the guard.
- **A missing `binary_info` is refused** rather than raising.

**AArch64 keeps the defect, deliberately.** The shared `getNextGap` is what both backends call, so its gap scan abandons gaps the same way; `int3` runs are an Intel shape and a rule for AArch64 alignment padding needs its own measurement, on a corpus where it can be checked. The base hook returns `None`, so nothing changes for it.

Worth knowing: `nextGapCandidate` already carries a narrow version of this for one shape — a retained hot-patch pad that produced no function resumes past itself rather than abandoning the gap. This generalises that reasoning rather than introducing it.

## Verification

13 new cases, each verified to fail under a mutation of the line it covers: dropping the resume branch, rounding instead of declining, the base returning a target, taking the resume without `min()`, and each of the two guards. Two of them were vacuous when first written — the overshoot case put its padding outside the search window, and the negative-offset case produced an empty slice — and both are noted in the test where the geometry matters.

Full suite **2,124 passed, 1 skipped, 2,596 subtests**; `ruff check .` and `ruff format --check .` clean; `make typecheck` exit 0 at master's own 263 diagnostics. The tree measured and the tree here produce byte-identical output on spot-checked cells, re-verified after the two guards were added.

No bundled fixture moves, so the mechanism is pinned by unit cases and the magnitude rests on corpora that are not bundled — the standard settled on #322 item 2. The `Unreleased` entry says so.
