### PR TITLE
docs(docs): track release scope in a milestone named for the tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,13 @@ When a change warrants a version bump, update **all three** in one commit:
 
 Keep the two version strings in sync. Do not bump versions unless the change is a release-worthy change (and see Git Workflow re: explicit ask).
 
+**Scope lives in a milestone named for the tag.** A PR joins `vX.Y.Z` when it is accepted for that
+release rather than when it is opened, so the milestone stays a list of what is left rather than a
+wishlist; issues that have to close for the release join it too. Cut when it reads 100% and `master`
+is green, and close it when the tag is pushed. It answers "what is left before the release" as a
+query instead of a re-read of the issue and PR lists, which is the half `CHANGELOG.md` cannot cover:
+the changelog records what landed and what it cost, the milestone what has not landed yet.
+
 **Tag after `master` is green, not at merge.** A tag created on the merge commit before CI has confirmed the merged tree can need moving, and moving one a PyPI publish has already consumed is a different problem from moving one nobody has fetched.
 
 Every other PR writes its own bullet under `## [Unreleased]` as it merges, rather than the release being reconstructed from merge commits afterwards — see *How an entry is written* in `CHANGELOG.md` for the subsections, the scope prefix and the four content rules. `.github/workflows/changelog.yml` requires a PR touching `src/smda/` to touch `CHANGELOG.md` or carry the `no-changelog` label.


### PR DESCRIPTION
Adds one paragraph to the release checklist, and creates the milestone it describes.

## Why

Four times today "what is left before v4.7.0" was answered by re-reading the issue list and the PR list and working out which of them mattered. The scope was living in three places, none queryable and two hand-maintained: #322 acting as an ad-hoc release tracker, the handover sections of session notes that live outside this repository, and PR bodies.

The `Unreleased` section #337 introduced covers the other half of this well — it is the record of what landed and what it cost — but it says nothing about what has *not* landed, which is what the question is actually about. A milestone is the thin version of the missing piece: one bucket holding both issues and PRs, a closed/total count, and a filter.

## The convention

A PR joins `vX.Y.Z` **when it is accepted for that release, not when it is opened**. That is the whole discipline — the alternative is a wishlist whose count means nothing. Issues that must close for the release join too. Cut when it reads 100% and `master` is green; close it when the tag is pushed.

## What it does not do, stated so nobody expects it to

- **One milestone per item**, so an issue spanning two releases has to be re-pointed, and something parked on an external trigger (#297, waiting on capstone 6.0 final) belongs in no release milestone at all.
- **No ordering or dependencies.** The #327 → #329 stack is not expressible, and that stack is what actually bit twice today — once on rebase, once when #327's squash-merge rewrote the commits #329 was still carrying.
- **Nothing assigns it.** Forgetting is the real failure mode and a stale milestone is worse than none. The mitigation is a periodic filter for open items with no milestone. Projects v2 can auto-add by filter and is the only option that fixes this properly, but it is a lot of machinery for a repository with two open items.

## Already live

`v4.7.0` exists and carries #328 and #329, which is the true remaining scope.

Backfilling the eleven merged PRs and four closed issues that also belong to v4.7.0 would turn it into a complete record of the release rather than just a list of what is left. I have not done it — it is beyond what this change is for, and the milestone is useful either way — but say the word and it is fifteen calls.

## One thing to settle

**No `CHANGELOG.md` entry here.** This changes how the repository is organised and nothing a consumer of the package can observe. The `Changelog entry` check agrees by construction, since nothing under `src/smda/` is touched — but AGENTS.md says "every other PR writes its own bullet", and taken literally that includes this one.

This is the second change today where that rule meets a PR with nothing user-facing to say. #340 did write an entry, on the grounds that it changed what `make test` does and could surprise somebody; this one changes no command anyone runs. I think the line is "would a consumer or a contributor be surprised by the old behaviour", and that a changelog accumulating repository-housekeeping entries is worse for its readers — but it is worth a ruling rather than two precedents pointing different ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
